### PR TITLE
chore: add HANDOFF-*.md to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ DEEP-DIVE_*.md
 # Browser testing screenshots
 assets/
 build/
+HANDOFF-*.md


### PR DESCRIPTION
## Summary
- Add `HANDOFF-*.md` pattern to .gitignore
- Handoff prompts are local planning documents like project plans

## Test plan
- [x] Handoff files exist locally but are not tracked by git