### PR TITLE
feat(cursor): add PR review and fix commands

### DIFF
--- a/.cursor/rules/fix-pr-review.mdc
+++ b/.cursor/rules/fix-pr-review.mdc
@@ -1,0 +1,233 @@
+---
+description: Fix PR review comments and CI issues with prioritized plan
+globs: 
+alwaysApply: false
+---
+
+# /fix-pr-review - Fix PR Review Issues Command
+
+Create and execute a plan to fix GitHub Actions failures and review comments.
+
+## Usage
+
+Invoke with: `/fix-pr-review` or `/fix-pr-review PR_NUMBER`
+
+## Workflow
+
+### Step 1: Gather Current State
+
+Run `/review-pr-status` first to understand current issues.
+
+### Step 2: Create Prioritized Plan
+
+Generate a plan with milestones ordered by priority:
+
+```markdown
+## Fix Plan for PR #XX
+
+### Phase 1: CI Failures (Blocking)
+- [ ] M1.1: Fix {error} in {file}
+
+### Phase 2: High Priority Comments (Security/Bugs)
+- [ ] M2.1: {issue} in {file}:{line}
+
+### Phase 3: Medium Priority Comments (Performance)
+- [ ] M3.1: {issue} in {file}:{line}
+
+### Phase 4: Low Priority Comments (Acknowledge/Skip)
+- [ ] M4.1: Reply to {issue} - explain why not fixing
+```
+
+### Step 3: Execute Fixes
+
+For each fixable issue:
+
+1. Read the relevant file
+2. Apply the fix
+3. Run QA checks (`just qa-python` or equivalent)
+4. Stage changes
+
+### Step 4: Handle Low Priority / Info Comments
+
+For comments that don't need code changes, reply with explanation using GraphQL:
+
+```bash
+# Add reply to a review comment thread
+gh api graphql -f query='
+mutation {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: "{THREAD_ID}",
+    body: "**Acknowledged** - {explanation}\n\nThis is intentional because {reason}. No code change needed."
+  }) {
+    comment {
+      id
+    }
+  }
+}'
+```
+
+Common "no change needed" reasons:
+
+- **Type annotation style**: "The `str | None = None` pattern with `__post_init__` is valid for frozen dataclasses. The value is always set after initialization."
+- **Development-only code**: "This is intentional for local development. Production deployments use environment variable overrides."
+- **Protocol conformance**: "These parameters are required by the protocol interface but not used in this adapter implementation."
+- **Intentional design**: "This pattern was chosen for {reason}. See ADR-XXX for details."
+
+### Step 5: Resolve Fixed Comment Threads
+
+After fixing, resolve the thread with a link to the fix:
+
+```bash
+# First, add a reply noting the fix
+gh api graphql -f query='
+mutation {
+  addPullRequestReviewThreadReply(input: {
+    pullRequestReviewThreadId: "{THREAD_ID}",
+    body: "✅ Fixed in commit {SHORT_SHA}\n\n{brief description of fix}"
+  }) {
+    comment {
+      id
+    }
+  }
+}'
+
+# Then resolve the thread
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {
+    threadId: "{THREAD_ID}"
+  }) {
+    thread {
+      isResolved
+    }
+  }
+}'
+```
+
+### Step 6: Commit and Push
+
+```bash
+# Stage all changes
+git add -A
+
+# Amend existing commit (if single commit PR) or create new commit
+git commit --amend --no-edit
+# OR
+git commit -m "fix: address PR review comments
+
+- Fix {issue1}
+- Fix {issue2}
+- Acknowledge {low-priority-issue} (no change needed)"
+
+# Force push if amended
+git push --force-with-lease
+```
+
+### Step 7: Verify
+
+Run `/review-pr-status` again to confirm:
+- All CI checks passing
+- All comment threads resolved
+- No new issues introduced
+
+## GraphQL Reference
+
+### Get Thread IDs for Comments
+
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "{owner}", name: "{repo}") {
+    pullRequest(number: {PR_NUMBER}) {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          comments(first: 1) {
+            nodes {
+              body
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+### Resolve Thread (without reply)
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {
+    threadId: "{THREAD_ID}"
+  }) {
+    thread {
+      isResolved
+    }
+  }
+}'
+```
+
+### Batch Resolve Multiple Threads
+
+```bash
+for thread_id in THREAD1 THREAD2 THREAD3; do
+  gh api graphql -f query="mutation { resolveReviewThread(input: {threadId: \"$thread_id\"}) { thread { isResolved } } }"
+done
+```
+
+## Example Session
+
+```
+User: /fix-pr-review 21
+
+Agent: [MODE: EXECUTE]
+
+## PR #21 Fix Plan
+
+### Current State
+- CI: ✅ All passing
+- Comments: 16 unresolved (14 outdated, 2 current)
+
+### Phase 1: CI Failures
+None - all checks passing.
+
+### Phase 2: High Priority (0 comments)
+None identified.
+
+### Phase 3: Medium Priority (0 comments)  
+None identified.
+
+### Phase 4: Low Priority (2 comments)
+- M4.1: `ArtifactUploadedEvent.py:70` - Type annotation style
+- M4.2: `docker-compose.supabase.yaml:36` - Already fixed
+
+Executing...
+
+[Resolves threads, adds explanatory comments where needed]
+
+✅ All 16 comment threads resolved!
+```
+
+## Priority Keywords
+
+Use these to classify comment severity:
+
+### 🔴 High Priority
+- security, vulnerability, injection, XSS, CSRF, auth bypass
+- crash, panic, data loss, corruption
+- race condition, deadlock
+
+### 🟡 Medium Priority  
+- performance, blocking I/O, async, memory leak
+- deprecated, breaking change
+- error handling, exception
+
+### 🟢 Low Priority
+- style, naming, documentation, typo
+- suggestion, consider, might want
+- formatting, organization

--- a/.cursor/rules/review-pr-status.mdc
+++ b/.cursor/rules/review-pr-status.mdc
@@ -1,0 +1,139 @@
+---
+description: Review GitHub Actions status and PR review comments
+globs: 
+alwaysApply: false
+---
+
+# /review-pr-status - PR Status Review Command
+
+Review the current PR's GitHub Actions status and Copilot/reviewer comments.
+
+## Usage
+
+Invoke with: `/review-pr-status` or `/review-pr-status PR_NUMBER`
+
+## Workflow
+
+### Step 1: Identify the PR
+
+If no PR number provided, detect from current branch:
+
+```bash
+# Get current branch and find associated PR
+gh pr view --json number,title,url,state,headRefName
+```
+
+### Step 2: Check GitHub Actions Status
+
+```bash
+# Get all CI check statuses
+gh pr checks <PR_NUMBER>
+```
+
+Present results in a table:
+
+| Check | Status | Duration | Link |
+|-------|--------|----------|------|
+| Python Tests | ✅ pass | 2m30s | [link] |
+| Python QA | ❌ fail | 45s | [link] |
+
+### Step 3: If Any Checks Failed, Get Details
+
+```bash
+# Get the failed job logs (last 100 lines)
+gh run view <RUN_ID> --log-failed | tail -100
+```
+
+### Step 4: Get Review Comments
+
+```bash
+# Get all PR reviews
+gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/reviews \
+  --jq '.[] | {user: .user.login, state: .state, body: .body[0:200]}'
+
+# Get inline comments with thread resolution status
+gh api graphql -f query='
+query {
+  repository(owner: "{owner}", name: "{repo}") {
+    pullRequest(number: {PR_NUMBER}) {
+      reviewThreads(first: 50) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first: 1) {
+            nodes {
+              author { login }
+              body
+              path
+              line
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+### Step 5: Categorize Comments
+
+Organize comments by:
+
+1. **🔴 Unresolved & Current** - Active comments that need attention
+2. **🟡 Unresolved & Outdated** - Comments on changed code (may be fixed)
+3. **✅ Resolved** - Already addressed
+
+### Step 6: Present Summary
+
+```markdown
+## PR #XX Status Summary
+
+### CI Status
+| Check | Status |
+|-------|--------|
+| ... | ... |
+
+### Review Comments
+- **Unresolved (current):** X comments
+- **Unresolved (outdated):** Y comments  
+- **Resolved:** Z comments
+
+### Unresolved Comments Detail
+
+#### 🔴 High Priority (Security/Bugs)
+| File | Line | Issue |
+|------|------|-------|
+| ... | ... | ... |
+
+#### 🟡 Medium Priority (Performance/Best Practices)
+| File | Line | Issue |
+|------|------|-------|
+| ... | ... | ... |
+
+#### 🟢 Low Priority (Style/Info)
+| File | Line | Issue |
+|------|------|-------|
+| ... | ... | ... |
+```
+
+## Priority Classification
+
+Classify comments by keywords:
+
+- **🔴 High**: security, vulnerability, bug, crash, data loss, auth, injection, XSS, CSRF
+- **🟡 Medium**: performance, blocking, async, memory, leak, race condition, deprecated
+- **🟢 Low**: style, naming, comment, documentation, typo, formatting, suggestion
+
+## Output
+
+Always end with actionable next steps:
+
+```markdown
+## Recommended Actions
+
+1. [If CI failed] Fix CI failure in `{file}`: {error summary}
+2. [If high priority comments] Address security issue in `{file}:{line}`
+3. [If medium priority] Consider performance fix in `{file}:{line}`
+4. [If low priority only] Run `/fix-pr-review` to handle remaining comments
+```


### PR DESCRIPTION
## Summary

Adds two new Cursor rule commands for PR workflow automation:

- **`/review-pr-status`**: Review GitHub Actions status and Copilot/reviewer comments
  - Checks all CI statuses
  - Fetches review comments via GraphQL
  - Categorizes by priority (🔴 High, 🟡 Medium, 🟢 Low)
  - Shows resolution status (resolved/unresolved/outdated)

- **`/fix-pr-review`**: Create and execute a plan to fix PR issues
  - Generates prioritized fix plan
  - Executes fixes in order of severity
  - Handles low-priority comments with explanatory replies
  - Resolves fixed threads with commit references
  - Uses `gh` CLI and GraphQL API

## Usage

```
/review-pr-status 21
/fix-pr-review 21
```

## Test Plan

- [x] Commands created and documented
- [ ] Test with active PR (can use PR #21)