### PR TITLE
fix(ui): inject version from package.json via Vite define

### DIFF
--- a/apps/syn-dashboard-ui/src/App.tsx
+++ b/apps/syn-dashboard-ui/src/App.tsx
@@ -25,7 +25,7 @@ export function App() {
     <FeedbackProvider
       apiUrl={FEEDBACK_API_URL}
       appName="syn-dashboard"
-      appVersion="0.1.0"
+      appVersion={__APP_VERSION__}
       environment={import.meta.env.MODE}
       gitCommit={import.meta.env.VITE_GIT_COMMIT}
       gitBranch={import.meta.env.VITE_GIT_BRANCH}

--- a/apps/syn-dashboard-ui/src/components/Layout.tsx
+++ b/apps/syn-dashboard-ui/src/components/Layout.tsx
@@ -68,7 +68,7 @@ export function Layout() {
               <p className="truncate text-xs font-medium text-[var(--color-text-primary)]">
                 Local Dev
               </p>
-              <p className="truncate text-xs text-[var(--color-text-muted)]">v0.1.0</p>
+              <p className="truncate text-xs text-[var(--color-text-muted)]">v{__APP_VERSION__}</p>
             </div>
             <button className="rounded p-1 text-[var(--color-text-secondary)] hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text-primary)]">
               <Settings className="h-4 w-4" />

--- a/apps/syn-dashboard-ui/src/ui-feedback.d.ts
+++ b/apps/syn-dashboard-ui/src/ui-feedback.d.ts
@@ -1,3 +1,6 @@
+/** Injected by Vite define at build time (from package.json version) */
+declare const __APP_VERSION__: string
+
 /**
  * Type declarations for @syn137/ui-feedback-react
  *

--- a/apps/syn-dashboard-ui/vite.config.ts
+++ b/apps/syn-dashboard-ui/vite.config.ts
@@ -2,11 +2,17 @@ import path from 'path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { readFileSync } from 'fs'
+
+const { version } = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8')) as { version: string }
 
 const uiFeedbackPath = path.resolve(__dirname, '../../lib/ui-feedback/packages/ui-feedback-react/src')
 
 // https://vite.dev/config/
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   plugins: [react(), tailwindcss()],
   server: {
     port: 5173,


### PR DESCRIPTION
## Summary
- Replace hardcoded `v0.1.0` in `Layout.tsx` (bottom-left version display) and `App.tsx` (feedback widget) with `__APP_VERSION__` injected at build time from `package.json`
- Add `define: { __APP_VERSION__ }` to `vite.config.ts`
- Add `declare const __APP_VERSION__: string` to `ui-feedback.d.ts` for TypeScript

Now the version shown in the UI always matches `package.json` — no more manual string updates.

## Test plan
- [ ] `pnpm build` passes (verified locally)
- [ ] Bottom-left of dashboard shows `v0.4.0` (not `v0.1.0`)