### PR TITLE
fix(infra): add MinIO storage config to dev compose

### DIFF
--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -45,8 +45,11 @@ services:
       SYN_OBSERVABILITY_DB_URL: postgres://syn:syn_dev_password@timescaledb:5432/syn
       EVENT_STORE_HOST: event-store
       EVENT_STORE_PORT: "50051"
-      # Override MinIO endpoint for Docker network
+      # MinIO storage for artifacts (ADR default is 'local' which isn't implemented)
+      SYN_STORAGE_PROVIDER: minio
       SYN_STORAGE_MINIO_ENDPOINT: minio:9000
+      SYN_STORAGE_MINIO_ACCESS_KEY: ${MINIO_ROOT_USER:-minioadmin}
+      SYN_STORAGE_MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-minioadmin}
       # Workspace directory configuration for Docker-in-Docker
       # Container path where workspaces are accessible
       SYN_WORKSPACE_CONTAINER_DIR: /workspaces


### PR DESCRIPTION
## Summary
- The API container defaulted to `SYN_STORAGE_PROVIDER=local` which isn't implemented, causing the subscription coordinator to crash on startup
- Projections never populated, so workflows/triggers were invisible via the API after seeding
- Adds `SYN_STORAGE_PROVIDER=minio` plus access/secret key env vars to the dev compose, so fresh setups work out of the box

## Test plan
- [x] `just dev-fresh` completes successfully
- [x] `just health-check` — all core services healthy
- [x] `syn workflow list` shows seeded workflows
- [x] `curl /triggers` returns seeded trigger rules
- [x] Workflow dry-run passes