### PR TITLE
refactor(orchestration): extract collaborator classes from WorkflowExecutionEngine

### DIFF
--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ArtifactCollector.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ArtifactCollector.py
@@ -1,0 +1,283 @@
+"""Artifact collection and injection for workflow execution.
+
+Handles artifact lifecycle within a phase:
+- Injecting artifacts from previous phases into workspace
+- Collecting output artifacts from workspace after execution
+- Creating artifact aggregates with two-tier storage (ADR-012)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+from uuid import uuid4
+
+from syn_domain.contexts.artifacts._shared.value_objects import ArtifactType
+
+if TYPE_CHECKING:
+    from syn_domain.contexts.artifacts.domain.ports.artifact_storage import (
+        ArtifactContentStoragePort,
+    )
+    from syn_domain.contexts.artifacts.domain.services.artifact_query_service import (
+        ArtifactQueryServiceProtocol,
+    )
+    from syn_domain.contexts.orchestration.slices.execute_workflow.WorkflowExecutionEngine import (
+        ArtifactRepository,
+        ExecutionContext,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class ArtifactWorkspace(Protocol):
+    """Protocol for workspace methods needed by ArtifactCollector."""
+
+    async def inject_files(self, files: list[tuple[str, bytes]]) -> None: ...
+
+    async def collect_files(self, patterns: list[str]) -> list[tuple[str, bytes]]: ...
+
+
+# Mapping from string artifact types to enum values
+_ARTIFACT_TYPE_MAP: dict[str, ArtifactType] = {
+    "text": ArtifactType.TEXT,
+    "markdown": ArtifactType.MARKDOWN,
+    "code": ArtifactType.CODE,
+    "json": ArtifactType.JSON,
+    "yaml": ArtifactType.YAML,
+    "research_summary": ArtifactType.RESEARCH_SUMMARY,
+    "plan": ArtifactType.PLAN,
+    "execution_report": ArtifactType.EXECUTION_REPORT,
+    "documentation": ArtifactType.DOCUMENTATION,
+    "analysis_report": ArtifactType.ANALYSIS_REPORT,
+    "requirements": ArtifactType.REQUIREMENTS,
+    "design_doc": ArtifactType.DESIGN_DOC,
+    "configuration": ArtifactType.CONFIGURATION,
+    "script": ArtifactType.SCRIPT,
+}
+
+
+def map_artifact_type(type_str: str) -> ArtifactType:
+    """Map string artifact type to enum."""
+    return _ARTIFACT_TYPE_MAP.get(type_str.lower(), ArtifactType.OTHER)
+
+
+@dataclass(frozen=True)
+class CollectedArtifacts:
+    """Result of collecting artifacts from a workspace."""
+
+    artifact_ids: list[str]
+    first_content: str | None
+
+
+class ArtifactCollector:
+    """Handles artifact injection and collection for phase execution."""
+
+    def __init__(
+        self,
+        repository: ArtifactRepository,
+        content_storage: ArtifactContentStoragePort | None,
+        query_service: ArtifactQueryServiceProtocol | None,
+    ) -> None:
+        self._repository = repository
+        self._content_storage = content_storage
+        self._query_service = query_service
+
+    async def inject_from_previous_phases(
+        self,
+        workspace: ArtifactWorkspace,
+        ctx: ExecutionContext,
+    ) -> None:
+        """Inject input artifacts from previous phases into workspace.
+
+        Writes files to artifacts/input/ in the workspace (ADR-036).
+        Uses in-memory cache first, falls back to projection query.
+        """
+        if not ctx.completed_phase_ids:
+            return
+
+        phase_outputs: dict[str, str] = {}
+
+        # 1. Get from in-memory cache (immediate, no eventual consistency)
+        for pid in ctx.completed_phase_ids:
+            if pid in ctx.phase_outputs:
+                phase_outputs[pid] = ctx.phase_outputs[pid]
+
+        # 2. Query projection for any missing phases
+        missing_phases = [pid for pid in ctx.completed_phase_ids if pid not in phase_outputs]
+        if missing_phases and self._query_service:
+            projection_outputs = await self._query_service.get_for_phase_injection(
+                execution_id=ctx.execution_id,
+                completed_phase_ids=missing_phases,
+            )
+            phase_outputs.update(projection_outputs)
+
+        # Write artifacts to /workspace/artifacts/input/
+        files_to_inject = [
+            (f"artifacts/input/{prev_phase_id}.md", content.encode())
+            for prev_phase_id, content in phase_outputs.items()
+        ]
+        if files_to_inject:
+            await workspace.inject_files(files_to_inject)
+            logger.info(
+                "Injected %d artifact(s) from previous phases: %s",
+                len(files_to_inject),
+                list(phase_outputs.keys()),
+            )
+        elif ctx.completed_phase_ids:
+            logger.warning(
+                "No artifacts found for completed phases: %s",
+                ctx.completed_phase_ids,
+            )
+
+    async def collect_from_workspace(
+        self,
+        workspace: ArtifactWorkspace,
+        workflow_id: str,
+        phase_id: str,
+        execution_id: str,
+        session_id: str,
+        phase_name: str,
+        output_artifact_type: str,
+    ) -> CollectedArtifacts:
+        """Collect output artifacts from workspace after execution.
+
+        Collects from artifacts/output/ (ADR-036) and creates artifact aggregates.
+
+        Returns:
+            CollectedArtifacts with IDs and first artifact content for injection.
+        """
+        artifacts = await workspace.collect_files(
+            patterns=["artifacts/output/**/*"],
+        )
+
+        artifact_ids: list[str] = []
+        first_content: str | None = None
+
+        for artifact_path, artifact_content in artifacts:
+            artifact_id = str(uuid4())
+            content_str = artifact_content.decode("utf-8", errors="replace")
+            await self._create_artifact(
+                artifact_id=artifact_id,
+                workflow_id=workflow_id,
+                phase_id=phase_id,
+                execution_id=execution_id,
+                session_id=session_id,
+                artifact_type=output_artifact_type,
+                content=content_str,
+                title=f"{phase_name}: {artifact_path}",
+            )
+            artifact_ids.append(artifact_id)
+            if first_content is None:
+                first_content = content_str
+
+        return CollectedArtifacts(
+            artifact_ids=artifact_ids,
+            first_content=first_content,
+        )
+
+    async def collect_partial(
+        self,
+        workspace: ArtifactWorkspace,
+        workflow_id: str,
+        phase_id: str,
+        execution_id: str,
+        session_id: str,
+        phase_name: str,
+        output_artifact_type: str,
+    ) -> list[str]:
+        """Collect partial artifacts during interrupt. Never raises."""
+        try:
+            partial_artifacts = await workspace.collect_files(patterns=["artifacts/output/**/*"])
+            artifact_ids: list[str] = []
+            for artifact_path, artifact_content in partial_artifacts:
+                artifact_id = str(uuid4())
+                content_str = artifact_content.decode("utf-8", errors="replace")
+                await self._create_artifact(
+                    artifact_id=artifact_id,
+                    workflow_id=workflow_id,
+                    phase_id=phase_id,
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    artifact_type=output_artifact_type,
+                    content=content_str,
+                    title=f"{phase_name} (partial): {artifact_path}",
+                )
+                artifact_ids.append(artifact_id)
+            return artifact_ids
+        except Exception as err:
+            logger.warning(
+                "Failed to collect partial artifacts for %s: %s",
+                session_id,
+                err,
+            )
+            return []
+
+    async def _create_artifact(
+        self,
+        artifact_id: str,
+        workflow_id: str,
+        phase_id: str,
+        execution_id: str,
+        session_id: str,
+        artifact_type: str,
+        content: str,
+        title: str,
+    ) -> None:
+        """Create and save an artifact with two-tier storage (ADR-012)."""
+        from syn_domain.contexts.artifacts.domain.aggregate_artifact.ArtifactAggregate import (
+            ArtifactAggregate,
+        )
+        from syn_domain.contexts.artifacts.domain.commands.CreateArtifactCommand import (
+            CreateArtifactCommand,
+        )
+
+        artifact_type_enum = map_artifact_type(artifact_type)
+
+        # Upload content to object storage if configured (ADR-012)
+        storage_uri: str | None = None
+        if self._content_storage is not None:
+            try:
+                result = await self._content_storage.upload(
+                    artifact_id=artifact_id,
+                    content=content.encode("utf-8"),
+                    workflow_id=workflow_id,
+                    phase_id=phase_id,
+                    execution_id=execution_id,
+                    content_type="text/markdown",
+                    metadata={
+                        "session_id": session_id,
+                        "artifact_type": artifact_type,
+                        "title": title,
+                    },
+                )
+                storage_uri = result.storage_uri
+                logger.info(
+                    "Artifact content uploaded to object storage",
+                    extra={
+                        "artifact_id": artifact_id,
+                        "storage_uri": storage_uri,
+                        "size_bytes": result.size_bytes,
+                    },
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to upload artifact to object storage, "
+                    "content will be stored in event store only",
+                    extra={"artifact_id": artifact_id, "error": str(e)},
+                )
+
+        aggregate = ArtifactAggregate()
+        command = CreateArtifactCommand(
+            aggregate_id=artifact_id,
+            workflow_id=workflow_id,
+            phase_id=phase_id,
+            execution_id=execution_id,
+            session_id=session_id,
+            artifact_type=artifact_type_enum,
+            content=content,
+            title=title,
+            storage_uri=storage_uri,
+        )
+        aggregate._handle_command(command)
+        await self._repository.save(aggregate)

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ConversationRecorder.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ConversationRecorder.py
@@ -1,0 +1,74 @@
+"""Conversation recording helper for workflow execution.
+
+Deduplicates the 3 nearly-identical conversation storage blocks
+(success/failure/interrupt) into a single reusable method.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from syn_adapters.conversations import ConversationStoragePort
+
+logger = logging.getLogger(__name__)
+
+
+class ConversationRecorder:
+    """Stores conversation logs to object storage. No-ops if storage is None."""
+
+    def __init__(self, storage: ConversationStoragePort | None) -> None:
+        self._storage = storage
+
+    async def store(
+        self,
+        session_id: str,
+        lines: list[str],
+        execution_id: str,
+        phase_id: str,
+        workflow_id: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+        started_at: datetime,
+        success: bool,
+    ) -> None:
+        """Store conversation log. No-op if storage is None or lines empty. Never raises."""
+        if self._storage is None or not lines:
+            return
+
+        try:
+            from syn_adapters.conversations import SessionContext
+
+            context = SessionContext(
+                execution_id=execution_id,
+                phase_id=phase_id,
+                workflow_id=workflow_id,
+                model=model,
+                event_count=len(lines),
+                tool_counts={},
+                total_input_tokens=input_tokens,
+                total_output_tokens=output_tokens,
+                started_at=started_at,
+                completed_at=datetime.now(UTC),
+                success=success,
+            )
+            await self._storage.store_session(
+                session_id=session_id,
+                lines=lines,
+                context=context,
+            )
+            logger.info(
+                "Conversation log stored: %s (%d lines, success=%s)",
+                session_id,
+                len(lines),
+                success,
+            )
+        except Exception as err:
+            logger.warning(
+                "Failed to store conversation log for %s: %s",
+                session_id,
+                err,
+            )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/EventStreamProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/EventStreamProcessor.py
@@ -1,0 +1,601 @@
+"""Event stream processor for workflow execution.
+
+Processes Claude CLI JSONL output stream, dispatching events to
+TokenAccumulator, SubagentTracker, and observability writer.
+
+Extracted from WorkflowExecutionEngine._execute_phase_in_container().
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+# Any: dict[str, Any] used for JSON data from json.loads() (system boundary — external CLI JSONL)
+from agentic_events import enrich_event, parse_jsonl_line
+
+from syn_domain.contexts.agent_sessions.domain.events.agent_observation import (
+    ObservationType,
+)
+from syn_shared.events import VALID_EVENT_TYPES
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from syn_adapters.control import ExecutionController
+    from syn_domain.contexts.orchestration.slices.execute_workflow.SubagentTracker import (
+        SubagentTracker,
+    )
+    from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+        TokenAccumulator,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class InterruptableWorkspace(Protocol):
+    """Protocol for workspace interrupt capability needed during stream processing."""
+
+    async def interrupt(self) -> bool: ...
+
+
+class ObservabilityRecorder(Protocol):
+    """Protocol for recording observations to the observability backend."""
+
+    async def record(
+        self,
+        observation_type: ObservationType | str,
+        session_id: str,
+        data: dict[str, Any],
+        execution_id: str | None = None,
+        phase_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> None: ...
+
+
+@dataclass(frozen=True)
+class StreamResult:
+    """Result of processing the event stream."""
+
+    line_count: int
+    interrupt_requested: bool
+    interrupt_reason: str | None
+    agent_task_result: dict[str, Any] | None
+    conversation_lines: list[str] = field(default_factory=list)
+
+
+class EventStreamProcessor:
+    """Processes Claude CLI JSONL event stream.
+
+    Dispatches events to TokenAccumulator and SubagentTracker,
+    records observations, and accumulates conversation lines.
+    """
+
+    def __init__(
+        self,
+        tokens: TokenAccumulator,
+        subagents: SubagentTracker,
+        observability: ObservabilityRecorder | None,
+        controller: ExecutionController | None,
+        execution_id: str,
+        phase_id: str,
+        session_id: str,
+        workspace_id: str | None,
+        agent_model: str,
+    ) -> None:
+        self._tokens = tokens
+        self._subagents = subagents
+        self._observability = observability
+        self._controller = controller
+        self._execution_id = execution_id
+        self._phase_id = phase_id
+        self._session_id = session_id
+        self._workspace_id = workspace_id
+        self._agent_model = agent_model
+
+    async def process_stream(
+        self,
+        stream: AsyncIterator[str],
+        workspace: InterruptableWorkspace,
+    ) -> StreamResult:
+        """Process the JSONL event stream from Claude CLI.
+
+        Args:
+            stream: Async iterator of JSONL lines from workspace.stream()
+            workspace: Workspace instance (for interrupt())
+
+        Returns:
+            StreamResult with accumulated state
+        """
+        conversation_lines: list[str] = []
+        line_count = 0
+        interrupt_requested = False
+        interrupt_reason: str | None = None
+        agent_task_result: dict[str, Any] | None = None
+
+        async for line in stream:
+            line_count += 1
+            logger.debug("Received line %d: %s", line_count, line[:100])
+
+            # Poll for CANCEL signal every 10 lines
+            if line_count % 10 == 0 and self._controller is not None:
+                from syn_adapters.control.commands import ControlSignalType
+
+                signal = await self._controller.check_signal(self._execution_id)
+                if signal and signal.signal_type == ControlSignalType.CANCEL:
+                    logger.info(
+                        "CANCEL signal received for execution %s at line %d — sending SIGINT",
+                        self._execution_id,
+                        line_count,
+                    )
+                    interrupt_requested = True
+                    interrupt_reason = signal.reason
+                    await workspace.interrupt()
+                    break
+
+            # Collect line for conversation storage (ADR-035)
+            if line.strip():
+                conversation_lines.append(line)
+
+            # Parse hook events from the stream
+            hook_events = self._parse_hook_events(line)
+
+            for hook_event in hook_events:
+                await self._process_hook_event(hook_event)
+
+            # Skip native CLI event processing if we handled hook events
+            if hook_events:
+                continue
+
+            # Fall back to Claude CLI native events
+            task_result = await self._process_cli_event(line)
+            if task_result is not None:
+                agent_task_result = task_result
+
+        logger.info(
+            "Agent runner streaming complete: %d lines, %d input tokens, %d output tokens",
+            line_count,
+            self._tokens.input_tokens,
+            self._tokens.output_tokens,
+        )
+
+        return StreamResult(
+            line_count=line_count,
+            interrupt_requested=interrupt_requested,
+            interrupt_reason=interrupt_reason,
+            agent_task_result=agent_task_result,
+            conversation_lines=conversation_lines,
+        )
+
+    def _parse_hook_events(self, line: str) -> list[dict[str, Any]]:
+        """Parse hook events from a stream line.
+
+        Two sources:
+        - SOURCE A: Standalone JSONL from Claude Code hooks
+        - SOURCE B: hook_response system events with embedded JSONL
+        """
+        hook_events: list[dict[str, Any]] = []
+
+        standalone = parse_jsonl_line(line)
+        if standalone:
+            hook_events.append(standalone)
+        else:
+            try:
+                parsed = json.loads(line)
+                line_type = parsed.get("type", "")
+                line_subtype = parsed.get("subtype", "")
+
+                if line_type == "system":
+                    logger.info(
+                        "System event: subtype=%s keys=%s",
+                        line_subtype,
+                        list(parsed.keys()),
+                    )
+
+                if line_type == "system" and line_subtype == "hook_response":
+                    hook_name = parsed.get("hook_name", "?")
+                    hook_event = parsed.get("hook_event", "?")
+                    seen: set[str] = set()
+
+                    for channel in ("output", "stdout", "stderr"):
+                        channel_text = parsed.get(channel, "")
+                        logger.info(
+                            "hook_response hook=%s event=%s channel=%s len=%d content=%r",
+                            hook_name,
+                            hook_event,
+                            channel,
+                            len(channel_text),
+                            channel_text[:300],
+                        )
+                        for hook_line in channel_text.splitlines():
+                            hook_line = hook_line.strip()
+                            if hook_line and hook_line not in seen:
+                                evt = parse_jsonl_line(hook_line)
+                                if evt:
+                                    seen.add(hook_line)
+                                    hook_events.append(evt)
+                                else:
+                                    logger.info(
+                                        "hook_response line not a hook event: %r",
+                                        hook_line[:200],
+                                    )
+            except (json.JSONDecodeError, AttributeError):
+                pass
+
+        return hook_events
+
+    async def _process_hook_event(self, hook_event: dict[str, Any]) -> None:
+        """Process a single hook event: validate, enrich, record, track subagents."""
+        event_type = hook_event.get("event_type")
+        if event_type not in VALID_EVENT_TYPES:
+            logger.warning(
+                "Unknown event_type from hook: %s — "
+                "add it to syn_shared.events or check for a producer/consumer mismatch",
+                event_type,
+            )
+
+        enriched = enrich_event(
+            hook_event,
+            execution_id=self._execution_id,
+            phase_id=self._phase_id,
+        )
+        logger.debug("Hook event: %s", enriched.get("event_type"))
+
+        # Store via observability writer
+        if self._observability is not None:
+            hook_data = {
+                **(enriched.get("context") or {}),
+                **(enriched.get("metadata") or {}),
+            }
+            await self._observability.record(
+                observation_type=enriched.get("event_type", "unknown"),
+                session_id=self._session_id,
+                data=hook_data,
+                execution_id=self._execution_id,
+                phase_id=self._phase_id,
+                workspace_id=self._workspace_id,
+            )
+
+        # Track subagent lifecycle from Task tool events (ADR-037)
+        hook_type = hook_event.get("type", "")
+        ctx_data = enriched.get("context", {})
+        tool_name = ctx_data.get("tool_name", "")
+        tool_use_id = ctx_data.get("tool_use_id", "")
+
+        if tool_name == "Task" and tool_use_id:
+            if hook_type == "tool_use_started":
+                input_preview = ctx_data.get("input_preview", "")
+                event = self._subagents.on_task_started_from_hook(tool_use_id, input_preview)
+                if self._observability is not None:
+                    await self._observability.record(
+                        observation_type=ObservationType.SUBAGENT_STARTED,
+                        session_id=self._session_id,
+                        data={
+                            "agent_name": event.agent_name,
+                            "subagent_tool_use_id": tool_use_id,
+                        },
+                        execution_id=self._execution_id,
+                        phase_id=self._phase_id,
+                        workspace_id=self._workspace_id,
+                    )
+                    logger.info(
+                        "Subagent started: %s (id=%s)",
+                        event.agent_name,
+                        tool_use_id,
+                    )
+
+            elif hook_type == "tool_use_completed":
+                success = ctx_data.get("success", True)
+                stopped_event = self._subagents.on_task_completed(tool_use_id, success=success)
+                if stopped_event and self._observability is not None:
+                    await self._observability.record(
+                        observation_type=ObservationType.SUBAGENT_STOPPED,
+                        session_id=self._session_id,
+                        data={
+                            "agent_name": stopped_event.agent_name,
+                            "subagent_tool_use_id": tool_use_id,
+                            "duration_ms": stopped_event.duration_ms,
+                            "success": stopped_event.success,
+                            "tools_used": stopped_event.tools_used,
+                        },
+                        execution_id=self._execution_id,
+                        phase_id=self._phase_id,
+                        workspace_id=self._workspace_id,
+                    )
+                    logger.info(
+                        "Subagent stopped: %s (id=%s, duration=%dms, tools=%s)",
+                        stopped_event.agent_name,
+                        tool_use_id,
+                        stopped_event.duration_ms or 0,
+                        stopped_event.tools_used,
+                    )
+
+    async def _process_cli_event(self, line: str) -> dict[str, Any] | None:
+        """Process a Claude CLI native event. Returns task result if found."""
+        try:
+            cli_event = json.loads(line)
+        except json.JSONDecodeError:
+            logger.debug("Non-JSON line: %s", line[:50])
+            return None
+
+        cli_type = cli_event.get("type", "")
+        logger.debug("CLI event type: %s", cli_type)
+
+        task_result: dict[str, Any] | None = None
+
+        if cli_type == "result":
+            task_result = await self._handle_result_event(cli_event)
+
+        if cli_type == "assistant":
+            await self._handle_assistant_event(cli_event)
+
+        if cli_type == "user":
+            await self._handle_user_event(cli_event)
+
+        if cli_type == "system":
+            logger.debug("CLI message: %s", cli_type)
+
+        return task_result
+
+    async def _handle_result_event(self, cli_event: dict[str, Any]) -> dict[str, Any] | None:
+        """Handle a result event — extract task result and token usage."""
+        task_result: dict[str, Any] | None = None
+
+        # Parse structured task result
+        result_text = cli_event.get("result", "")
+        if result_text and "TASK_RESULT:" in result_text:
+            try:
+                marker = "TASK_RESULT:"
+                idx = result_text.rfind(marker)
+                raw = result_text[idx + len(marker) :].strip()
+                brace_end = raw.find("}")
+                if brace_end >= 0:
+                    raw = raw[: brace_end + 1]
+                parsed_result: dict[str, Any] = json.loads(raw)
+                task_result = parsed_result
+                logger.info(
+                    "Agent task result: success=%s comments=%s",
+                    parsed_result.get("success"),
+                    str(parsed_result.get("comments", ""))[:100],
+                )
+            except (json.JSONDecodeError, ValueError):
+                logger.debug("Could not parse TASK_RESULT block")
+
+        # Extract token usage
+        usage = cli_event.get("usage", {})
+        input_tokens = usage.get("input_tokens", 0)
+        output_tokens = usage.get("output_tokens", 0)
+
+        if input_tokens > 0 or output_tokens > 0:
+            self._tokens.record(input_tokens, output_tokens)
+
+            if self._observability is not None:
+                cache_creation = usage.get("cache_creation_input_tokens", 0)
+                cache_read = usage.get("cache_read_input_tokens", 0)
+                await self._observability.record(
+                    observation_type=ObservationType.TOKEN_USAGE,
+                    session_id=self._session_id,
+                    data={
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "cache_creation_tokens": cache_creation,
+                        "cache_read_tokens": cache_read,
+                        "model": self._agent_model,
+                    },
+                    execution_id=self._execution_id,
+                    phase_id=self._phase_id,
+                    workspace_id=self._workspace_id,
+                )
+                logger.info(
+                    "Result token usage: %d in, %d out",
+                    input_tokens,
+                    output_tokens,
+                )
+
+        return task_result
+
+    async def _handle_assistant_event(self, cli_event: dict[str, Any]) -> None:
+        """Handle assistant event — extract per-turn tokens and tool_use."""
+        message = cli_event.get("message", {})
+        content = message.get("content", [])
+
+        # Extract per-turn token usage
+        usage = message.get("usage", {})
+        if usage:
+            input_tokens = usage.get("input_tokens", 0)
+            output_tokens = usage.get("output_tokens", 0)
+
+            if input_tokens > 0 or output_tokens > 0:
+                self._tokens.record(input_tokens, output_tokens)
+
+                if self._observability is not None:
+                    cache_creation = usage.get("cache_creation_input_tokens", 0)
+                    cache_read = usage.get("cache_read_input_tokens", 0)
+                    await self._observability.record(
+                        observation_type=ObservationType.TOKEN_USAGE,
+                        session_id=self._session_id,
+                        data={
+                            "input_tokens": input_tokens,
+                            "output_tokens": output_tokens,
+                            "cache_creation_tokens": cache_creation,
+                            "cache_read_tokens": cache_read,
+                            "model": self._agent_model,
+                        },
+                        execution_id=self._execution_id,
+                        phase_id=self._phase_id,
+                        workspace_id=self._workspace_id,
+                    )
+                    logger.info(
+                        "Per-turn token usage: %d in, %d out (cache: %d read, %d create)",
+                        input_tokens,
+                        output_tokens,
+                        cache_read,
+                        cache_creation,
+                    )
+
+        # Process tool_use items
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "tool_use":
+                await self._handle_tool_use(item)
+
+    async def _handle_tool_use(self, item: dict[str, Any]) -> None:
+        """Handle a tool_use content block from an assistant message."""
+        tool_name = item.get("name", "unknown")
+        tool_use_id = item.get("id", "unknown")
+        tool_input = item.get("input", {})
+        if isinstance(tool_input, str):
+            try:
+                tool_input = json.loads(tool_input)
+            except (json.JSONDecodeError, ValueError):
+                tool_input = {}
+
+        # Cache tool_name for enriching tool_result events
+        self._subagents.register_tool_use(tool_use_id, tool_name)
+
+        if self._observability is not None:
+            await self._observability.record(
+                observation_type=ObservationType.TOOL_EXECUTION_STARTED,
+                session_id=self._session_id,
+                data={
+                    "tool_name": tool_name,
+                    "tool_use_id": tool_use_id,
+                    "input_preview": json.dumps(tool_input)[:500],
+                },
+                execution_id=self._execution_id,
+                phase_id=self._phase_id,
+                workspace_id=self._workspace_id,
+            )
+            logger.debug("Tool started: %s", tool_name)
+
+        # Detect Task tool as subagent start (ADR-037)
+        if tool_name == "Task" and tool_use_id:
+            event = self._subagents.on_task_started(tool_use_id, tool_input)
+            if self._observability is not None:
+                await self._observability.record(
+                    observation_type=ObservationType.SUBAGENT_STARTED,
+                    session_id=self._session_id,
+                    data={
+                        "agent_name": event.agent_name,
+                        "subagent_tool_use_id": tool_use_id,
+                    },
+                    execution_id=self._execution_id,
+                    phase_id=self._phase_id,
+                    workspace_id=self._workspace_id,
+                )
+                logger.info(
+                    "Subagent started (CLI): %s (id=%s)",
+                    event.agent_name,
+                    tool_use_id,
+                )
+
+    async def _handle_user_event(self, cli_event: dict[str, Any]) -> None:
+        """Handle user event — process tool results."""
+        message = cli_event.get("message", {})
+        content = message.get("content", [])
+
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "tool_result":
+                await self._handle_tool_result(item)
+
+    async def _handle_tool_result(self, item: dict[str, Any]) -> None:
+        """Handle a tool_result content block from a user message."""
+        tool_use_id = item.get("tool_use_id", "unknown")
+        is_error = item.get("is_error", False)
+
+        # Extract tool output content
+        tool_content = item.get("content", "")
+        if isinstance(tool_content, list):
+            tool_content = " ".join(
+                str(c.get("text", c) if isinstance(c, dict) else c) for c in tool_content
+            )
+        output_preview = str(tool_content)[:500] if tool_content else None
+        tool_name = self._subagents.resolve_tool_name(tool_use_id)
+
+        # Scan tool output for embedded git hook JSONL (ADR-043)
+        if tool_content and self._observability is not None:
+            for tl in str(tool_content).splitlines():
+                tl = tl.strip()
+                if not tl:
+                    continue
+                embedded = parse_jsonl_line(tl)
+                if not embedded:
+                    continue
+                et = embedded.get("event_type")
+                if et not in VALID_EVENT_TYPES:
+                    logger.debug("Unknown event_type in tool output: %s", et)
+                    continue
+                enriched = enrich_event(
+                    embedded,
+                    execution_id=self._execution_id,
+                    phase_id=self._phase_id,
+                )
+                hd = {
+                    **(enriched.get("context") or {}),
+                    **(enriched.get("metadata") or {}),
+                }
+                await self._observability.record(
+                    observation_type=et,
+                    session_id=self._session_id,
+                    data=hd,
+                    execution_id=self._execution_id,
+                    phase_id=self._phase_id,
+                    workspace_id=self._workspace_id,
+                )
+                logger.info(
+                    "Git hook event from tool output: %s (tool=%s)",
+                    et,
+                    tool_name,
+                )
+
+        # Record tool completion
+        if self._observability is not None:
+            await self._observability.record(
+                observation_type=ObservationType.TOOL_EXECUTION_COMPLETED,
+                session_id=self._session_id,
+                data={
+                    "tool_name": tool_name,
+                    "tool_use_id": tool_use_id,
+                    "success": not is_error,
+                    "output_preview": output_preview,
+                },
+                execution_id=self._execution_id,
+                phase_id=self._phase_id,
+                workspace_id=self._workspace_id,
+            )
+            logger.debug(
+                "Tool completed: %s (%s) success=%s",
+                tool_use_id,
+                tool_name,
+                not is_error,
+            )
+
+        # Detect Task tool completion as subagent stop (ADR-037)
+        if tool_name == "Task":
+            event = self._subagents.on_task_completed(tool_use_id, success=not is_error)
+            if event and self._observability is not None:
+                await self._observability.record(
+                    observation_type=ObservationType.SUBAGENT_STOPPED,
+                    session_id=self._session_id,
+                    data={
+                        "agent_name": event.agent_name,
+                        "subagent_tool_use_id": tool_use_id,
+                        "duration_ms": event.duration_ms,
+                        "success": event.success,
+                        "tools_used": event.tools_used,
+                    },
+                    execution_id=self._execution_id,
+                    phase_id=self._phase_id,
+                    workspace_id=self._workspace_id,
+                )
+                logger.info(
+                    "Subagent stopped (CLI): %s (id=%s, duration=%dms, tools=%s)",
+                    event.agent_name,
+                    tool_use_id,
+                    event.duration_ms or 0,
+                    event.tools_used,
+                )
+        elif tool_name != "Task":
+            # Attribute non-Task tool to the most recently started subagent
+            self._subagents.attribute_tool(tool_name)

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/PhaseResultBuilder.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/PhaseResultBuilder.py
@@ -1,0 +1,63 @@
+"""Phase result construction helpers for workflow execution.
+
+Static factory methods for building PhaseResult in success/failure paths.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+    PhaseResult,
+    PhaseStatus,
+)
+
+if TYPE_CHECKING:
+    from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+        TokenAccumulator,
+    )
+
+
+class PhaseResultBuilder:
+    """Factory methods for constructing PhaseResult."""
+
+    @staticmethod
+    def success(
+        phase_id: str,
+        started_at: datetime,
+        session_id: str,
+        artifact_ids: list[str],
+        tokens: TokenAccumulator,
+    ) -> PhaseResult:
+        """Build a successful PhaseResult."""
+        completed_at = datetime.now(UTC)
+        return PhaseResult(
+            phase_id=phase_id,
+            status=PhaseStatus.COMPLETED,
+            started_at=started_at,
+            completed_at=completed_at,
+            artifact_id=artifact_ids[0] if artifact_ids else None,
+            session_id=session_id,
+            input_tokens=tokens.input_tokens,
+            output_tokens=tokens.output_tokens,
+            total_tokens=tokens.total_tokens,
+            cost_usd=tokens.estimate_cost(),
+        )
+
+    @staticmethod
+    def failure(
+        phase_id: str,
+        started_at: datetime,
+        session_id: str,
+        error_message: str,
+    ) -> PhaseResult:
+        """Build a failed PhaseResult."""
+        return PhaseResult(
+            phase_id=phase_id,
+            status=PhaseStatus.FAILED,
+            started_at=started_at,
+            completed_at=datetime.now(UTC),
+            session_id=session_id,
+            error_message=error_message,
+        )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/SubagentTracker.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/SubagentTracker.py
@@ -1,0 +1,135 @@
+"""Subagent lifecycle tracker for workflow execution.
+
+Tracks Task tool (subagent) start/stop events and tool name resolution.
+Extracted from WorkflowExecutionEngine per ADR-037.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+# Any: input_data comes from json.loads() (external CLI JSONL — system boundary)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class SubagentEvent:
+    """Represents a subagent lifecycle event."""
+
+    agent_name: str
+    tool_use_id: str
+    event_type: Literal["started", "stopped"]
+    duration_ms: int | None = None
+    success: bool | None = None
+    tools_used: dict[str, int] | None = None
+
+
+class SubagentTracker:
+    """Tracks active subagents (Task tool) and tool name resolution.
+
+    Owns two pieces of state:
+    - Active subagents: tool_use_id → (agent_name, started_at, tools_used)
+    - Tool name cache: tool_use_id → tool_name (for enriching tool_result events)
+    """
+
+    def __init__(self) -> None:
+        self._active: dict[str, tuple[str, datetime, dict[str, int]]] = {}
+        self._tool_names_cache: dict[str, str] = {}
+
+    def register_tool_use(self, tool_use_id: str, tool_name: str) -> None:
+        """Cache a tool_use_id → tool_name mapping for later resolution."""
+        self._tool_names_cache[tool_use_id] = tool_name
+
+    def resolve_tool_name(self, tool_use_id: str) -> str:
+        """Resolve tool_use_id to tool_name. Returns 'unknown' if not cached."""
+        return self._tool_names_cache.get(tool_use_id, "unknown")
+
+    def on_task_started(self, tool_use_id: str, input_data: dict[str, Any]) -> SubagentEvent:
+        """Record a Task tool starting (subagent spawn).
+
+        Args:
+            tool_use_id: The tool_use_id of the Task tool call
+            input_data: Parsed input data (may contain subagent_type or description)
+
+        Returns:
+            SubagentEvent with event_type="started"
+        """
+        agent_name = str(input_data.get("subagent_type", input_data.get("description", "unknown")))[
+            :50
+        ]
+        self._active[tool_use_id] = (agent_name, datetime.now(UTC), {})
+        return SubagentEvent(
+            agent_name=agent_name,
+            tool_use_id=tool_use_id,
+            event_type="started",
+        )
+
+    def on_task_started_from_hook(self, tool_use_id: str, input_preview: str) -> SubagentEvent:
+        """Record a Task tool starting from hook event format.
+
+        Args:
+            tool_use_id: The tool_use_id
+            input_preview: JSON string of the input preview
+
+        Returns:
+            SubagentEvent with event_type="started"
+        """
+        agent_name = "unknown"
+        if input_preview:
+            try:
+                input_data = json.loads(input_preview)
+                agent_name = str(
+                    input_data.get("subagent_type", input_data.get("description", "unknown"))
+                )[:50]
+            except (json.JSONDecodeError, TypeError):
+                pass
+        self._active[tool_use_id] = (agent_name, datetime.now(UTC), {})
+        return SubagentEvent(
+            agent_name=agent_name,
+            tool_use_id=tool_use_id,
+            event_type="started",
+        )
+
+    def on_task_completed(self, tool_use_id: str, success: bool) -> SubagentEvent | None:
+        """Record a Task tool completing (subagent stop).
+
+        Args:
+            tool_use_id: The tool_use_id of the completed Task
+            success: Whether the task completed successfully
+
+        Returns:
+            SubagentEvent with event_type="stopped", or None if no matching active subagent
+        """
+        if tool_use_id not in self._active:
+            return None
+        agent_name, started_at, tools_used = self._active.pop(tool_use_id)
+        duration_ms = int((datetime.now(UTC) - started_at).total_seconds() * 1000)
+        return SubagentEvent(
+            agent_name=agent_name,
+            tool_use_id=tool_use_id,
+            event_type="stopped",
+            duration_ms=duration_ms,
+            success=success,
+            tools_used=tools_used,
+        )
+
+    def attribute_tool(self, tool_name: str) -> None:
+        """Attribute a tool call to the most recently started subagent."""
+        if not self._active or not tool_name:
+            return
+        latest_id = max(
+            self._active.keys(),
+            key=lambda k: self._active[k][1],  # Sort by started_at
+        )
+        _, _, tools_dict = self._active[latest_id]
+        tools_dict[tool_name] = tools_dict.get(tool_name, 0) + 1
+
+    @property
+    def has_active(self) -> bool:
+        """Whether there are any active subagents."""
+        return len(self._active) > 0

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/TokenAccumulator.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/TokenAccumulator.py
@@ -1,0 +1,48 @@
+"""Token accumulation state machine for workflow execution.
+
+Extracted from WorkflowExecutionEngine to isolate token tracking
+and cost estimation concerns.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+
+class TokenAccumulator:
+    """Accumulates token usage across streaming events and estimates cost.
+
+    Pure state machine with no external dependencies.
+    """
+
+    # Claude Sonnet 4 pricing (per million tokens)
+    _INPUT_PRICE = Decimal("3.00") / Decimal("1000000")
+    _OUTPUT_PRICE = Decimal("15.00") / Decimal("1000000")
+
+    def __init__(self) -> None:
+        self._input_tokens: int = 0
+        self._output_tokens: int = 0
+
+    def record(self, input_tokens: int, output_tokens: int) -> None:
+        """Record token usage from a streaming event."""
+        self._input_tokens += input_tokens
+        self._output_tokens += output_tokens
+
+    def estimate_cost(self) -> Decimal:
+        """Estimate cost based on accumulated token usage."""
+        return (
+            Decimal(self._input_tokens) * self._INPUT_PRICE
+            + Decimal(self._output_tokens) * self._OUTPUT_PRICE
+        )
+
+    @property
+    def input_tokens(self) -> int:
+        return self._input_tokens
+
+    @property
+    def output_tokens(self) -> int:
+        return self._output_tokens
+
+    @property
+    def total_tokens(self) -> int:
+        return self._input_tokens + self._output_tokens

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionEngine.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionEngine.py
@@ -10,7 +10,6 @@ Key requirements:
 
 from __future__ import annotations
 
-import json
 import logging
 import shlex
 from collections.abc import Callable
@@ -20,13 +19,9 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Protocol
 from uuid import uuid4
 
-# ADR-029: Simplified Event System - use agentic_events from agentic-primitives
-from agentic_events import enrich_event, parse_jsonl_line
-
 from syn_domain.contexts.agent_sessions.domain.events.agent_observation import (
     ObservationType,
 )
-from syn_domain.contexts.artifacts._shared.value_objects import ArtifactType
 from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
     ExecutablePhase,
     ExecutionMetrics,
@@ -42,10 +37,27 @@ from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecut
     StartPhaseCommand,
     WorkflowExecutionAggregate,
 )
+from syn_domain.contexts.orchestration.slices.execute_workflow.ArtifactCollector import (
+    ArtifactCollector,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.ConversationRecorder import (
+    ConversationRecorder,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProcessor import (
+    EventStreamProcessor,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.PhaseResultBuilder import (
+    PhaseResultBuilder,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.SubagentTracker import (
+    SubagentTracker,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+    TokenAccumulator,
+)
 from syn_domain.contexts.orchestration.slices.execute_workflow.workspace_prompt import (
     SYN_WORKSPACE_PROMPT,
 )
-from syn_shared.events import VALID_EVENT_TYPES
 
 if TYPE_CHECKING:
     from syn_adapters.agents.protocol import AgentProtocol as InstrumentedAgent  # Alias for compat
@@ -714,11 +726,14 @@ class WorkflowExecutionEngine:
 
             # Create artifact linked to this execution run
             artifact_id = str(uuid4())
-            await self._create_artifact(
+            artifact_collector = ArtifactCollector(
+                self._artifacts, self._artifact_content_storage, self._artifact_query
+            )
+            await artifact_collector._create_artifact(
                 artifact_id=artifact_id,
                 workflow_id=ctx.workflow_id,
                 phase_id=phase.phase_id,
-                execution_id=ctx.execution_id,  # Link to execution run for retrieval
+                execution_id=ctx.execution_id,
                 session_id=session_id,
                 artifact_type=phase.output_artifact_type,
                 content=response.content,
@@ -905,151 +920,24 @@ class WorkflowExecutionEngine:
 
         return prompt
 
-    async def _create_artifact(
-        self,
-        artifact_id: str,
-        workflow_id: str,
-        phase_id: str,
-        execution_id: str,
-        session_id: str,
-        artifact_type: str,
-        content: str,
-        title: str,
-    ) -> None:
-        """Create and save an artifact.
-
-        Two-tier storage (ADR-012):
-        1. Content → Object storage (MinIO/S3) if configured
-        2. Metadata + storage_uri → Event store
-
-        Args:
-            artifact_id: Unique artifact identifier
-            workflow_id: Parent workflow ID
-            phase_id: Phase that produced this artifact
-            execution_id: Execution run ID (links to WorkflowExecution aggregate)
-            session_id: Agent session ID
-            artifact_type: Type of artifact (string, mapped to enum)
-            content: Artifact content
-            title: Human-readable title
-        """
-        from syn_domain.contexts.artifacts.domain.aggregate_artifact.ArtifactAggregate import (
-            ArtifactAggregate,
-        )
-        from syn_domain.contexts.artifacts.domain.commands.CreateArtifactCommand import (
-            CreateArtifactCommand,
-        )
-
-        # Map string type to ArtifactType enum
-        artifact_type_enum = self._map_artifact_type(artifact_type)
-
-        # Upload content to object storage if configured (ADR-012)
-        storage_uri: str | None = None
-        if self._artifact_content_storage is not None:
-            try:
-                result = await self._artifact_content_storage.upload(
-                    artifact_id=artifact_id,
-                    content=content.encode("utf-8"),
-                    workflow_id=workflow_id,
-                    phase_id=phase_id,
-                    execution_id=execution_id,
-                    content_type="text/markdown",
-                    metadata={
-                        "session_id": session_id,
-                        "artifact_type": artifact_type,
-                        "title": title,
-                    },
-                )
-                storage_uri = result.storage_uri
-                logger.info(
-                    "Artifact content uploaded to object storage",
-                    extra={
-                        "artifact_id": artifact_id,
-                        "storage_uri": storage_uri,
-                        "size_bytes": result.size_bytes,
-                    },
-                )
-            except Exception as e:
-                # Log error but continue - content will still be in event store
-                logger.warning(
-                    "Failed to upload artifact to object storage, "
-                    "content will be stored in event store only",
-                    extra={"artifact_id": artifact_id, "error": str(e)},
-                )
-
-        aggregate = ArtifactAggregate()
-        command = CreateArtifactCommand(
-            aggregate_id=artifact_id,
-            workflow_id=workflow_id,
-            phase_id=phase_id,
-            execution_id=execution_id,  # Links artifact to specific execution run
-            session_id=session_id,
-            artifact_type=artifact_type_enum,
-            content=content,
-            title=title,
-            storage_uri=storage_uri,  # NEW: Reference to object storage
-        )
-        aggregate._handle_command(command)
-        await self._artifacts.save(aggregate)
-
-    def _map_artifact_type(self, type_str: str) -> ArtifactType:
-        """Map string artifact type to enum."""
-        type_mapping = {
-            "text": ArtifactType.TEXT,
-            "markdown": ArtifactType.MARKDOWN,
-            "code": ArtifactType.CODE,
-            "json": ArtifactType.JSON,
-            "yaml": ArtifactType.YAML,
-            "research_summary": ArtifactType.RESEARCH_SUMMARY,
-            "plan": ArtifactType.PLAN,
-            "execution_report": ArtifactType.EXECUTION_REPORT,
-            "documentation": ArtifactType.DOCUMENTATION,
-            "analysis_report": ArtifactType.ANALYSIS_REPORT,
-            "requirements": ArtifactType.REQUIREMENTS,
-            "design_doc": ArtifactType.DESIGN_DOC,
-            "configuration": ArtifactType.CONFIGURATION,
-            "script": ArtifactType.SCRIPT,
-        }
-        return type_mapping.get(type_str.lower(), ArtifactType.OTHER)
-
     async def _execute_phase_in_container(
         self,
         phase: ExecutablePhase,
         ctx: ExecutionContext,
         aggregate: WorkflowExecutionAggregate,
-        tenant_id: str | None = None,
+        tenant_id: str | None = None,  # noqa: ARG002 — reserved for multi-tenant routing
     ) -> PhaseResult:
         """Execute a phase inside an isolated container with sidecar proxy.
 
-        This implements the full agent-in-container pattern per ADR-023:
-
-        1. Create isolated workspace with sidecar via WorkspaceService
-        2. Inject input artifacts from previous phases
-        3. Write task.json with phase configuration
-        4. Execute Claude CLI via workspace.stream() (ADR-029)
-        5. Parse JSONL events and emit to aggregate
-        6. Collect output artifacts
-        7. Destroy workspace (stateless)
+        This implements the full agent-in-container pattern per ADR-023.
 
         Contract:
-            This method RETURNS the PhaseResult - it does NOT append to ctx.
-            The caller is responsible for:
-            - ctx.phase_results.append(result)
-            - ctx.completed_phase_ids.append(phase.phase_id)
-            - ctx.artifact_ids.append(result.artifact_id) if applicable
-
-            This follows the pattern: helper methods RETURN results, callers append.
-
-        Args:
-            phase: The phase to execute
-            ctx: Execution context
-            aggregate: Workflow execution aggregate for events
-            tenant_id: Optional tenant ID for multi-tenancy
-
-        Returns:
-            PhaseResult with execution metrics
-
-        Raises:
-            WorkflowExecutionError: If phase execution fails
+            On success: RETURNS PhaseResult. Caller appends to ctx.phase_results,
+            ctx.completed_phase_ids, and ctx.artifact_ids.
+            On failure: Appends failure PhaseResult to ctx.phase_results, then raises
+            WorkflowExecutionError. Caller should NOT append again.
+            On interrupt: Extends ctx.artifact_ids with partial artifacts, then raises
+            WorkflowInterruptedError.
         """
         from syn_domain.contexts.agent_sessions._shared.value_objects import OperationType
         from syn_domain.contexts.agent_sessions.domain.aggregate_session.AgentSessionAggregate import (
@@ -1085,7 +973,6 @@ class WorkflowExecutionEngine:
         )
 
         # Create session aggregate for detailed observability
-        # This tracks the session at a more granular level than the workflow aggregate
         session: AgentSessionAggregate | None = None
         if self._sessions is not None:
             session = AgentSessionAggregate()
@@ -1101,29 +988,29 @@ class WorkflowExecutionEngine:
             await self._sessions.save(session)
             logger.debug("Session started: %s (phase: %s)", session_id, phase.phase_id)
 
-        # ADR-035: Initialize conversation tracking variables before try block
-        # This ensures we can store partial conversation logs even on early failures
-        conversation_lines: list[str] = []
-        total_input_tokens = 0
-        total_output_tokens = 0
+        # Create collaborators
+        tokens = TokenAccumulator()
+        subagents = SubagentTracker()
+        recorder = ConversationRecorder(self._conversation_storage)
+        artifacts = ArtifactCollector(
+            self._artifacts, self._artifact_content_storage, self._artifact_query
+        )
+
+        # Track conversation lines for failure handling (stream_result may not exist
+        # if exception occurs before stream processing)
+        _conversation_lines: list[str] = []
 
         try:
-            # Create isolated workspace using WorkspaceService
-            # Setup phase secrets pattern (ADR-024): secrets available during
-            # setup phase, cleared before agent runs
             async with self._workspace_service.create_workspace(
                 execution_id=ctx.execution_id,
                 workflow_id=ctx.workflow_id,
                 phase_id=phase.phase_id,
-                with_sidecar=False,  # Sidecar not needed with setup phase pattern
-                inject_tokens=False,  # Handled by setup phase
+                with_sidecar=False,
+                inject_tokens=False,
             ) as workspace:
                 # Run setup phase with secrets (ADR-024)
-                # Uses GitHub App to generate installation token if configured
                 from syn_adapters.workspace_backends.service import SetupPhaseSecrets
 
-                # Parse "https://github.com/owner/repo" → "owner/repo"
-                # Skip sentinel/placeholder URLs used for workflows with no repo configured.
                 _SKIP_URLS = {
                     "https://github.com/placeholder/not-configured",
                     "https://github.com/example/repo",
@@ -1148,112 +1035,14 @@ class WorkflowExecutionEngine:
                     )
                 logger.info("Setup phase completed, secrets cleared")
 
-                # Inject input artifacts from previous phases
-                # ADR-036: Write to artifacts/input/ (not inputs/)
-                if ctx.completed_phase_ids:
-                    # Use in-memory cache first (avoids eventual consistency issues)
-                    # Fall back to projection query for phases not in cache
-                    phase_outputs: dict[str, str] = {}
+                # Inject input artifacts from previous phases (ADR-036)
+                await artifacts.inject_from_previous_phases(workspace, ctx)
 
-                    # 1. Get from in-memory cache (immediate, no eventual consistency)
-                    for pid in ctx.completed_phase_ids:
-                        if pid in ctx.phase_outputs:
-                            phase_outputs[pid] = ctx.phase_outputs[pid]
-
-                    # 2. Query projection for any missing phases
-                    missing_phases = [
-                        pid for pid in ctx.completed_phase_ids if pid not in phase_outputs
-                    ]
-                    if missing_phases and self._artifact_query:
-                        projection_outputs = await self._artifact_query.get_for_phase_injection(
-                            execution_id=ctx.execution_id,
-                            completed_phase_ids=missing_phases,
-                        )
-                        phase_outputs.update(projection_outputs)
-
-                    # Write artifacts to /workspace/artifacts/input/
-                    files_to_inject = [
-                        (f"artifacts/input/{prev_phase_id}.md", content.encode())
-                        for prev_phase_id, content in phase_outputs.items()
-                    ]
-                    if files_to_inject:
-                        await workspace.inject_files(files_to_inject)
-                        logger.info(
-                            "Injected %d artifact(s) from previous phases: %s",
-                            len(files_to_inject),
-                            list(phase_outputs.keys()),
-                        )
-                    elif ctx.completed_phase_ids:
-                        logger.warning(
-                            "No artifacts found for completed phases: %s",
-                            ctx.completed_phase_ids,
-                        )
-
-                # Build task.json (kept for future use with task file injection)
+                # Build prompt and CLI command
                 prompt = await self._build_prompt(phase, ctx)
-                _task_data = {
-                    "phase": phase.phase_id,
-                    "prompt": prompt,
-                    "execution_id": ctx.execution_id,
-                    "tenant_id": tenant_id or "default",
-                    "inputs": ctx.inputs,
-                    "artifacts": [f"{pid}.md" for pid in ctx.completed_phase_ids],
-                    "config": {
-                        "model": phase.agent_config.model,
-                        "max_tokens": phase.agent_config.max_tokens,
-                        "timeout_seconds": phase.timeout_seconds,
-                    },
-                }
+                claude_cmd = self._build_claude_command(phase, prompt)
 
-                # ADR-029: Run Claude CLI directly (no syn-agent-runner wrapper)
-                # Build the Claude CLI command
-                # ADR-012: Append system prompt for artifact output instructions
-                claude_args = [
-                    "claude",
-                    "--print",  # Non-interactive mode
-                    "--verbose",  # Required for stream-json output format
-                    "--append-system-prompt",
-                    SYN_WORKSPACE_PROMPT,  # Workspace contract from agentic-primitives
-                    prompt,
-                    "--output-format",
-                    "stream-json",  # Stream JSON for real-time events
-                    "--dangerously-skip-permissions",  # Agent runs autonomously
-                ]
-
-                # Add allowed tools if specified
-                if phase.agent_config.allowed_tools:
-                    claude_args.extend(
-                        [
-                            "--allowedTools",
-                            ",".join(phase.agent_config.allowed_tools),
-                        ]
-                    )
-
-                # Wrap in sh -c to dynamically discover and load plugins from the container.
-                # We can't use $AGENTIC_PLUGIN_FLAGS (set by entrypoint.sh) because docker exec
-                # spawns a new process that doesn't inherit shell-exported vars from entrypoint.
-                # Instead, we inline the same discovery logic as entrypoint.sh:
-                #   scan /opt/agentic/plugins/ for dirs with .claude-plugin/plugin.json
-                # This loads observability hooks (git events, security events, etc.)
-                _quoted_args = " ".join(shlex.quote(a) for a in claude_args)
-                _plugin_scan = (
-                    'PLUGIN_FLAGS=""; '
-                    'PLUGINS_DIR="${AGENTIC_PLUGINS_DIR:-/opt/agentic/plugins}"; '
-                    'if [ -d "$PLUGINS_DIR" ]; then '
-                    '  for d in "$PLUGINS_DIR"/*/; do '
-                    '    if [ -f "${d}.claude-plugin/plugin.json" ]; then '
-                    '      PLUGIN_FLAGS="$PLUGIN_FLAGS --plugin-dir ${d%/}"; '
-                    "    fi; "
-                    "  done; "
-                    "fi; "
-                    f"exec {_quoted_args} $PLUGIN_FLAGS"
-                )
-                claude_cmd = ["sh", "-c", _plugin_scan]
-
-                # Execute Claude CLI and stream events
-                # Claude auth is passed to agent (needed for Claude calls)
-                # CLAUDE_CODE_OAUTH_TOKEN takes priority over ANTHROPIC_API_KEY
-                # GitHub auth uses cached credentials from setup phase (ADR-024)
+                # Validate Claude authentication
                 if not secrets.claude_code_oauth_token and not secrets.anthropic_api_key:
                     raise WorkflowExecutionError(
                         message=(
@@ -1264,577 +1053,39 @@ class WorkflowExecutionEngine:
                         phase_id=phase.phase_id,
                     )
 
-                agent_env = {
-                    "CLAUDE_SESSION_ID": session_id,  # For hook event correlation
+                agent_env: dict[str, str] = {
+                    "CLAUDE_SESSION_ID": session_id,
                 }
                 if secrets.claude_code_oauth_token:
                     agent_env["CLAUDE_CODE_OAUTH_TOKEN"] = secrets.claude_code_oauth_token
                 if secrets.anthropic_api_key:
                     agent_env["ANTHROPIC_API_KEY"] = secrets.anthropic_api_key
 
-                total_input_tokens = 0
-                total_output_tokens = 0
-
-                # Variables for observation events
-                execution_id = ctx.execution_id
-                workspace_id = getattr(workspace, "id", None)
-                agent_model = phase.agent_config.model
-
-                # Cache tool_use_id → tool_name for enriching tool_result events
-                # Claude CLI's tool_result only has tool_use_id, not tool_name
-                tool_names_cache: dict[str, str] = {}
-
-                # ADR-037: Track active subagents (Task tool) for observability
-                # tool_use_id → (agent_name, started_at, tools_used)
-                active_subagents: dict[str, tuple[str, datetime, dict[str, int]]] = {}
-
-                def _attribute_tool_to_latest_subagent(
-                    tool: str, subagents: dict[str, tuple[str, datetime, dict[str, int]]]
-                ) -> None:
-                    """Attribute a tool call to the most recently started subagent."""
-                    if not subagents or not tool:
-                        return
-                    latest_subagent_id = max(
-                        subagents.keys(),
-                        key=lambda k: subagents[k][1],  # Sort by started_at
-                    )
-                    _, _, tools_dict = subagents[latest_subagent_id]
-                    tools_dict[tool] = tools_dict.get(tool, 0) + 1
-
-                # ADR-035: Collect all JSONL lines for conversation storage
-                # (conversation_lines initialized before try block for failure handling)
-                conversation_lines.clear()
-
-                # Structured task result parsed from final `result` event text.
-                # Agents emit: TASK_RESULT: {"success": bool, "comments": "..."}
-                agent_task_result: dict | None = None
-
-                line_count = 0
-                _interrupt_requested = False
-                _interrupt_reason: str | None = None
-                async for line in workspace.stream(
-                    claude_cmd,
-                    timeout_seconds=phase.timeout_seconds or 300,
-                    environment=agent_env,
-                ):
-                    line_count += 1
-                    logger.debug("Received line %d: %s", line_count, line[:100])
-
-                    # Poll for CANCEL signal every 10 lines (low overhead, fast response)
-                    if line_count % 10 == 0 and self._controller is not None:
-                        from syn_adapters.control.commands import ControlSignalType
-
-                        signal = await self._controller.check_signal(ctx.execution_id)
-                        if signal and signal.signal_type == ControlSignalType.CANCEL:
-                            logger.info(
-                                "CANCEL signal received for execution %s at line %d — sending SIGINT",
-                                ctx.execution_id,
-                                line_count,
-                            )
-                            _interrupt_requested = True
-                            _interrupt_reason = signal.reason
-                            await workspace.interrupt()
-                            break
-
-                    # ADR-035: Collect line for conversation storage
-                    if line.strip():
-                        conversation_lines.append(line)
-
-                    # ADR-029 / ADR-043: Parse hook events from the stream.
-                    #
-                    # Two sources of hook JSONL exist:
-                    #
-                    # SOURCE A — Claude Code hooks (observe.py via PreToolUse/PostToolUse):
-                    #   These appear as stream-json {"type":"system","subtype":"hook_response"}
-                    #   lines, with JSONL embedded in the "output"/"stderr" fields.
-                    #   Handled below in the hook_response branch.
-                    #
-                    # SOURCE B — Git hooks (post-commit, pre-push, etc.):
-                    #   These emit JSONL to their own stderr. The Bash tool inside Claude
-                    #   Code captures that stderr along with stdout, then packages the whole
-                    #   combined output as the tool_result content in a stream-json "user"
-                    #   message. The JSONL is therefore EMBEDDED INSIDE a tool_result, NOT
-                    #   a standalone raw line. Handled below in the tool_result branch.
-                    #
-                    # parse_jsonl_line() on raw stream lines catches SOURCE A's standalone
-                    # output and any direct stderr from the claude process (via stderr=STDOUT).
-                    # SOURCE B is handled separately in the tool_result scan below.
-                    _hook_events: list[dict] = []
-                    _standalone = parse_jsonl_line(line)
-                    if _standalone:
-                        _hook_events.append(_standalone)
-                    else:
-                        try:
-                            _parsed_line = json.loads(line)
-                            _line_type = _parsed_line.get("type", "")
-                            _line_subtype = _parsed_line.get("subtype", "")
-                            if _line_type == "system":
-                                logger.info(
-                                    "System event: subtype=%s keys=%s",
-                                    _line_subtype,
-                                    list(_parsed_line.keys()),
-                                )
-                            if _line_type == "system" and _line_subtype == "hook_response":
-                                _hook_name = _parsed_line.get("hook_name", "?")
-                                _hook_event = _parsed_line.get("hook_event", "?")
-                                # Check all channels: output, stdout, stderr
-                                # (Claude Code uses 'output'+'stderr' but also has 'stdout')
-                                _seen_hook_jsons: set[str] = set()
-                                for _channel in ("output", "stdout", "stderr"):
-                                    _channel_text = _parsed_line.get(_channel, "")
-                                    logger.info(
-                                        "hook_response hook=%s event=%s channel=%s len=%d content=%r",
-                                        _hook_name,
-                                        _hook_event,
-                                        _channel,
-                                        len(_channel_text),
-                                        _channel_text[:300],
-                                    )
-                                    for _hook_line in _channel_text.splitlines():
-                                        _hook_line = _hook_line.strip()
-                                        if _hook_line and _hook_line not in _seen_hook_jsons:
-                                            _evt = parse_jsonl_line(_hook_line)
-                                            if _evt:
-                                                _seen_hook_jsons.add(_hook_line)
-                                                _hook_events.append(_evt)
-                                            else:
-                                                logger.info(
-                                                    "hook_response line not a hook event: %r",
-                                                    _hook_line[:200],
-                                                )
-                        except (json.JSONDecodeError, AttributeError):
-                            pass
-
-                    for hook_event in _hook_events:
-                        # Validate event_type against VALID_EVENT_TYPES (syn_shared.events)
-                        # An unknown type means producer/consumer are out of sync.
-                        _hook_event_type = hook_event.get("event_type")
-                        if _hook_event_type not in VALID_EVENT_TYPES:
-                            logger.warning(
-                                "Unknown event_type from hook: %s — "
-                                "add it to syn_shared.events or check for a producer/consumer mismatch",
-                                _hook_event_type,
-                            )
-
-                        # Enrich with workflow context
-                        enriched = enrich_event(
-                            hook_event,
-                            execution_id=execution_id,
-                            phase_id=phase.phase_id,
-                        )
-                        logger.debug("Hook event: %s", enriched.get("event_type"))
-
-                        # Store hook events directly via observability writer.
-                        # Merge context + metadata so all rich data (sha, branch, message,
-                        # files_changed, etc.) is stored in the event data column.
-                        if self._observability_writer is not None:
-                            _hook_data = {
-                                **(enriched.get("context") or {}),
-                                **(enriched.get("metadata") or {}),
-                            }
-                            await self._record_observation(
-                                observation_type=enriched.get("event_type", "unknown"),
-                                session_id=session_id,
-                                data=_hook_data,
-                                execution_id=execution_id,
-                                phase_id=phase.phase_id,
-                                workspace_id=workspace_id,
-                            )
-
-                        # ADR-037: Detect subagent lifecycle from Task tool events
-                        hook_type = hook_event.get("type", "")
-                        ctx_data = enriched.get("context", {})
-                        tool_name = ctx_data.get("tool_name", "")
-                        tool_use_id = ctx_data.get("tool_use_id", "")
-
-                        if tool_name == "Task" and tool_use_id:
-                            if hook_type == "tool_use_started":
-                                # Parse agent_name from input_preview JSON
-                                agent_name = "unknown"
-                                input_preview = ctx_data.get("input_preview", "")
-                                if input_preview:
-                                    try:
-                                        input_data = json.loads(input_preview)
-                                        agent_name = str(
-                                            input_data.get(
-                                                "subagent_type",
-                                                input_data.get("description", "unknown"),
-                                            )
-                                        )[:50]
-                                    except (json.JSONDecodeError, TypeError):
-                                        pass
-                                active_subagents[tool_use_id] = (agent_name, datetime.now(UTC), {})
-
-                                if self._observability_writer is not None:
-                                    await self._record_observation(
-                                        observation_type=ObservationType.SUBAGENT_STARTED,
-                                        session_id=session_id,
-                                        data={
-                                            "agent_name": agent_name,
-                                            "subagent_tool_use_id": tool_use_id,
-                                        },
-                                        execution_id=execution_id,
-                                        phase_id=phase.phase_id,
-                                        workspace_id=workspace_id,
-                                    )
-                                    logger.info(
-                                        "Subagent started: %s (id=%s)",
-                                        agent_name,
-                                        tool_use_id,
-                                    )
-
-                            elif hook_type == "tool_use_completed":
-                                if tool_use_id in active_subagents:
-                                    agent_name, started_at, tools_used = active_subagents.pop(
-                                        tool_use_id
-                                    )
-                                    duration_ms = int(
-                                        (datetime.now(UTC) - started_at).total_seconds() * 1000
-                                    )
-                                    success = ctx_data.get("success", True)
-
-                                    if self._observability_writer is not None:
-                                        await self._record_observation(
-                                            observation_type=ObservationType.SUBAGENT_STOPPED,
-                                            session_id=session_id,
-                                            data={
-                                                "agent_name": agent_name,
-                                                "subagent_tool_use_id": tool_use_id,
-                                                "duration_ms": duration_ms,
-                                                "success": success,
-                                                "tools_used": tools_used,
-                                            },
-                                            execution_id=execution_id,
-                                            phase_id=phase.phase_id,
-                                            workspace_id=workspace_id,
-                                        )
-                                        logger.info(
-                                            "Subagent stopped: %s (id=%s, duration=%dms, tools=%s)",
-                                            agent_name,
-                                            tool_use_id,
-                                            duration_ms,
-                                            tools_used,
-                                        )
-                                else:
-                                    # Non-Task tool completed - attribute to active subagent
-                                    _attribute_tool_to_latest_subagent(tool_name, active_subagents)
-
-                    # Skip native CLI event processing if we handled hook events
-                    if _hook_events:
-                        continue
-
-                    # Fall back to Claude CLI native events
-                    try:
-                        cli_event = json.loads(line)
-                        cli_type = cli_event.get("type", "")
-                        logger.debug("CLI event type: %s", cli_type)
-
-                        # Handle result event (session completion)
-                        if cli_type == "result":
-                            # Parse structured task result from agent's final text
-                            result_text = cli_event.get("result", "")
-                            if result_text and "TASK_RESULT:" in result_text:
-                                try:
-                                    marker = "TASK_RESULT:"
-                                    idx = result_text.rfind(marker)
-                                    raw = result_text[idx + len(marker) :].strip()
-                                    # Extract just the JSON object (stop at first newline after })
-                                    brace_end = raw.find("}")
-                                    if brace_end >= 0:
-                                        raw = raw[: brace_end + 1]
-                                    agent_task_result = json.loads(raw)
-                                    logger.info(
-                                        "Agent task result: success=%s comments=%s",
-                                        agent_task_result.get("success"),
-                                        agent_task_result.get("comments", "")[:100],
-                                    )
-                                except (json.JSONDecodeError, ValueError):
-                                    logger.debug("Could not parse TASK_RESULT block")
-
-                            # Extract token usage
-                            usage = cli_event.get("usage", {})
-                            input_tokens = usage.get("input_tokens", 0)
-                            output_tokens = usage.get("output_tokens", 0)
-                            cache_creation = usage.get("cache_creation_input_tokens", 0)
-                            cache_read = usage.get("cache_read_input_tokens", 0)
-
-                            # Only record and accumulate if there's actual usage
-                            if input_tokens > 0 or output_tokens > 0:
-                                total_input_tokens += input_tokens
-                                total_output_tokens += output_tokens
-
-                                if self._observability_writer is not None:
-                                    await self._record_observation(
-                                        observation_type=ObservationType.TOKEN_USAGE,
-                                        session_id=session_id,
-                                        data={
-                                            "input_tokens": input_tokens,
-                                            "output_tokens": output_tokens,
-                                            "cache_creation_tokens": cache_creation,
-                                            "cache_read_tokens": cache_read,
-                                            "model": agent_model,
-                                        },
-                                        execution_id=execution_id,
-                                        phase_id=phase.phase_id,
-                                        workspace_id=workspace_id,
-                                    )
-                                    logger.info(
-                                        "Result token usage: %d in, %d out",
-                                        input_tokens,
-                                        output_tokens,
-                                    )
-
-                        # Extract tool events from assistant messages
-                        # Claude CLI emits tool_use in message.content
-                        if cli_type == "assistant":
-                            message = cli_event.get("message", {})
-                            content = message.get("content", [])
-
-                            # Extract per-turn token usage from assistant messages
-                            # (result event only has cumulative totals at the end)
-                            # Note: Claude CLI streams messages incrementally, and early
-                            # chunks may have empty/zero usage. Only record when we have
-                            # actual token counts.
-                            usage = message.get("usage", {})
-                            if usage:
-                                input_tokens = usage.get("input_tokens", 0)
-                                output_tokens = usage.get("output_tokens", 0)
-                                cache_creation = usage.get("cache_creation_input_tokens", 0)
-                                cache_read = usage.get("cache_read_input_tokens", 0)
-
-                                # Only record if there's actual token usage
-                                # (skip empty streaming chunks)
-                                if input_tokens > 0 or output_tokens > 0:
-                                    total_input_tokens += input_tokens
-                                    total_output_tokens += output_tokens
-
-                                    if self._observability_writer is not None:
-                                        await self._record_observation(
-                                            observation_type=ObservationType.TOKEN_USAGE,
-                                            session_id=session_id,
-                                            data={
-                                                "input_tokens": input_tokens,
-                                                "output_tokens": output_tokens,
-                                                "cache_creation_tokens": cache_creation,
-                                                "cache_read_tokens": cache_read,
-                                                "model": agent_model,
-                                            },
-                                            execution_id=execution_id,
-                                            phase_id=phase.phase_id,
-                                            workspace_id=workspace_id,
-                                        )
-                                        logger.info(
-                                            "Per-turn token usage: %d in, %d out (cache: %d read, %d create)",
-                                            input_tokens,
-                                            output_tokens,
-                                            cache_read,
-                                            cache_creation,
-                                        )
-                            for item in content:
-                                if isinstance(item, dict) and item.get("type") == "tool_use":
-                                    tool_name = item.get("name", "unknown")
-                                    tool_use_id = item.get("id", "unknown")
-                                    tool_input = item.get("input", {})
-                                    if isinstance(tool_input, str):
-                                        try:
-                                            tool_input = json.loads(tool_input)
-                                        except (json.JSONDecodeError, ValueError):
-                                            tool_input = {}
-
-                                    # Cache tool_name for enriching tool_result events
-                                    tool_names_cache[tool_use_id] = tool_name
-
-                                    if self._observability_writer is not None:
-                                        await self._record_observation(
-                                            observation_type=ObservationType.TOOL_EXECUTION_STARTED,
-                                            session_id=session_id,
-                                            data={
-                                                "tool_name": tool_name,
-                                                "tool_use_id": tool_use_id,
-                                                "input_preview": json.dumps(tool_input)[:500],
-                                            },
-                                            execution_id=execution_id,
-                                            phase_id=phase.phase_id,
-                                            workspace_id=workspace_id,
-                                        )
-                                        logger.debug("Tool started: %s", tool_name)
-
-                                    # ADR-037: Detect Task tool as subagent start (raw CLI format)
-                                    if tool_name == "Task" and tool_use_id:
-                                        agent_name = str(
-                                            tool_input.get(
-                                                "subagent_type",
-                                                tool_input.get("description", "unknown"),
-                                            )
-                                        )[:50]
-                                        active_subagents[tool_use_id] = (
-                                            agent_name,
-                                            datetime.now(UTC),
-                                            {},  # tools_used dict
-                                        )
-
-                                        if self._observability_writer is not None:
-                                            await self._record_observation(
-                                                observation_type=ObservationType.SUBAGENT_STARTED,
-                                                session_id=session_id,
-                                                data={
-                                                    "agent_name": agent_name,
-                                                    "subagent_tool_use_id": tool_use_id,
-                                                },
-                                                execution_id=execution_id,
-                                                phase_id=phase.phase_id,
-                                                workspace_id=workspace_id,
-                                            )
-                                            logger.info(
-                                                "Subagent started (CLI): %s (id=%s)",
-                                                agent_name,
-                                                tool_use_id,
-                                            )
-
-                        # Handle tool results from user messages
-                        if cli_type == "user":
-                            message = cli_event.get("message", {})
-                            content = message.get("content", [])
-                            for item in content:
-                                if isinstance(item, dict) and item.get("type") == "tool_result":
-                                    tool_use_id = item.get("tool_use_id", "unknown")
-                                    is_error = item.get("is_error", False)
-                                    # Extract tool output content
-                                    tool_content = item.get("content", "")
-                                    if isinstance(tool_content, list):
-                                        # Content can be a list of content blocks
-                                        tool_content = " ".join(
-                                            str(c.get("text", c) if isinstance(c, dict) else c)
-                                            for c in tool_content
-                                        )
-                                    output_preview = (
-                                        str(tool_content)[:500] if tool_content else None
-                                    )
-                                    # Look up tool_name from cache
-                                    tool_name = tool_names_cache.get(tool_use_id, "unknown")
-
-                                    # ADR-043: Scan tool output for embedded git hook JSONL.
-                                    #
-                                    # Git hooks (post-commit, pre-push, etc.) emit JSONL to
-                                    # stderr. Because the Bash tool runs inside Claude Code,
-                                    # Claude Code captures the subprocess's stderr along with
-                                    # stdout and packages everything as the tool result content.
-                                    # The JSONL does NOT arrive as a standalone stream line;
-                                    # it's embedded in the tool_result here.
-                                    #
-                                    # We scan every line of tool output for parse_jsonl_line()
-                                    # hits and process them identically to standalone hook events.
-                                    if tool_content and self._observability_writer is not None:
-                                        for _tl in str(tool_content).splitlines():
-                                            _tl = _tl.strip()
-                                            if not _tl:
-                                                continue
-                                            _embedded = parse_jsonl_line(_tl)
-                                            if not _embedded:
-                                                continue
-                                            _et = _embedded.get("event_type")
-                                            if _et not in VALID_EVENT_TYPES:
-                                                logger.debug(
-                                                    "Unknown event_type in tool output: %s", _et
-                                                )
-                                                continue
-                                            _enriched = enrich_event(
-                                                _embedded,
-                                                execution_id=execution_id,
-                                                phase_id=phase.phase_id,
-                                            )
-                                            _hd = {
-                                                **(_enriched.get("context") or {}),
-                                                **(_enriched.get("metadata") or {}),
-                                            }
-                                            await self._record_observation(
-                                                observation_type=_et,
-                                                session_id=session_id,
-                                                data=_hd,
-                                                execution_id=execution_id,
-                                                phase_id=phase.phase_id,
-                                                workspace_id=workspace_id,
-                                            )
-                                            logger.info(
-                                                "Git hook event from tool output: %s (tool=%s)",
-                                                _et,
-                                                tool_name,
-                                            )
-
-                                    if self._observability_writer is not None:
-                                        await self._record_observation(
-                                            observation_type=ObservationType.TOOL_EXECUTION_COMPLETED,
-                                            session_id=session_id,
-                                            data={
-                                                "tool_name": tool_name,  # Now included!
-                                                "tool_use_id": tool_use_id,
-                                                "success": not is_error,
-                                                "output_preview": output_preview,  # Show why it failed!
-                                            },
-                                            execution_id=execution_id,
-                                            phase_id=phase.phase_id,
-                                            workspace_id=workspace_id,
-                                        )
-                                        logger.debug(
-                                            "Tool completed: %s (%s) success=%s",
-                                            tool_use_id,
-                                            tool_name,
-                                            not is_error,
-                                        )
-
-                                    # ADR-037: Detect Task tool completion as subagent stop (raw CLI format)
-                                    if tool_name == "Task" and tool_use_id in active_subagents:
-                                        agent_name, started_at, tools_used = active_subagents.pop(
-                                            tool_use_id
-                                        )
-                                        duration_ms = int(
-                                            (datetime.now(UTC) - started_at).total_seconds() * 1000
-                                        )
-
-                                        if self._observability_writer is not None:
-                                            await self._record_observation(
-                                                observation_type=ObservationType.SUBAGENT_STOPPED,
-                                                session_id=session_id,
-                                                data={
-                                                    "agent_name": agent_name,
-                                                    "subagent_tool_use_id": tool_use_id,
-                                                    "duration_ms": duration_ms,
-                                                    "success": not is_error,
-                                                    "tools_used": tools_used,
-                                                },
-                                                execution_id=execution_id,
-                                                phase_id=phase.phase_id,
-                                                workspace_id=workspace_id,
-                                            )
-                                            logger.info(
-                                                "Subagent stopped (CLI): %s (id=%s, duration=%dms, tools=%s)",
-                                                agent_name,
-                                                tool_use_id,
-                                                duration_ms,
-                                                tools_used,
-                                            )
-                                    elif tool_name != "Task":
-                                        # Attribute non-Task tool to the most recently started subagent
-                                        _attribute_tool_to_latest_subagent(
-                                            tool_name, active_subagents
-                                        )
-
-                        if cli_type in ("system",):
-                            logger.debug("CLI message: %s", cli_type)
-
-                    except json.JSONDecodeError:
-                        # Not all lines are JSON (could be plain text output)
-                        logger.debug("Non-JSON line: %s", line[:50])
-
-                logger.info(
-                    "Agent runner streaming complete: %d lines, %d input tokens, %d output tokens",
-                    line_count,
-                    total_input_tokens,
-                    total_output_tokens,
+                # Process event stream
+                processor = EventStreamProcessor(
+                    tokens=tokens,
+                    subagents=subagents,
+                    observability=self._observability_writer,
+                    controller=self._controller,
+                    execution_id=ctx.execution_id,
+                    phase_id=phase.phase_id,
+                    session_id=session_id,
+                    workspace_id=getattr(workspace, "id", None),
+                    agent_model=phase.agent_config.model,
                 )
 
-                # If CANCEL signal was received, collect partial state and raise interrupt
-                if _interrupt_requested:
+                stream_result = await processor.process_stream(
+                    workspace.stream(
+                        claude_cmd,
+                        timeout_seconds=phase.timeout_seconds or 300,
+                        environment=agent_env,
+                    ),
+                    workspace,
+                )
+                _conversation_lines = stream_result.conversation_lines
+
+                # Handle interrupt
+                if stream_result.interrupt_requested:
                     try:
                         git_sha = await self._get_container_git_sha(workspace)
                     except Exception as git_err:
@@ -1844,73 +1095,41 @@ class WorkflowExecutionEngine:
                             git_err,
                         )
                         git_sha = None
-                    partial_artifact_ids: list[str] = []
-                    try:
-                        partial_artifacts = await workspace.collect_files(
-                            patterns=["artifacts/output/**/*"]
-                        )
-                        for artifact_path, artifact_content in partial_artifacts:
-                            artifact_id = str(uuid4())
-                            content_str = artifact_content.decode("utf-8", errors="replace")
-                            await self._create_artifact(
-                                artifact_id=artifact_id,
-                                workflow_id=ctx.workflow_id,
-                                phase_id=phase.phase_id,
-                                execution_id=ctx.execution_id,
-                                session_id=session_id,
-                                artifact_type=phase.output_artifact_type,
-                                content=content_str,
-                                title=f"{phase.name} (partial): {artifact_path}",
-                            )
-                            partial_artifact_ids.append(artifact_id)
-                            ctx.artifact_ids.append(artifact_id)
-                    except Exception as artifact_err:
-                        logger.warning(
-                            "Failed to collect partial artifacts for %s: %s",
-                            session_id,
-                            artifact_err,
-                        )
 
-                    # Store partial conversation log
-                    if self._conversation_storage is not None and conversation_lines:
-                        try:
-                            from syn_adapters.conversations import SessionContext
+                    partial_artifact_ids = await artifacts.collect_partial(
+                        workspace=workspace,
+                        workflow_id=ctx.workflow_id,
+                        phase_id=phase.phase_id,
+                        execution_id=ctx.execution_id,
+                        session_id=session_id,
+                        phase_name=phase.name,
+                        output_artifact_type=phase.output_artifact_type,
+                    )
+                    ctx.artifact_ids.extend(partial_artifact_ids)
 
-                            conv_context = SessionContext(
-                                execution_id=ctx.execution_id,
-                                phase_id=phase.phase_id,
-                                workflow_id=ctx.workflow_id,
-                                model=phase.agent_config.model,
-                                event_count=len(conversation_lines),
-                                tool_counts={},
-                                total_input_tokens=total_input_tokens,
-                                total_output_tokens=total_output_tokens,
-                                started_at=phase_started_at,
-                                completed_at=datetime.now(UTC),
-                                success=False,
-                            )
-                            await self._conversation_storage.store_session(
-                                session_id=session_id,
-                                lines=conversation_lines,
-                                context=conv_context,
-                            )
-                        except Exception as conv_err:
-                            logger.warning(
-                                "Failed to store partial conversation log for %s: %s",
-                                session_id,
-                                conv_err,
-                            )
+                    await recorder.store(
+                        session_id=session_id,
+                        lines=stream_result.conversation_lines,
+                        execution_id=ctx.execution_id,
+                        phase_id=phase.phase_id,
+                        workflow_id=ctx.workflow_id,
+                        model=phase.agent_config.model,
+                        input_tokens=tokens.input_tokens,
+                        output_tokens=tokens.output_tokens,
+                        started_at=phase_started_at,
+                        success=False,
+                    )
 
                     raise WorkflowInterruptedError(
                         phase_id=phase.phase_id,
-                        reason=_interrupt_reason,
+                        reason=stream_result.interrupt_reason,
                         git_sha=git_sha,
                         partial_artifact_ids=partial_artifact_ids,
-                        partial_input_tokens=total_input_tokens,
-                        partial_output_tokens=total_output_tokens,
+                        partial_input_tokens=tokens.input_tokens,
+                        partial_output_tokens=tokens.output_tokens,
                     )
 
-                # Check process exit code — non-zero means agent failed
+                # Check process exit code
                 exit_code = workspace.last_stream_exit_code
                 if exit_code is not None and exit_code != 0:
                     raise WorkflowExecutionError(
@@ -1922,95 +1141,58 @@ class WorkflowExecutionEngine:
                         phase_id=phase.phase_id,
                     )
 
-                # Check structured task result — agent explicitly reported failure
-                if agent_task_result is not None and not agent_task_result.get("success", True):
-                    comments = agent_task_result.get("comments", "Agent reported task failure")
+                # Check structured task result
+                task_result = stream_result.agent_task_result
+                if task_result is not None and not task_result.get("success", True):
+                    comments = task_result.get("comments", "Agent reported task failure")
                     raise WorkflowExecutionError(
                         message=comments,
                         workflow_id=ctx.workflow_id,
                         phase_id=phase.phase_id,
                     )
 
-                # ADR-035: Store conversation log to MinIO/S3
-                if self._conversation_storage is not None and conversation_lines:
-                    try:
-                        from syn_adapters.conversations import SessionContext
-
-                        conv_context = SessionContext(
-                            execution_id=ctx.execution_id,
-                            phase_id=phase.phase_id,
-                            workflow_id=ctx.workflow_id,
-                            model=phase.agent_config.model,
-                            event_count=len(conversation_lines),
-                            tool_counts={},  # Tool counts tracked separately via observability events
-                            total_input_tokens=total_input_tokens,
-                            total_output_tokens=total_output_tokens,
-                            started_at=phase_started_at,
-                            completed_at=datetime.now(UTC),
-                            success=True,
-                        )
-                        await self._conversation_storage.store_session(
-                            session_id=session_id,
-                            lines=conversation_lines,
-                            context=conv_context,
-                        )
-                        logger.info(
-                            "Conversation log stored: %s (%d lines)",
-                            session_id,
-                            len(conversation_lines),
-                        )
-                    except Exception as conv_err:
-                        # Don't fail the phase if conversation storage fails
-                        logger.warning(
-                            "Failed to store conversation log for %s: %s",
-                            session_id,
-                            conv_err,
-                        )
-
-                # Collect output artifacts
-                # ADR-036: Collect from artifacts/output/ (not artifacts/)
-                artifacts = await workspace.collect_files(
-                    patterns=["artifacts/output/**/*"],
+                # Store conversation log (ADR-035)
+                await recorder.store(
+                    session_id=session_id,
+                    lines=stream_result.conversation_lines,
+                    execution_id=ctx.execution_id,
+                    phase_id=phase.phase_id,
+                    workflow_id=ctx.workflow_id,
+                    model=phase.agent_config.model,
+                    input_tokens=tokens.input_tokens,
+                    output_tokens=tokens.output_tokens,
+                    started_at=phase_started_at,
+                    success=True,
                 )
 
-                # Create artifact records for each output
-                artifact_ids: list[str] = []
-                first_artifact_content: str | None = None
-                for artifact_path, artifact_content in artifacts:
-                    artifact_id = str(uuid4())
-                    content_str = artifact_content.decode("utf-8", errors="replace")
-                    await self._create_artifact(
-                        artifact_id=artifact_id,
-                        workflow_id=ctx.workflow_id,
-                        phase_id=phase.phase_id,
-                        execution_id=ctx.execution_id,
-                        session_id=session_id,
-                        artifact_type=phase.output_artifact_type,
-                        content=content_str,
-                        title=f"{phase.name}: {artifact_path}",
-                    )
-                    artifact_ids.append(artifact_id)
-                    ctx.artifact_ids.append(artifact_id)
-                    # Store first artifact for phase-to-phase injection
-                    if first_artifact_content is None:
-                        first_artifact_content = content_str
+                # Collect output artifacts (ADR-036)
+                collected = await artifacts.collect_from_workspace(
+                    workspace=workspace,
+                    workflow_id=ctx.workflow_id,
+                    phase_id=phase.phase_id,
+                    execution_id=ctx.execution_id,
+                    session_id=session_id,
+                    phase_name=phase.name,
+                    output_artifact_type=phase.output_artifact_type,
+                )
+                ctx.artifact_ids.extend(collected.artifact_ids)
 
-                # Store in in-memory cache for immediate use by next phase
-                # This avoids eventual consistency issues with projection queries
-                if first_artifact_content:
-                    ctx.phase_outputs[phase.phase_id] = first_artifact_content
+                # Cache first artifact for phase-to-phase injection
+                if collected.first_content:
+                    ctx.phase_outputs[phase.phase_id] = collected.first_content
                     logger.info(
                         "Phase output cached for injection: %s (%d chars)",
                         phase.phase_id,
-                        len(first_artifact_content),
+                        len(collected.first_content),
                     )
+
+                # Capture values needed after workspace exit
+                _line_count = stream_result.line_count
+                _collected_artifact_ids = collected.artifact_ids
 
             # Workspace destroyed here (context manager exit)
 
-            # Validate agent actually produced output
-            # If line_count == 0 AND no tokens were consumed, the agent failed silently
-            # (e.g., auth failure, crash, missing config)
-            if line_count == 0 and total_input_tokens == 0 and total_output_tokens == 0:
+            if _line_count == 0 and tokens.total_tokens == 0:
                 raise WorkflowExecutionError(
                     message=(
                         "Agent produced no output. Possible causes: "
@@ -2020,58 +1202,50 @@ class WorkflowExecutionEngine:
                     phase_id=phase.phase_id,
                 )
 
-            # Record success
-            phase_completed_at = datetime.now(UTC)
-            duration = (phase_completed_at - phase_started_at).total_seconds()
-
-            result = PhaseResult(
+            # Build success result
+            result = PhaseResultBuilder.success(
                 phase_id=phase.phase_id,
-                status=PhaseStatus.COMPLETED,
                 started_at=phase_started_at,
-                completed_at=phase_completed_at,
-                artifact_id=artifact_ids[0] if artifact_ids else None,
                 session_id=session_id,
-                input_tokens=total_input_tokens,
-                output_tokens=total_output_tokens,
-                total_tokens=total_input_tokens + total_output_tokens,
-                cost_usd=self._estimate_cost(total_input_tokens, total_output_tokens),
+                artifact_ids=_collected_artifact_ids,
+                tokens=tokens,
             )
-            # NOTE: Do NOT append here - caller is responsible for appending
-            # to ctx.phase_results, ctx.completed_phase_ids, and ctx.artifact_ids.
-            # This follows the contract: helper methods RETURN results, callers append.
 
             # Emit phase completed
+            duration = (
+                (result.completed_at - phase_started_at).total_seconds()
+                if result.completed_at
+                else 0.0
+            )
             complete_cmd = CompletePhaseCommand(
                 execution_id=ctx.execution_id,
                 workflow_id=ctx.workflow_id,
                 phase_id=phase.phase_id,
                 session_id=session_id,
-                artifact_id=artifact_ids[0] if artifact_ids else None,
-                input_tokens=total_input_tokens,
-                output_tokens=total_output_tokens,
-                total_tokens=total_input_tokens + total_output_tokens,
+                artifact_id=_collected_artifact_ids[0] if _collected_artifact_ids else None,
+                input_tokens=tokens.input_tokens,
+                output_tokens=tokens.output_tokens,
+                total_tokens=tokens.total_tokens,
                 cost_usd=result.cost_usd,
                 duration_seconds=duration,
             )
             aggregate._handle_command(complete_cmd)
 
             # Record token usage on session before completing
-            # This ensures SessionCompleted event contains accumulated tokens
             if session is not None and self._sessions is not None:
-                if total_input_tokens > 0 or total_output_tokens > 0:
+                if tokens.total_tokens > 0:
                     record_op_cmd = RecordOperationCommand(
                         aggregate_id=session_id,
                         operation_type=OperationType.MESSAGE_RESPONSE,
-                        input_tokens=total_input_tokens,
-                        output_tokens=total_output_tokens,
-                        total_tokens=total_input_tokens + total_output_tokens,
+                        input_tokens=tokens.input_tokens,
+                        output_tokens=tokens.output_tokens,
+                        total_tokens=tokens.total_tokens,
                         success=True,
                         duration_seconds=duration,
                         metadata={"phase_id": phase.phase_id, "source": "container_execution"},
                     )
                     session._handle_command(record_op_cmd)
 
-                # Complete session aggregate (success)
                 complete_session_cmd = CompleteSessionCommand(
                     aggregate_id=session_id,
                     success=True,
@@ -2081,13 +1255,13 @@ class WorkflowExecutionEngine:
                 logger.debug(
                     "Session completed: %s (success, tokens: %d)",
                     session_id,
-                    total_input_tokens + total_output_tokens,
+                    tokens.total_tokens,
                 )
 
             logger.info(
                 "Phase completed (container mode): %s (tokens: %d)",
                 phase.phase_id,
-                total_input_tokens + total_output_tokens,
+                tokens.total_tokens,
             )
 
             return result
@@ -2113,58 +1287,31 @@ class WorkflowExecutionEngine:
                     logger.warning(
                         "Failed to complete session %s during cancel: %s", session_id, _sess_err
                     )
-            # Let interrupt propagate to execute() where it's handled correctly
             raise
 
         except Exception as e:
-            # Record failure
-            phase_completed_at = datetime.now(UTC)
-            result = PhaseResult(
+            # Build failure result
+            result = PhaseResultBuilder.failure(
                 phase_id=phase.phase_id,
-                status=PhaseStatus.FAILED,
                 started_at=phase_started_at,
-                completed_at=phase_completed_at,
                 session_id=session_id,
                 error_message=str(e),
             )
             ctx.phase_results.append(result)
 
-            # ADR-035: Store conversation log even on failure
-            # This ensures we capture partial conversation for debugging and analysis
-            if self._conversation_storage is not None and conversation_lines:
-                try:
-                    from syn_adapters.conversations import SessionContext
-
-                    conv_context = SessionContext(
-                        execution_id=ctx.execution_id,
-                        phase_id=phase.phase_id,
-                        workflow_id=ctx.workflow_id,
-                        model=phase.agent_config.model,
-                        event_count=len(conversation_lines),
-                        tool_counts={},
-                        total_input_tokens=total_input_tokens,
-                        total_output_tokens=total_output_tokens,
-                        started_at=phase_started_at,
-                        completed_at=phase_completed_at,
-                        success=False,  # Mark as failed
-                    )
-                    await self._conversation_storage.store_session(
-                        session_id=session_id,
-                        lines=conversation_lines,
-                        context=conv_context,
-                    )
-                    logger.info(
-                        "Conversation log stored (failed phase): %s (%d lines)",
-                        session_id,
-                        len(conversation_lines),
-                    )
-                except Exception as conv_err:
-                    # Don't let conversation storage failure hide the original error
-                    logger.warning(
-                        "Failed to store conversation log for failed phase %s: %s",
-                        session_id,
-                        conv_err,
-                    )
+            # Store conversation log even on failure (ADR-035)
+            await recorder.store(
+                session_id=session_id,
+                lines=_conversation_lines,
+                execution_id=ctx.execution_id,
+                phase_id=phase.phase_id,
+                workflow_id=ctx.workflow_id,
+                model=phase.agent_config.model,
+                input_tokens=tokens.input_tokens,
+                output_tokens=tokens.output_tokens,
+                started_at=phase_started_at,
+                success=False,
+            )
 
             # Complete session aggregate (failure)
             if session is not None and self._sessions is not None:
@@ -2178,7 +1325,6 @@ class WorkflowExecutionEngine:
                     await self._sessions.save(session)
                     logger.debug("Session completed: %s (failed: %s)", session_id, str(e))
                 except Exception as session_err:
-                    # Don't let session persistence failure hide the original error
                     logger.warning(
                         "Failed to complete session %s: %s",
                         session_id,
@@ -2198,13 +1344,40 @@ class WorkflowExecutionEngine:
                 cause=e,
             ) from e
 
-    def _estimate_cost(self, input_tokens: int, output_tokens: int) -> Decimal:
-        """Estimate cost based on token usage.
+    def _build_claude_command(self, phase: ExecutablePhase, prompt: str) -> list[str]:
+        """Build the Claude CLI command with plugin discovery."""
+        claude_args = [
+            "claude",
+            "--print",
+            "--verbose",
+            "--append-system-prompt",
+            SYN_WORKSPACE_PROMPT,
+            prompt,
+            "--output-format",
+            "stream-json",
+            "--dangerously-skip-permissions",
+        ]
 
-        Uses Claude Sonnet pricing as default.
-        """
-        # Claude Sonnet 4 pricing (per million tokens)
-        input_price = Decimal("3.00") / Decimal("1000000")
-        output_price = Decimal("15.00") / Decimal("1000000")
+        if phase.agent_config.allowed_tools:
+            claude_args.extend(
+                [
+                    "--allowedTools",
+                    ",".join(phase.agent_config.allowed_tools),
+                ]
+            )
 
-        return Decimal(input_tokens) * input_price + Decimal(output_tokens) * output_price
+        # Wrap in sh -c for dynamic plugin discovery
+        _quoted_args = " ".join(shlex.quote(a) for a in claude_args)
+        _plugin_scan = (
+            'PLUGIN_FLAGS=""; '
+            'PLUGINS_DIR="${AGENTIC_PLUGINS_DIR:-/opt/agentic/plugins}"; '
+            'if [ -d "$PLUGINS_DIR" ]; then '
+            '  for d in "$PLUGINS_DIR"/*/; do '
+            '    if [ -f "${d}.claude-plugin/plugin.json" ]; then '
+            '      PLUGIN_FLAGS="$PLUGIN_FLAGS --plugin-dir ${d%/}"; '
+            "    fi; "
+            "  done; "
+            "fi; "
+            f"exec {_quoted_args} $PLUGIN_FLAGS"
+        )
+        return ["sh", "-c", _plugin_scan]

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_artifact_collector.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_artifact_collector.py
@@ -1,0 +1,188 @@
+"""Tests for ArtifactCollector."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from syn_domain.contexts.artifacts._shared.value_objects import ArtifactType
+from syn_domain.contexts.orchestration.slices.execute_workflow.ArtifactCollector import (
+    ArtifactCollector,
+    map_artifact_type,
+)
+
+
+class TestMapArtifactType:
+    def test_known_types(self) -> None:
+        assert map_artifact_type("text") == ArtifactType.TEXT
+        assert map_artifact_type("markdown") == ArtifactType.MARKDOWN
+        assert map_artifact_type("code") == ArtifactType.CODE
+        assert map_artifact_type("json") == ArtifactType.JSON
+
+    def test_case_insensitive(self) -> None:
+        assert map_artifact_type("TEXT") == ArtifactType.TEXT
+        assert map_artifact_type("Markdown") == ArtifactType.MARKDOWN
+
+    def test_unknown_type(self) -> None:
+        assert map_artifact_type("unknown_type") == ArtifactType.OTHER
+
+
+@dataclass
+class MockWorkspace:
+    injected_files: list[tuple[str, bytes]] = field(default_factory=list)
+    collected_files: list[tuple[str, bytes]] = field(default_factory=list)
+
+    async def inject_files(self, files: list[tuple[str, bytes]]) -> None:
+        self.injected_files.extend(files)
+
+    async def collect_files(self, patterns: list[str]) -> list[tuple[str, bytes]]:
+        return self.collected_files
+
+
+@dataclass
+class MockArtifactRepo:
+    saved: list[Any] = field(default_factory=list)
+
+    async def save(self, aggregate: Any) -> None:
+        self.saved.append(aggregate)
+
+    async def get_by_id(self, artifact_id: str) -> None:
+        return None
+
+
+@dataclass
+class MockExecutionContext:
+    workflow_id: str = "w1"
+    execution_id: str = "e1"
+    completed_phase_ids: list[str] = field(default_factory=list)
+    phase_outputs: dict[str, str] = field(default_factory=dict)
+
+
+class TestArtifactCollector:
+    @pytest.mark.asyncio
+    async def test_inject_no_previous_phases(self) -> None:
+        collector = ArtifactCollector(MockArtifactRepo(), None, None)
+        workspace = MockWorkspace()
+        ctx = MockExecutionContext()
+        await collector.inject_from_previous_phases(workspace, ctx)  # type: ignore[arg-type]
+        assert workspace.injected_files == []
+
+    @pytest.mark.asyncio
+    async def test_inject_from_cache(self) -> None:
+        collector = ArtifactCollector(MockArtifactRepo(), None, None)
+        workspace = MockWorkspace()
+        ctx = MockExecutionContext(
+            completed_phase_ids=["p1"],
+            phase_outputs={"p1": "content from p1"},
+        )
+        await collector.inject_from_previous_phases(workspace, ctx)  # type: ignore[arg-type]
+        assert len(workspace.injected_files) == 1
+        path, content = workspace.injected_files[0]
+        assert path == "artifacts/input/p1.md"
+        assert content == b"content from p1"
+
+    @pytest.mark.asyncio
+    async def test_collect_from_workspace(self) -> None:
+        repo = MockArtifactRepo()
+        collector = ArtifactCollector(repo, None, None)
+        workspace = MockWorkspace(
+            collected_files=[
+                ("artifacts/output/result.md", b"# Result"),
+                ("artifacts/output/data.json", b'{"key": "value"}'),
+            ]
+        )
+        result = await collector.collect_from_workspace(
+            workspace=workspace,
+            workflow_id="w1",
+            phase_id="p1",
+            execution_id="e1",
+            session_id="s1",
+            phase_name="Test Phase",
+            output_artifact_type="markdown",
+        )
+        assert len(result.artifact_ids) == 2
+        assert result.first_content == "# Result"
+        assert len(repo.saved) == 2
+
+    @pytest.mark.asyncio
+    async def test_collect_empty_workspace(self) -> None:
+        collector = ArtifactCollector(MockArtifactRepo(), None, None)
+        workspace = MockWorkspace()
+        result = await collector.collect_from_workspace(
+            workspace=workspace,
+            workflow_id="w1",
+            phase_id="p1",
+            execution_id="e1",
+            session_id="s1",
+            phase_name="Test Phase",
+            output_artifact_type="text",
+        )
+        assert result.artifact_ids == []
+        assert result.first_content is None
+
+    @pytest.mark.asyncio
+    async def test_inject_from_query_service(self) -> None:
+        """Test injection path that falls back to query service for missing phases."""
+        queried: list[tuple[str, list[str]]] = []
+
+        class MockQueryService:
+            async def get_for_phase_injection(
+                self, execution_id: str, completed_phase_ids: list[str]
+            ) -> dict[str, str]:
+                queried.append((execution_id, completed_phase_ids))
+                return {"p2": "content from projection"}
+
+        collector = ArtifactCollector(MockArtifactRepo(), None, MockQueryService())  # type: ignore[arg-type]
+        workspace = MockWorkspace()
+        ctx = MockExecutionContext(
+            completed_phase_ids=["p1", "p2"],
+            phase_outputs={"p1": "cached content"},  # p2 missing from cache
+        )
+        await collector.inject_from_previous_phases(workspace, ctx)  # type: ignore[arg-type]
+        assert len(workspace.injected_files) == 2
+        # p1 from cache, p2 from query service
+        paths = [f[0] for f in workspace.injected_files]
+        assert "artifacts/input/p1.md" in paths
+        assert "artifacts/input/p2.md" in paths
+        assert len(queried) == 1
+        assert queried[0] == ("e1", ["p2"])
+
+    @pytest.mark.asyncio
+    async def test_collect_partial_success(self) -> None:
+        """Test successful partial artifact collection."""
+        repo = MockArtifactRepo()
+        collector = ArtifactCollector(repo, None, None)
+        workspace = MockWorkspace(
+            collected_files=[("artifacts/output/partial.md", b"partial content")]
+        )
+        result = await collector.collect_partial(
+            workspace=workspace,
+            workflow_id="w1",
+            phase_id="p1",
+            execution_id="e1",
+            session_id="s1",
+            phase_name="Phase",
+            output_artifact_type="text",
+        )
+        assert len(result) == 1
+        assert len(repo.saved) == 1
+
+    @pytest.mark.asyncio
+    async def test_collect_partial_never_raises(self) -> None:
+        class BrokenWorkspace:
+            async def collect_files(self, patterns: list[str]) -> list[tuple[str, bytes]]:
+                raise RuntimeError("disk full")
+
+        collector = ArtifactCollector(MockArtifactRepo(), None, None)
+        result = await collector.collect_partial(
+            workspace=BrokenWorkspace(),
+            workflow_id="w1",
+            phase_id="p1",
+            execution_id="e1",
+            session_id="s1",
+            phase_name="Phase",
+            output_artifact_type="text",
+        )
+        assert result == []

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_conversation_recorder.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_conversation_recorder.py
@@ -1,0 +1,96 @@
+"""Tests for ConversationRecorder."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from syn_domain.contexts.orchestration.slices.execute_workflow.ConversationRecorder import (
+    ConversationRecorder,
+)
+
+
+class TestConversationRecorder:
+    @pytest.mark.asyncio
+    async def test_noop_when_no_storage(self) -> None:
+        recorder = ConversationRecorder(None)
+        # Should not raise
+        await recorder.store(
+            session_id="s1",
+            lines=["line1"],
+            execution_id="e1",
+            phase_id="p1",
+            workflow_id="w1",
+            model="claude",
+            input_tokens=100,
+            output_tokens=200,
+            started_at=datetime.now(UTC),
+            success=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_lines(self) -> None:
+        recorder = ConversationRecorder(None)
+        await recorder.store(
+            session_id="s1",
+            lines=[],
+            execution_id="e1",
+            phase_id="p1",
+            workflow_id="w1",
+            model="claude",
+            input_tokens=0,
+            output_tokens=0,
+            started_at=datetime.now(UTC),
+            success=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_stores_with_valid_storage(self) -> None:
+        stored: list[tuple[str, list[str]]] = []
+
+        class FakeStorage:
+            async def store_session(
+                self, session_id: str, lines: list[str], context: object
+            ) -> str:
+                stored.append((session_id, lines))
+                return "key"
+
+        recorder = ConversationRecorder(FakeStorage())  # type: ignore[arg-type]
+        await recorder.store(
+            session_id="s1",
+            lines=["line1", "line2"],
+            execution_id="e1",
+            phase_id="p1",
+            workflow_id="w1",
+            model="claude",
+            input_tokens=100,
+            output_tokens=200,
+            started_at=datetime.now(UTC),
+            success=True,
+        )
+        assert len(stored) == 1
+        assert stored[0] == ("s1", ["line1", "line2"])
+
+    @pytest.mark.asyncio
+    async def test_never_raises_on_storage_error(self) -> None:
+        class BrokenStorage:
+            async def store_session(
+                self, session_id: str, lines: list[str], context: object
+            ) -> str:
+                raise RuntimeError("storage down")
+
+        recorder = ConversationRecorder(BrokenStorage())  # type: ignore[arg-type]
+        # Should not raise
+        await recorder.store(
+            session_id="s1",
+            lines=["line1"],
+            execution_id="e1",
+            phase_id="p1",
+            workflow_id="w1",
+            model="claude",
+            input_tokens=0,
+            output_tokens=0,
+            started_at=datetime.now(UTC),
+            success=False,
+        )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_event_stream_processor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_event_stream_processor.py
@@ -1,0 +1,287 @@
+"""Tests for EventStreamProcessor."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+import pytest
+
+from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProcessor import (
+    EventStreamProcessor,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.SubagentTracker import (
+    SubagentTracker,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+    TokenAccumulator,
+)
+
+
+async def _lines_to_stream(*lines: str) -> AsyncIterator[str]:
+    for line in lines:
+        yield line
+
+
+@dataclass
+class MockObservability:
+    recordings: list[tuple[str, str, dict[str, Any]]] = field(default_factory=list)
+
+    async def record(
+        self,
+        observation_type: Any,
+        session_id: str,
+        data: dict[str, Any],
+        execution_id: str | None = None,
+        phase_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> None:
+        obs_str = (
+            observation_type.value if hasattr(observation_type, "value") else str(observation_type)
+        )
+        self.recordings.append((obs_str, session_id, data))
+
+
+@dataclass
+class MockWorkspace:
+    interrupted: bool = False
+
+    async def interrupt(self) -> bool:
+        self.interrupted = True
+        return True
+
+
+def _make_processor(
+    tokens: TokenAccumulator | None = None,
+    subagents: SubagentTracker | None = None,
+    observability: MockObservability | None = None,
+) -> EventStreamProcessor:
+    return EventStreamProcessor(
+        tokens=tokens or TokenAccumulator(),
+        subagents=subagents or SubagentTracker(),
+        observability=observability,
+        controller=None,
+        execution_id="exec-1",
+        phase_id="phase-1",
+        session_id="session-1",
+        workspace_id="ws-1",
+        agent_model="claude-sonnet",
+    )
+
+
+class TestEventStreamProcessor:
+    @pytest.mark.asyncio
+    async def test_empty_stream(self) -> None:
+        proc = _make_processor()
+        result = await proc.process_stream(_lines_to_stream(), MockWorkspace())
+        assert result.line_count == 0
+        assert not result.interrupt_requested
+        assert result.agent_task_result is None
+        assert result.conversation_lines == []
+
+    @pytest.mark.asyncio
+    async def test_result_event_accumulates_tokens(self) -> None:
+        tokens = TokenAccumulator()
+        proc = _make_processor(tokens=tokens)
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "result": "done",
+                "usage": {"input_tokens": 500, "output_tokens": 100},
+            }
+        )
+        result = await proc.process_stream(_lines_to_stream(result_line), MockWorkspace())
+        assert tokens.input_tokens == 500
+        assert tokens.output_tokens == 100
+        assert result.line_count == 1
+
+    @pytest.mark.asyncio
+    async def test_assistant_event_tokens(self) -> None:
+        tokens = TokenAccumulator()
+        obs = MockObservability()
+        proc = _make_processor(tokens=tokens, observability=obs)
+        assistant_line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [],
+                    "usage": {"input_tokens": 200, "output_tokens": 50},
+                },
+            }
+        )
+        await proc.process_stream(_lines_to_stream(assistant_line), MockWorkspace())
+        assert tokens.input_tokens == 200
+        assert tokens.output_tokens == 50
+        # Should have recorded token usage observation
+        token_obs = [r for r in obs.recordings if r[0] == "token_usage"]
+        assert len(token_obs) == 1
+
+    @pytest.mark.asyncio
+    async def test_tool_use_and_result(self) -> None:
+        subagents = SubagentTracker()
+        obs = MockObservability()
+        proc = _make_processor(subagents=subagents, observability=obs)
+
+        tool_use_line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [{"type": "tool_use", "id": "tu-1", "name": "Read", "input": {}}],
+                    "usage": {},
+                },
+            }
+        )
+        tool_result_line = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "tu-1", "content": "file contents"}
+                    ],
+                },
+            }
+        )
+        await proc.process_stream(
+            _lines_to_stream(tool_use_line, tool_result_line), MockWorkspace()
+        )
+        assert subagents.resolve_tool_name("tu-1") == "Read"
+        # Should have tool started and completed observations
+        tool_started = [r for r in obs.recordings if r[0] == "tool_execution_started"]
+        tool_completed = [r for r in obs.recordings if r[0] == "tool_execution_completed"]
+        assert len(tool_started) == 1
+        assert len(tool_completed) == 1
+
+    @pytest.mark.asyncio
+    async def test_task_result_parsing(self) -> None:
+        proc = _make_processor()
+        result_line = json.dumps(
+            {
+                "type": "result",
+                "result": 'Done. TASK_RESULT: {"success": true, "comments": "All good"}',
+                "usage": {},
+            }
+        )
+        result = await proc.process_stream(_lines_to_stream(result_line), MockWorkspace())
+        assert result.agent_task_result is not None
+        assert result.agent_task_result["success"] is True
+        assert result.agent_task_result["comments"] == "All good"
+
+    @pytest.mark.asyncio
+    async def test_conversation_lines_collected(self) -> None:
+        proc = _make_processor()
+        result = await proc.process_stream(
+            _lines_to_stream("line1", "  ", "line3"), MockWorkspace()
+        )
+        # Empty/whitespace lines are skipped
+        assert result.conversation_lines == ["line1", "line3"]
+
+    @pytest.mark.asyncio
+    async def test_non_json_lines_handled(self) -> None:
+        proc = _make_processor()
+        result = await proc.process_stream(
+            _lines_to_stream("not json at all", "also not json"), MockWorkspace()
+        )
+        assert result.line_count == 2
+
+    @pytest.mark.asyncio
+    async def test_subagent_lifecycle(self) -> None:
+        subagents = SubagentTracker()
+        obs = MockObservability()
+        proc = _make_processor(subagents=subagents, observability=obs)
+
+        # Task tool_use (start subagent)
+        task_start = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "task-1",
+                            "name": "Task",
+                            "input": {"subagent_type": "test-agent"},
+                        }
+                    ],
+                    "usage": {},
+                },
+            }
+        )
+        # Task tool_result (stop subagent)
+        task_stop = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "task-1", "content": "done"}
+                    ],
+                },
+            }
+        )
+        await proc.process_stream(_lines_to_stream(task_start, task_stop), MockWorkspace())
+        assert not subagents.has_active
+        subagent_started = [r for r in obs.recordings if r[0] == "subagent_started"]
+        subagent_stopped = [r for r in obs.recordings if r[0] == "subagent_stopped"]
+        assert len(subagent_started) == 1
+        assert len(subagent_stopped) == 1
+
+    @pytest.mark.asyncio
+    async def test_cancel_signal_triggers_interrupt(self) -> None:
+        """Test that CANCEL signal from controller triggers interrupt."""
+        from dataclasses import dataclass as dc
+
+        @dc
+        class FakeSignal:
+            signal_type: object
+            reason: str
+
+        class FakeSignalType:
+            CANCEL = "cancel"
+
+        class FakeController:
+            def __init__(self) -> None:
+                self.check_count = 0
+
+            async def check_signal(self, execution_id: str) -> FakeSignal | None:
+                self.check_count += 1
+                # Return cancel on 2nd check (after 20 lines)
+                if self.check_count >= 2:
+                    return FakeSignal(
+                        signal_type=FakeSignalType.CANCEL,
+                        reason="user requested",
+                    )
+                return None
+
+        # Patch ControlSignalType for the import inside the processor
+        import syn_adapters.control.commands as ctrl_mod
+
+        original = ctrl_mod.ControlSignalType
+        ctrl_mod.ControlSignalType = FakeSignalType  # type: ignore[assignment,misc]
+
+        try:
+            controller = FakeController()
+            proc = EventStreamProcessor(
+                tokens=TokenAccumulator(),
+                subagents=SubagentTracker(),
+                observability=None,
+                controller=controller,  # type: ignore[arg-type]
+                execution_id="exec-1",
+                phase_id="phase-1",
+                session_id="session-1",
+                workspace_id=None,
+                agent_model="claude",
+            )
+
+            # Generate 30 lines — cancel should trigger at line 20
+            lines = [f"line-{i}" for i in range(30)]
+            ws = MockWorkspace()
+            result = await proc.process_stream(_lines_to_stream(*lines), ws)
+            assert result.interrupt_requested
+            assert result.interrupt_reason == "user requested"
+            assert ws.interrupted
+            assert result.line_count == 20  # Stopped at line 20
+        finally:
+            ctrl_mod.ControlSignalType = original

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_phase_result_builder.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_phase_result_builder.py
@@ -1,0 +1,61 @@
+"""Tests for PhaseResultBuilder."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+    PhaseStatus,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.PhaseResultBuilder import (
+    PhaseResultBuilder,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+    TokenAccumulator,
+)
+
+
+class TestPhaseResultBuilder:
+    def test_success_result(self) -> None:
+        tokens = TokenAccumulator()
+        tokens.record(100, 200)
+        started = datetime.now(UTC)
+
+        result = PhaseResultBuilder.success(
+            phase_id="p1",
+            started_at=started,
+            session_id="s1",
+            artifact_ids=["a1", "a2"],
+            tokens=tokens,
+        )
+        assert result.phase_id == "p1"
+        assert result.status == PhaseStatus.COMPLETED
+        assert result.session_id == "s1"
+        assert result.artifact_id == "a1"
+        assert result.input_tokens == 100
+        assert result.output_tokens == 200
+        assert result.total_tokens == 300
+
+    def test_success_no_artifacts(self) -> None:
+        tokens = TokenAccumulator()
+        result = PhaseResultBuilder.success(
+            phase_id="p1",
+            started_at=datetime.now(UTC),
+            session_id="s1",
+            artifact_ids=[],
+            tokens=tokens,
+        )
+        assert result.artifact_id is None
+
+    def test_failure_result(self) -> None:
+        started = datetime.now(UTC)
+        result = PhaseResultBuilder.failure(
+            phase_id="p1",
+            started_at=started,
+            session_id="s1",
+            error_message="boom",
+        )
+        assert result.phase_id == "p1"
+        assert result.status == PhaseStatus.FAILED
+        assert result.error_message == "boom"
+        assert result.session_id == "s1"

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_subagent_tracker.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_subagent_tracker.py
@@ -1,0 +1,75 @@
+"""Tests for SubagentTracker."""
+
+from __future__ import annotations
+
+from syn_domain.contexts.orchestration.slices.execute_workflow.SubagentTracker import (
+    SubagentTracker,
+)
+
+
+class TestSubagentTracker:
+    def test_initial_state(self) -> None:
+        tracker = SubagentTracker()
+        assert not tracker.has_active
+
+    def test_register_and_resolve_tool(self) -> None:
+        tracker = SubagentTracker()
+        tracker.register_tool_use("id-1", "Read")
+        assert tracker.resolve_tool_name("id-1") == "Read"
+        assert tracker.resolve_tool_name("unknown-id") == "unknown"
+
+    def test_task_lifecycle(self) -> None:
+        tracker = SubagentTracker()
+        started = tracker.on_task_started("task-1", {"subagent_type": "test-agent"})
+        assert started.agent_name == "test-agent"
+        assert started.event_type == "started"
+        assert tracker.has_active
+
+        stopped = tracker.on_task_completed("task-1", success=True)
+        assert stopped is not None
+        assert stopped.agent_name == "test-agent"
+        assert stopped.event_type == "stopped"
+        assert stopped.success is True
+        assert stopped.duration_ms is not None
+        assert not tracker.has_active
+
+    def test_task_completed_unknown_id(self) -> None:
+        tracker = SubagentTracker()
+        result = tracker.on_task_completed("unknown", success=True)
+        assert result is None
+
+    def test_hook_started(self) -> None:
+        tracker = SubagentTracker()
+        import json
+
+        preview = json.dumps({"subagent_type": "explore"})
+        event = tracker.on_task_started_from_hook("task-2", preview)
+        assert event.agent_name == "explore"
+        assert tracker.has_active
+
+    def test_hook_started_invalid_json(self) -> None:
+        tracker = SubagentTracker()
+        event = tracker.on_task_started_from_hook("task-3", "not-json")
+        assert event.agent_name == "unknown"
+
+    def test_attribute_tool(self) -> None:
+        tracker = SubagentTracker()
+        tracker.on_task_started("task-1", {"description": "agent-a"})
+        tracker.attribute_tool("Read")
+        tracker.attribute_tool("Read")
+        tracker.attribute_tool("Write")
+
+        stopped = tracker.on_task_completed("task-1", success=True)
+        assert stopped is not None
+        assert stopped.tools_used == {"Read": 2, "Write": 1}
+
+    def test_attribute_tool_no_active(self) -> None:
+        tracker = SubagentTracker()
+        # Should not raise
+        tracker.attribute_tool("Read")
+
+    def test_agent_name_truncated(self) -> None:
+        tracker = SubagentTracker()
+        long_name = "a" * 100
+        event = tracker.on_task_started("task-1", {"subagent_type": long_name})
+        assert len(event.agent_name) == 50

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_token_accumulator.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_token_accumulator.py
@@ -1,0 +1,37 @@
+"""Tests for TokenAccumulator."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+    TokenAccumulator,
+)
+
+
+class TestTokenAccumulator:
+    def test_initial_state(self) -> None:
+        acc = TokenAccumulator()
+        assert acc.input_tokens == 0
+        assert acc.output_tokens == 0
+        assert acc.total_tokens == 0
+        assert acc.estimate_cost() == Decimal("0")
+
+    def test_record_accumulates(self) -> None:
+        acc = TokenAccumulator()
+        acc.record(100, 200)
+        acc.record(50, 100)
+        assert acc.input_tokens == 150
+        assert acc.output_tokens == 300
+        assert acc.total_tokens == 450
+
+    def test_estimate_cost(self) -> None:
+        acc = TokenAccumulator()
+        acc.record(1_000_000, 1_000_000)
+        cost = acc.estimate_cost()
+        # 1M input * $3/M + 1M output * $15/M = $18
+        assert cost == Decimal("18.00")
+
+    def test_estimate_cost_zero_tokens(self) -> None:
+        acc = TokenAccumulator()
+        assert acc.estimate_cost() == Decimal("0")


### PR DESCRIPTION
## Summary

Closes #144.

Decomposes `_execute_phase_in_container()` from ~1,186 LOC God Method into 6 focused collaborator classes, reducing it to ~380 LOC as a thin orchestrator:

- **`TokenAccumulator`** — pure state machine for token tracking and cost estimation
- **`SubagentTracker`** — Task tool lifecycle and tool name resolution (ADR-037)
- **`ConversationRecorder`** — deduplicated conversation storage (ADR-035)
- **`PhaseResultBuilder`** — static factory methods for PhaseResult construction
- **`ArtifactCollector`** — artifact injection/collection with two-tier storage (ADR-012)
- **`EventStreamProcessor`** — JSONL stream dispatch to collaborators (ADR-029)

All new files stay within `execute_workflow/` slice (VSA compliant). Net -827 LOC in the engine file, +1,121 LOC across 6 new collaborator classes with proper separation of concerns.

## Test plan

- [x] 39 new unit tests covering all 6 collaborators independently
- [x] All 1,185 existing tests pass unchanged
- [x] `ruff check` — all checks passed
- [x] `ruff format` — no changes needed
- [x] `mypy --strict` — no issues in 432 source files
- [ ] CI green on push