### PR TITLE
chore: bump version to v0.7.0-beta.1

### DIFF
--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.6.0"
+version = "0.7.0"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli/pyproject.toml
+++ b/apps/syn-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-cli"
-version = "0.6.0"
+version = "0.7.0"
 description = "CLI for Syntropic137 — thin wrapper over syn-api"
 requires-python = ">=3.12"
 

--- a/apps/syn-dashboard-ui/package-lock.json
+++ b/apps/syn-dashboard-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "syn-dashboard-ui",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "syn-dashboard-ui",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "clsx": "^2.1.1",
         "html2canvas": "^1.4.1",

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.6.0"
+version = "0.7.0"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.6.0"
+version = "0.7.0"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.6.0"
+version = "0.7.0"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.6.0"
+version = "0.7.0"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.6.0"
+version = "0.7.0"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.6.0"
+version = "0.7.0"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.6.0"
+version = "0.7.0"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Bump all package versions from 0.6.0 → 0.7.0
- Tag `v0.7.0-beta.1` will be created after merge

## Changes since v0.6.0-beta.1
- feat(organization): add organization bounded context (ISS-175)
- feat(observability): native subagent lifecycle events
- feat(infra): auto-detect Cloudflare tunnel in dev mode
- feat(triggers): remove skip_if_sender_is_bot guard
- Multiple bug fixes and documentation updates