### PR TITLE
feat(orchestration): Processor To-Do List pattern (ISS-196)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,101 @@ Goal: manual testing finds zero bugs — everything caught by automated tests.
 
 Test fixtures auto-detect infrastructure: env vars > test-stack (port 15432) > testcontainers.
 
+## Event Sourcing Architecture
+
+### Two-Lane Architecture
+
+All state and telemetry flows through two strictly separated lanes:
+
+1. **Lane 1: Event Sourcing (Domain Truth)** — Aggregates are the sole decision-makers for state transitions. Commands go in, events come out. The aggregate owns the rules. Infrastructure handlers react to events, do work, and report results back via new commands.
+
+2. **Lane 2: Observability (Telemetry)** — Token counts, tool traces, timing, stream chunks. Append-only, never replayed for state. Writes to observability recorder, NOT the event store. No interaction with aggregates.
+
+### Long-Running Process Orchestration
+
+When orchestrating multi-step processes (e.g., workflow execution with multiple phases):
+
+**Do NOT** use imperative async/await orchestration:
+```python
+# WRONG — imperative orchestrator
+async def execute(workflow):
+    for phase in workflow.phases:
+        workspace = await provision_workspace(phase)
+        result = await run_agent(workspace)
+        await collect_artifacts(result)
+```
+
+**DO** use the Processor To-Do List pattern:
+- **Aggregate** handles commands and emits events, enforces rules, decides "what's next"
+- **To-Do List Projection** (read model) builds a list of pending work from events
+- **Processor** reads the to-do list and dispatches commands — zero business logic
+- **Infrastructure Handlers** react to commands, do async work, emit result events
+
+Flow: `Event → Projection updates to-do list → Processor reads list → Dispatches command → Handler does work → Emits event → cycle repeats`
+
+Key properties:
+- Crash-resilient: to-do list persists, processor restarts and picks up where it left off
+- All business logic in aggregates and projections, never in the processor
+- Each handler is single-responsibility, <200 LOC, independently testable
+
+### When to Use Which Pattern
+
+| Scenario | Pattern | Example |
+|----------|---------|---------|
+| Multi-step process with infrastructure work | Processor To-Do List | Workflow execution (provision → run → collect → next phase) |
+| Simple command → event → done | Direct aggregate command | Creating a workspace, pausing an execution |
+| Querying derived state | Projection (read model) | Dashboard metrics, execution list, session tools |
+| Time-based triggers (timeouts, SLA deadlines) | Passage of Time (clock events) | Stale execution detection, phase timeout enforcement |
+
+### Projection Consistency in Processor Loops
+
+When a processor needs immediate feedback from its own commands (e.g., "I just completed phase 1, what's the next todo?"), the event subscription pipeline introduces eventual consistency delays. Two strategies:
+
+- **In-process synchronous projection:** The processor maintains a local projection instance. After each `repository.save(aggregate)`, it reads the aggregate's uncommitted events and applies them directly to the local projection. The persistent projection catches up asynchronously for external consumers (dashboard, API). This is the preferred approach for process-local to-do lists.
+- **Never** poll the persistent projection waiting for it to catch up — this creates fragile timing dependencies.
+
+### Crash Recovery and Restart Guarantees
+
+The Processor To-Do List pattern is crash-resilient by design:
+- **Domain state** is in the event store — fully recoverable by replaying events onto the aggregate
+- **To-Do list** is a projection — rebuilt from the event stream on restart (catch-up subscription)
+- **Infrastructure state** (active Docker containers, open connections) is ephemeral and NOT in the event stream. On crash, infrastructure is assumed lost. The processor re-provisions from the last completed domain event.
+- **Key invariant:** If the processor crashes between "handler did work" and "command reported to aggregate," the to-do item still shows as pending. On restart, the handler re-executes. Handlers MUST be idempotent — re-provisioning a workspace or re-collecting artifacts should be safe.
+
+### Handler Idempotency Rule
+
+Infrastructure handlers MUST be idempotent. If called twice with the same todo item:
+- `WorkspaceProvisionHandler`: Creates a new workspace (old one is gone after crash) — safe
+- `AgentExecutionHandler`: Re-runs the agent from scratch — safe (stateless container)
+- `ArtifactCollectionHandler`: Re-collects from workspace — safe (idempotent writes)
+
+The aggregate enforces ordering via command guards (e.g., reject `CompletePhaseCommand` if phase not in RUNNING state).
+
+### What Goes in the Event Store vs. What Doesn't
+
+| In Event Store (Lane 1) | NOT in Event Store |
+|---|---|
+| Phase started/completed | Docker container IDs |
+| Workspace provisioned (fact that it happened) | Active workspace handles |
+| Agent execution completed (tokens, cost, duration) | JSONL stream bytes |
+| Artifacts collected (artifact IDs) | Temporary file paths |
+| Workflow completed/failed | In-memory caches |
+
+Rule: If you need it after a restart, it must be an event. If it's only needed during the current process lifecycle, hold it in the processor.
+
+### Rules
+
+- Aggregates MUST be the decision-makers — never let an engine/service decide "what's next"
+- State MUST be derived from events — no mutable in-memory state (no `ExecutionContext` pattern)
+- Observability MUST be separate from domain — telemetry never flows through aggregates
+- Long-running processes MUST use Processor To-Do List — no imperative async loops
+
+### References
+
+- Martin Dilger, *Understanding Event Sourcing* — Ch. 37: Processor To-Do List pattern
+- Event Modeling specification: https://eventmodeling.org/posts/what-is-event-modeling/
+- To-Do List + Passage of Time patterns: https://event-driven.io/en/to_do_list_and_passage_of_time_patterns_combined/
+
 ## Tooling
 
 - **uv** for Python package management (workspaces)

--- a/packages/syn-adapters/src/syn_adapters/projections/manager.py
+++ b/packages/syn-adapters/src/syn_adapters/projections/manager.py
@@ -17,6 +17,9 @@ from syn_domain.contexts.agent_sessions.slices.session_cost.projection import Se
 from syn_domain.contexts.agent_sessions.slices.tool_timeline import ToolTimelineProjection
 from syn_domain.contexts.artifacts.slices.list_artifacts import ArtifactListProjection
 from syn_domain.contexts.orchestration.slices.dashboard_metrics import DashboardMetricsProjection
+from syn_domain.contexts.orchestration.slices.execution_todo.projection import (
+    ExecutionTodoProjection,
+)
 from syn_domain.contexts.orchestration.slices.execution_cost.projection import (
     ExecutionCostProjection,
 )
@@ -143,6 +146,7 @@ EVENT_HANDLERS: dict[str, list[tuple[str, str]]] = {
         ("dashboard_metrics", "on_workflow_execution_started"),
         ("repo_correlation", "on_workflow_execution_started"),  # Repo ↔ execution mapping
         ("realtime", "on_workflow_execution_started"),  # Real-time UI push
+        ("execution_todo", "on_workflow_execution_started"),  # To-do list (ISS-196)
     ],
     # Execution events - go to EXECUTION projections only
     "PhaseStarted": [
@@ -155,6 +159,7 @@ EVENT_HANDLERS: dict[str, list[tuple[str, str]]] = {
         ("workflow_execution_detail", "on_phase_completed"),
         ("workflow_phase_metrics", "on_phase_completed"),
         ("realtime", "on_phase_completed"),  # Real-time UI push
+        ("execution_todo", "on_phase_completed"),  # To-do list (ISS-196)
     ],
     "WorkflowCompleted": [
         ("workflow_execution_list", "on_workflow_completed"),
@@ -163,6 +168,7 @@ EVENT_HANDLERS: dict[str, list[tuple[str, str]]] = {
         ("repo_health", "on_workflow_completed"),  # Per-repo health tracking
         ("repo_cost", "on_workflow_completed"),  # Per-repo cost tracking
         ("realtime", "on_workflow_completed"),  # Real-time UI push
+        ("execution_todo", "on_workflow_completed"),  # To-do list (ISS-196)
     ],
     "WorkflowFailed": [
         ("workflow_execution_list", "on_workflow_failed"),
@@ -171,6 +177,20 @@ EVENT_HANDLERS: dict[str, list[tuple[str, str]]] = {
         ("repo_health", "on_workflow_failed"),  # Per-repo health tracking
         ("repo_cost", "on_workflow_failed"),  # Per-repo cost tracking
         ("realtime", "on_workflow_failed"),  # Real-time UI push
+        ("execution_todo", "on_workflow_failed"),  # To-do list (ISS-196)
+    ],
+    # Processor To-Do List events (ISS-196)
+    "WorkspaceProvisionedForPhase": [
+        ("execution_todo", "on_workspace_provisioned_for_phase"),
+    ],
+    "AgentExecutionCompleted": [
+        ("execution_todo", "on_agent_execution_completed"),
+    ],
+    "ArtifactsCollectedForPhase": [
+        ("execution_todo", "on_artifacts_collected_for_phase"),
+    ],
+    "NextPhaseReady": [
+        ("execution_todo", "on_next_phase_ready"),
     ],
     # Control plane events
     "ExecutionPaused": [
@@ -184,6 +204,7 @@ EVENT_HANDLERS: dict[str, list[tuple[str, str]]] = {
     "ExecutionCancelled": [
         ("workflow_execution_list", "on_execution_cancelled"),
         ("workflow_execution_detail", "on_execution_cancelled"),
+        ("execution_todo", "on_execution_cancelled"),
     ],
     # Session events
     "SessionStarted": [
@@ -292,6 +313,8 @@ class ProjectionManager:
             "repo_correlation": RepoCorrelationProjection(self._store),
             "repo_health": RepoHealthProjection(self._store),
             "repo_cost": RepoCostProjection(self._store),
+            # Processor to-do list (ISS-196) — in-memory, no persistent store needed
+            "execution_todo": ExecutionTodoProjection(),
             # Real-time projection for WebSocket push (doesn't use store)
             "realtime": get_realtime_projection(),
         }

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_execution/WorkflowExecutionAggregate.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_execution/WorkflowExecutionAggregate.py
@@ -18,6 +18,7 @@ from event_sourcing import AggregateRoot, aggregate, command_handler, event_sour
 
 from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
     ExecutionStatus,
+    PhaseDefinition,
 )
 
 if TYPE_CHECKING:
@@ -49,6 +50,7 @@ class StartExecutionCommand:
         total_phases: int,
         inputs: dict[str, Any],
         expected_completion_at: datetime | None = None,
+        phase_definitions: list[PhaseDefinition] | None = None,
     ) -> None:
         """Initialize command.
 
@@ -59,6 +61,9 @@ class StartExecutionCommand:
             total_phases: Number of phases to execute
             inputs: Input parameters for the workflow
             expected_completion_at: When we expect this to complete (for stale detection)
+            phase_definitions: Ordered phase definitions for aggregate sequencing.
+                Optional for backward compatibility — when absent, the aggregate
+                does not make sequencing decisions (legacy engine mode).
         """
         self.aggregate_id = execution_id
         self.workflow_id = workflow_id
@@ -66,6 +71,7 @@ class StartExecutionCommand:
         self.total_phases = total_phases
         self.inputs = inputs
         self.expected_completion_at = expected_completion_at
+        self.phase_definitions = phase_definitions
 
 
 class CompleteExecutionCommand:
@@ -235,6 +241,59 @@ class InterruptExecutionCommand:
         self.partial_output_tokens = partial_output_tokens
 
 
+class ProvisionWorkspaceCompletedCommand:
+    """Command reported by WorkspaceProvisionHandler after workspace is ready."""
+
+    def __init__(
+        self,
+        execution_id: str,
+        phase_id: str,
+        workspace_id: str,
+    ) -> None:
+        """Initialize command."""
+        self.aggregate_id = execution_id
+        self.phase_id = phase_id
+        self.workspace_id = workspace_id
+
+
+class AgentExecutionCompletedCommand:
+    """Command reported by AgentExecutionHandler after agent finishes."""
+
+    def __init__(
+        self,
+        execution_id: str,
+        phase_id: str,
+        session_id: str | None,
+        exit_code: int = 0,
+        input_tokens: int = 0,
+        output_tokens: int = 0,
+    ) -> None:
+        """Initialize command."""
+        self.aggregate_id = execution_id
+        self.phase_id = phase_id
+        self.session_id = session_id
+        self.exit_code = exit_code
+        self.input_tokens = input_tokens
+        self.output_tokens = output_tokens
+
+
+class ArtifactsCollectedCommand:
+    """Command reported by ArtifactCollectionHandler after outputs stored."""
+
+    def __init__(
+        self,
+        execution_id: str,
+        phase_id: str,
+        artifact_ids: list[str],
+        first_content_preview: str | None = None,
+    ) -> None:
+        """Initialize command."""
+        self.aggregate_id = execution_id
+        self.phase_id = phase_id
+        self.artifact_ids = artifact_ids
+        self.first_content_preview = first_content_preview
+
+
 # =============================================================================
 # Aggregate
 # =============================================================================
@@ -270,6 +329,10 @@ class WorkflowExecutionAggregate(AggregateRoot["WorkflowExecutionStartedEvent"])
         self._total_tokens: int = 0
         self._artifact_ids: list[str] = []
         self._error: str | None = None
+        # Phase intelligence (Processor To-Do List pattern, ISS-196)
+        self._phase_definitions: list[PhaseDefinition] = []
+        self._phase_order_map: dict[str, int] = {}  # phase_id → order index
+        self._current_phase_workspace_id: str | None = None
 
     def get_aggregate_type(self) -> str:
         """Return aggregate type name."""
@@ -302,6 +365,19 @@ class WorkflowExecutionAggregate(AggregateRoot["WorkflowExecutionStartedEvent"])
 
         self._initialize(command.aggregate_id)
 
+        # Serialize phase definitions for event storage
+        phase_defs_data: list[dict[str, Any]] | None = None
+        if command.phase_definitions:
+            phase_defs_data = [
+                {
+                    "phase_id": pd.phase_id,
+                    "name": pd.name,
+                    "order": pd.order,
+                    "timeout_seconds": pd.timeout_seconds,
+                }
+                for pd in command.phase_definitions
+            ]
+
         event = WorkflowExecutionStartedEvent(
             workflow_id=command.workflow_id,
             execution_id=command.aggregate_id,
@@ -310,6 +386,7 @@ class WorkflowExecutionAggregate(AggregateRoot["WorkflowExecutionStartedEvent"])
             total_phases=command.total_phases,
             inputs=command.inputs,
             expected_completion_at=command.expected_completion_at,
+            phase_definitions=phase_defs_data,
         )
         self._apply(event)
 
@@ -414,6 +491,100 @@ class WorkflowExecutionAggregate(AggregateRoot["WorkflowExecutionStartedEvent"])
         self._apply(event)  # type: ignore[arg-type]
 
     # =========================================================================
+    # PROCESSOR TO-DO LIST COMMAND HANDLERS (ISS-196)
+    # =========================================================================
+
+    @command_handler("ProvisionWorkspaceCompletedCommand")
+    def provision_workspace_completed(self, command: ProvisionWorkspaceCompletedCommand) -> None:
+        """Handle workspace provisioned for a phase."""
+        from syn_domain.contexts.orchestration.domain.events.WorkspaceProvisionedForPhaseEvent import (
+            WorkspaceProvisionedForPhaseEvent,
+        )
+
+        if self._status != ExecutionStatus.RUNNING:
+            msg = f"Cannot provision workspace in status {self._status}"
+            raise ValueError(msg)
+
+        event = WorkspaceProvisionedForPhaseEvent(
+            workflow_id=self._workflow_id or "",
+            execution_id=command.aggregate_id,
+            phase_id=command.phase_id,
+            workspace_id=command.workspace_id,
+            provisioned_at=datetime.now(UTC),
+        )
+        self._apply(event)  # type: ignore[arg-type]
+
+    @command_handler("AgentExecutionCompletedCommand")
+    def agent_execution_completed(self, command: AgentExecutionCompletedCommand) -> None:
+        """Handle agent finished executing in workspace."""
+        from syn_domain.contexts.orchestration.domain.events.AgentExecutionCompletedEvent import (
+            AgentExecutionCompletedEvent,
+        )
+
+        if self._status != ExecutionStatus.RUNNING:
+            msg = f"Cannot complete agent execution in status {self._status}"
+            raise ValueError(msg)
+
+        event = AgentExecutionCompletedEvent(
+            workflow_id=self._workflow_id or "",
+            execution_id=command.aggregate_id,
+            phase_id=command.phase_id,
+            session_id=command.session_id,
+            completed_at=datetime.now(UTC),
+            exit_code=command.exit_code,
+            input_tokens=command.input_tokens,
+            output_tokens=command.output_tokens,
+        )
+        self._apply(event)  # type: ignore[arg-type]
+
+    @command_handler("ArtifactsCollectedCommand")
+    def artifacts_collected(self, command: ArtifactsCollectedCommand) -> None:
+        """Handle artifacts collected — aggregate decides if more phases exist."""
+        from syn_domain.contexts.orchestration.domain.events.ArtifactsCollectedForPhaseEvent import (
+            ArtifactsCollectedForPhaseEvent,
+        )
+        from syn_domain.contexts.orchestration.domain.events.NextPhaseReadyEvent import (
+            NextPhaseReadyEvent,
+        )
+
+        if self._status != ExecutionStatus.RUNNING:
+            msg = f"Cannot collect artifacts in status {self._status}"
+            raise ValueError(msg)
+
+        event = ArtifactsCollectedForPhaseEvent(
+            workflow_id=self._workflow_id or "",
+            execution_id=command.aggregate_id,
+            phase_id=command.phase_id,
+            artifact_ids=command.artifact_ids,
+            collected_at=datetime.now(UTC),
+            first_content_preview=command.first_content_preview,
+        )
+        self._apply(event)  # type: ignore[arg-type]
+
+        # Aggregate decides: is there a next phase?
+        if self._phase_definitions:
+            current_order = self._phase_order_map.get(command.phase_id)
+            if current_order is not None:
+                next_phase = self._find_next_phase(current_order)
+                if next_phase is not None:
+                    next_event = NextPhaseReadyEvent(
+                        workflow_id=self._workflow_id or "",
+                        execution_id=command.aggregate_id,
+                        completed_phase_id=command.phase_id,
+                        next_phase_id=next_phase.phase_id,
+                        next_phase_order=next_phase.order,
+                        decided_at=datetime.now(UTC),
+                    )
+                    self._apply(next_event)  # type: ignore[arg-type]
+
+    def _find_next_phase(self, current_order: int) -> PhaseDefinition | None:
+        """Find the next phase after the given order, or None if this was the last."""
+        for phase_def in self._phase_definitions:
+            if phase_def.order > current_order:
+                return phase_def
+        return None
+
+    # =========================================================================
     # EVENT SOURCING HANDLERS
     # =========================================================================
 
@@ -426,6 +597,21 @@ class WorkflowExecutionAggregate(AggregateRoot["WorkflowExecutionStartedEvent"])
             self._started_at = event.started_at
             self._total_phases = event.total_phases
             self._expected_completion_at = getattr(event, "expected_completion_at", None)
+            # Phase definitions for aggregate sequencing (ISS-196)
+            raw_defs: list[dict[str, Any]] = getattr(event, "phase_definitions", []) or []
+            self._phase_definitions = sorted(
+                [
+                    PhaseDefinition(
+                        phase_id=d["phase_id"],
+                        name=d["name"],
+                        order=d["order"],
+                        timeout_seconds=d.get("timeout_seconds", 300),
+                    )
+                    for d in raw_defs
+                ],
+                key=lambda p: p.order,
+            )
+            self._phase_order_map = {p.phase_id: p.order for p in self._phase_definitions}
         else:
             # Dict-based event from gRPC
             data = event.model_dump() if hasattr(event, "model_dump") else dict(event)
@@ -434,6 +620,20 @@ class WorkflowExecutionAggregate(AggregateRoot["WorkflowExecutionStartedEvent"])
             self._started_at = data.get("started_at")
             self._total_phases = data.get("total_phases", 0)
             self._expected_completion_at = data.get("expected_completion_at")
+            raw_defs = data.get("phase_definitions", []) or []
+            self._phase_definitions = sorted(
+                [
+                    PhaseDefinition(
+                        phase_id=d["phase_id"],
+                        name=d["name"],
+                        order=d["order"],
+                        timeout_seconds=d.get("timeout_seconds", 300),
+                    )
+                    for d in raw_defs
+                ],
+                key=lambda p: p.order,
+            )
+            self._phase_order_map = {p.phase_id: p.order for p in self._phase_definitions}
 
         self._status = ExecutionStatus.RUNNING
 
@@ -483,6 +683,35 @@ class WorkflowExecutionAggregate(AggregateRoot["WorkflowExecutionStartedEvent"])
         # Increment completed phases count
         # Note: We don't use event data here - just counting phases
         self._completed_phases += 1
+
+    @event_sourcing_handler("WorkspaceProvisionedForPhase")
+    def on_workspace_provisioned_for_phase(self, event: Any) -> None:
+        """Apply WorkspaceProvisionedForPhaseEvent — track current workspace."""
+        if hasattr(event, "workspace_id"):
+            self._current_phase_workspace_id = event.workspace_id
+        else:
+            data = event.model_dump() if hasattr(event, "model_dump") else dict(event)
+            self._current_phase_workspace_id = data.get("workspace_id")
+
+    @event_sourcing_handler("AgentExecutionCompleted")
+    def on_agent_execution_completed(self, _event: Any) -> None:
+        """Apply AgentExecutionCompletedEvent — no state change needed."""
+
+    @event_sourcing_handler("ArtifactsCollectedForPhase")
+    def on_artifacts_collected_for_phase(self, event: Any) -> None:
+        """Apply ArtifactsCollectedForPhaseEvent — track artifact IDs."""
+        if hasattr(event, "artifact_ids"):
+            self._artifact_ids.extend(event.artifact_ids)
+        else:
+            data = event.model_dump() if hasattr(event, "model_dump") else dict(event)
+            self._artifact_ids.extend(data.get("artifact_ids", []))
+
+    @event_sourcing_handler("NextPhaseReady")
+    def on_next_phase_ready(self, _event: Any) -> None:
+        """Apply NextPhaseReadyEvent — no additional state change needed.
+
+        The to-do list projection reacts to this event, not the aggregate.
+        """
 
     # =========================================================================
     # CONTROL PLANE COMMAND HANDLERS

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_execution/test_phase_intelligence.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_execution/test_phase_intelligence.py
@@ -1,0 +1,396 @@
+"""Unit tests for aggregate phase intelligence (ISS-196).
+
+Tests the Processor To-Do List pattern: aggregate decides "what's next"
+after artifacts are collected for each phase.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+    ExecutionStatus,
+    PhaseDefinition,
+)
+from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    AgentExecutionCompletedCommand,
+    ArtifactsCollectedCommand,
+    CompletePhaseCommand,
+    ProvisionWorkspaceCompletedCommand,
+    StartExecutionCommand,
+    StartPhaseCommand,
+    WorkflowExecutionAggregate,
+)
+from syn_domain.contexts.orchestration.domain.events.AgentExecutionCompletedEvent import (
+    AgentExecutionCompletedEvent,
+)
+from syn_domain.contexts.orchestration.domain.events.ArtifactsCollectedForPhaseEvent import (
+    ArtifactsCollectedForPhaseEvent,
+)
+from syn_domain.contexts.orchestration.domain.events.NextPhaseReadyEvent import (
+    NextPhaseReadyEvent,
+)
+from syn_domain.contexts.orchestration.domain.events.WorkspaceProvisionedForPhaseEvent import (
+    WorkspaceProvisionedForPhaseEvent,
+)
+
+
+# =========================================================================
+# Helpers
+# =========================================================================
+
+TWO_PHASE_DEFS = [
+    PhaseDefinition(phase_id="p-1", name="Research", order=1),
+    PhaseDefinition(phase_id="p-2", name="Implement", order=2),
+]
+
+THREE_PHASE_DEFS = [
+    PhaseDefinition(phase_id="p-1", name="Research", order=1),
+    PhaseDefinition(phase_id="p-2", name="Implement", order=2),
+    PhaseDefinition(phase_id="p-3", name="Review", order=3, timeout_seconds=600),
+]
+
+
+def _make_started_aggregate(
+    execution_id: str = "exec-1",
+    phase_definitions: list[PhaseDefinition] | None = None,
+) -> WorkflowExecutionAggregate:
+    """Create an aggregate that has been started with phase definitions."""
+    agg = WorkflowExecutionAggregate()
+    cmd = StartExecutionCommand(
+        execution_id=execution_id,
+        workflow_id="wf-1",
+        workflow_name="Test Workflow",
+        total_phases=len(phase_definitions) if phase_definitions else 2,
+        inputs={"topic": "test"},
+        phase_definitions=phase_definitions,
+    )
+    agg._handle_command(cmd)
+    return agg
+
+
+def _get_new_events(agg: WorkflowExecutionAggregate, event_type: type) -> list:
+    """Get uncommitted events of a specific type."""
+    return [e.event for e in agg._uncommitted_events if isinstance(e.event, event_type)]
+
+
+# =========================================================================
+# StartExecution with phase_definitions
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestStartExecutionWithPhaseDefinitions:
+    """Tests for StartExecutionCommand with phase_definitions."""
+
+    def test_start_with_phase_definitions_stores_phases(self) -> None:
+        """Phase definitions are stored in aggregate state."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+        assert len(agg._phase_definitions) == 2
+        assert agg._phase_definitions[0].phase_id == "p-1"
+        assert agg._phase_definitions[1].phase_id == "p-2"
+
+    def test_start_with_phase_definitions_builds_order_map(self) -> None:
+        """Phase order map is built from definitions."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+        assert agg._phase_order_map == {"p-1": 1, "p-2": 2}
+
+    def test_start_without_phase_definitions_backward_compat(self) -> None:
+        """StartExecution without phase_definitions still works (legacy mode)."""
+        agg = _make_started_aggregate(phase_definitions=None)
+        assert agg.status == ExecutionStatus.RUNNING
+        assert agg._phase_definitions == []
+        assert agg._phase_order_map == {}
+
+    def test_phase_definitions_serialized_in_event(self) -> None:
+        """Phase definitions are included in the WorkflowExecutionStartedEvent."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+        started_events = [e.event for e in agg._uncommitted_events]
+        assert len(started_events) == 1
+        evt = started_events[0]
+        assert evt.phase_definitions is not None
+        assert len(evt.phase_definitions) == 2
+        assert evt.phase_definitions[0]["phase_id"] == "p-1"
+
+    def test_phase_definitions_sorted_by_order(self) -> None:
+        """Phases are sorted by order even if provided out-of-order."""
+        reversed_defs = [
+            PhaseDefinition(phase_id="p-2", name="Implement", order=2),
+            PhaseDefinition(phase_id="p-1", name="Research", order=1),
+        ]
+        agg = _make_started_aggregate(phase_definitions=reversed_defs)
+        assert agg._phase_definitions[0].phase_id == "p-1"
+        assert agg._phase_definitions[1].phase_id == "p-2"
+
+
+# =========================================================================
+# ProvisionWorkspaceCompletedCommand
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestProvisionWorkspaceCompleted:
+    """Tests for ProvisionWorkspaceCompletedCommand."""
+
+    def test_emits_workspace_provisioned_event(self) -> None:
+        """ProvisionWorkspaceCompleted emits WorkspaceProvisionedForPhaseEvent."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+
+        cmd = ProvisionWorkspaceCompletedCommand(
+            execution_id="exec-1",
+            phase_id="p-1",
+            workspace_id="ws-123",
+        )
+        agg._handle_command(cmd)
+
+        new_events = _get_new_events(agg, WorkspaceProvisionedForPhaseEvent)
+        assert len(new_events) == 1
+        assert new_events[0].phase_id == "p-1"
+        assert new_events[0].workspace_id == "ws-123"
+
+    def test_tracks_current_workspace_id(self) -> None:
+        """Aggregate state tracks current workspace ID."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+        cmd = ProvisionWorkspaceCompletedCommand(
+            execution_id="exec-1", phase_id="p-1", workspace_id="ws-123"
+        )
+        agg._handle_command(cmd)
+        assert agg._current_phase_workspace_id == "ws-123"
+
+    def test_rejected_when_not_running(self) -> None:
+        """Provision rejected when execution is not RUNNING."""
+        from decimal import Decimal
+
+        from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+            CompleteExecutionCommand,
+        )
+
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+        agg._handle_command(
+            CompleteExecutionCommand(
+                execution_id="exec-1",
+                completed_phases=2,
+                total_phases=2,
+                total_input_tokens=0,
+                total_output_tokens=0,
+                total_cost_usd=Decimal("0"),
+                duration_seconds=0.0,
+                artifact_ids=[],
+            )
+        )
+
+        with pytest.raises(ValueError, match="Cannot provision workspace"):
+            agg._handle_command(
+                ProvisionWorkspaceCompletedCommand(
+                    execution_id="exec-1", phase_id="p-1", workspace_id="ws-1"
+                )
+            )
+
+
+# =========================================================================
+# AgentExecutionCompletedCommand
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestAgentExecutionCompleted:
+    """Tests for AgentExecutionCompletedCommand."""
+
+    def test_emits_agent_execution_completed_event(self) -> None:
+        """AgentExecutionCompleted emits AgentExecutionCompletedEvent."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+
+        cmd = AgentExecutionCompletedCommand(
+            execution_id="exec-1",
+            phase_id="p-1",
+            session_id="sess-1",
+            exit_code=0,
+            input_tokens=100,
+            output_tokens=50,
+        )
+        agg._handle_command(cmd)
+
+        new_events = _get_new_events(agg, AgentExecutionCompletedEvent)
+        assert len(new_events) == 1
+        assert new_events[0].phase_id == "p-1"
+        assert new_events[0].session_id == "sess-1"
+        assert new_events[0].input_tokens == 100
+        assert new_events[0].output_tokens == 50
+
+    def test_rejected_when_not_running(self) -> None:
+        """AgentExecutionCompleted rejected when not RUNNING."""
+        from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+            CancelExecutionCommand,
+        )
+
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+        agg._handle_command(CancelExecutionCommand(execution_id="exec-1", phase_id="p-1"))
+
+        with pytest.raises(ValueError, match="Cannot complete agent execution"):
+            agg._handle_command(
+                AgentExecutionCompletedCommand(
+                    execution_id="exec-1", phase_id="p-1", session_id=None
+                )
+            )
+
+
+# =========================================================================
+# ArtifactsCollectedCommand — the key decision point
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestArtifactsCollected:
+    """Tests for ArtifactsCollectedCommand — aggregate decides next phase."""
+
+    def test_non_final_phase_emits_next_phase_ready(self) -> None:
+        """ArtifactsCollected for non-final phase → emits NextPhaseReadyEvent."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+
+        cmd = ArtifactsCollectedCommand(
+            execution_id="exec-1",
+            phase_id="p-1",
+            artifact_ids=["art-1"],
+            first_content_preview="result content",
+        )
+        agg._handle_command(cmd)
+
+        collected_events = _get_new_events(agg, ArtifactsCollectedForPhaseEvent)
+        assert len(collected_events) == 1
+        assert collected_events[0].artifact_ids == ["art-1"]
+
+        next_events = _get_new_events(agg, NextPhaseReadyEvent)
+        assert len(next_events) == 1
+        assert next_events[0].completed_phase_id == "p-1"
+        assert next_events[0].next_phase_id == "p-2"
+        assert next_events[0].next_phase_order == 2
+
+    def test_final_phase_does_not_emit_next_phase_ready(self) -> None:
+        """ArtifactsCollected for final phase → does NOT emit NextPhaseReadyEvent."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+
+        cmd = ArtifactsCollectedCommand(
+            execution_id="exec-1",
+            phase_id="p-2",  # Final phase
+            artifact_ids=["art-2"],
+        )
+        agg._handle_command(cmd)
+
+        next_events = _get_new_events(agg, NextPhaseReadyEvent)
+        assert len(next_events) == 0
+
+        collected_events = _get_new_events(agg, ArtifactsCollectedForPhaseEvent)
+        assert len(collected_events) == 1
+
+    def test_three_phase_workflow_middle_phase(self) -> None:
+        """Middle phase in 3-phase workflow emits NextPhaseReady for third phase."""
+        agg = _make_started_aggregate(phase_definitions=THREE_PHASE_DEFS)
+
+        cmd = ArtifactsCollectedCommand(
+            execution_id="exec-1",
+            phase_id="p-2",
+            artifact_ids=["art-2"],
+        )
+        agg._handle_command(cmd)
+
+        next_events = _get_new_events(agg, NextPhaseReadyEvent)
+        assert len(next_events) == 1
+        assert next_events[0].next_phase_id == "p-3"
+        assert next_events[0].next_phase_order == 3
+
+    def test_tracks_artifact_ids_in_state(self) -> None:
+        """Artifact IDs accumulate in aggregate state."""
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+
+        agg._handle_command(
+            ArtifactsCollectedCommand(
+                execution_id="exec-1", phase_id="p-1", artifact_ids=["art-1", "art-2"]
+            )
+        )
+        agg._handle_command(
+            ArtifactsCollectedCommand(
+                execution_id="exec-1", phase_id="p-2", artifact_ids=["art-3"]
+            )
+        )
+
+        assert agg._artifact_ids == ["art-1", "art-2", "art-3"]
+
+    def test_no_phase_definitions_no_next_phase_event(self) -> None:
+        """Without phase_definitions (legacy mode), no NextPhaseReady is emitted."""
+        agg = _make_started_aggregate(phase_definitions=None)
+
+        cmd = ArtifactsCollectedCommand(
+            execution_id="exec-1",
+            phase_id="p-1",
+            artifact_ids=["art-1"],
+        )
+        agg._handle_command(cmd)
+
+        # Should still emit ArtifactsCollectedForPhaseEvent
+        collected_events = _get_new_events(agg, ArtifactsCollectedForPhaseEvent)
+        assert len(collected_events) == 1
+
+        # But no NextPhaseReady
+        next_events = _get_new_events(agg, NextPhaseReadyEvent)
+        assert len(next_events) == 0
+
+    def test_rejected_when_not_running(self) -> None:
+        """ArtifactsCollected rejected when not RUNNING."""
+        from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+            CancelExecutionCommand,
+        )
+
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+        agg._handle_command(CancelExecutionCommand(execution_id="exec-1", phase_id="p-1"))
+
+        with pytest.raises(ValueError, match="Cannot collect artifacts"):
+            agg._handle_command(
+                ArtifactsCollectedCommand(
+                    execution_id="exec-1", phase_id="p-1", artifact_ids=[]
+                )
+            )
+
+
+# =========================================================================
+# Full lifecycle: existing commands still work with phase_definitions
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestBackwardCompatibility:
+    """Existing aggregate behavior is unchanged."""
+
+    def test_start_complete_phase_still_works(self) -> None:
+        """StartPhase + CompletePhase still works alongside new events."""
+        from decimal import Decimal
+
+        agg = _make_started_aggregate(phase_definitions=TWO_PHASE_DEFS)
+
+        # Start and complete phase using existing commands
+        agg._handle_command(
+            StartPhaseCommand(
+                execution_id="exec-1",
+                workflow_id="wf-1",
+                phase_id="p-1",
+                phase_name="Research",
+                phase_order=1,
+            )
+        )
+
+        agg._handle_command(
+            CompletePhaseCommand(
+                execution_id="exec-1",
+                workflow_id="wf-1",
+                phase_id="p-1",
+                session_id="sess-1",
+                artifact_id="art-1",
+                input_tokens=100,
+                output_tokens=50,
+                total_tokens=150,
+                cost_usd=Decimal("0.01"),
+                duration_seconds=10.0,
+            )
+        )
+
+        assert agg._completed_phases == 1
+        assert agg.status == ExecutionStatus.RUNNING

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_execution/value_objects.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_execution/value_objects.py
@@ -32,6 +32,20 @@ class PhaseStatus(str, Enum):
 
 
 @dataclass(frozen=True)
+class PhaseDefinition:
+    """Immutable definition of a phase for aggregate-level sequencing.
+
+    Used by the aggregate to know phase ordering and decide "what's next"
+    after artifacts are collected. The aggregate owns sequencing decisions.
+    """
+
+    phase_id: str
+    name: str
+    order: int
+    timeout_seconds: int = 300
+
+
+@dataclass(frozen=True)
 class AgentConfiguration:
     """Agent configuration for executing a phase.
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/AgentExecutionCompletedEvent.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/AgentExecutionCompletedEvent.py
@@ -1,0 +1,25 @@
+"""AgentExecutionCompleted event - agent finished executing in workspace."""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003 - needed at runtime for Pydantic
+
+from event_sourcing import DomainEvent, event
+
+
+@event("AgentExecutionCompleted", "v1")
+class AgentExecutionCompletedEvent(DomainEvent):
+    """Event emitted when the agent has finished executing in a workspace.
+
+    Captures the fact that execution completed and basic metrics.
+    Output content is in the observability lane, not here.
+    """
+
+    workflow_id: str
+    execution_id: str
+    phase_id: str
+    session_id: str | None
+    completed_at: datetime
+    exit_code: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/ArtifactsCollectedForPhaseEvent.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/ArtifactsCollectedForPhaseEvent.py
@@ -1,0 +1,23 @@
+"""ArtifactsCollectedForPhase event - outputs stored as artifacts."""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003 - needed at runtime for Pydantic
+
+from event_sourcing import DomainEvent, event
+
+
+@event("ArtifactsCollectedForPhase", "v1")
+class ArtifactsCollectedForPhaseEvent(DomainEvent):
+    """Event emitted when artifacts have been collected from a phase workspace.
+
+    Records which artifact IDs were created and basic content summary.
+    The actual artifact content is managed by the artifacts bounded context.
+    """
+
+    workflow_id: str
+    execution_id: str
+    phase_id: str
+    artifact_ids: list[str]
+    collected_at: datetime
+    first_content_preview: str | None = None

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/NextPhaseReadyEvent.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/NextPhaseReadyEvent.py
@@ -1,0 +1,23 @@
+"""NextPhaseReady event - aggregate decided another phase should run."""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003 - needed at runtime for Pydantic
+
+from event_sourcing import DomainEvent, event
+
+
+@event("NextPhaseReady", "v1")
+class NextPhaseReadyEvent(DomainEvent):
+    """Event emitted by the aggregate when it determines the next phase should run.
+
+    This is the aggregate's decision — not the processor's. The processor
+    reads the to-do list and dispatches provisioning for the next phase.
+    """
+
+    workflow_id: str
+    execution_id: str
+    completed_phase_id: str
+    next_phase_id: str
+    next_phase_order: int
+    decided_at: datetime

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/WorkflowExecutionStartedEvent.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/WorkflowExecutionStartedEvent.py
@@ -28,3 +28,7 @@ class WorkflowExecutionStartedEvent(DomainEvent):
     # Expected completion time (for stale detection)
     # Calculated as: started_at + sum of all phase timeouts + buffer
     expected_completion_at: datetime | None = None
+
+    # Phase definitions for aggregate-level sequencing (ISS-196)
+    # Optional for backward compatibility — when absent, aggregate does not sequence.
+    phase_definitions: list[dict[str, Any]] | None = None

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/WorkspaceProvisionedForPhaseEvent.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/WorkspaceProvisionedForPhaseEvent.py
@@ -1,0 +1,22 @@
+"""WorkspaceProvisionedForPhase event - workspace is ready for a phase."""
+
+from __future__ import annotations
+
+from datetime import datetime  # noqa: TC003 - needed at runtime for Pydantic
+
+from event_sourcing import DomainEvent, event
+
+
+@event("WorkspaceProvisionedForPhase", "v1")
+class WorkspaceProvisionedForPhaseEvent(DomainEvent):
+    """Event emitted when a workspace has been provisioned for a phase.
+
+    Indicates infrastructure is ready — secrets injected, artifacts staged,
+    CLI command built. The processor can now dispatch agent execution.
+    """
+
+    workflow_id: str
+    execution_id: str
+    phase_id: str
+    workspace_id: str
+    provisioned_at: datetime

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/__init__.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/events/__init__.py
@@ -6,6 +6,12 @@ Events represent facts - things that have happened.
 
 # Workflow execution events
 # Workspace events
+from syn_domain.contexts.orchestration.domain.events.AgentExecutionCompletedEvent import (
+    AgentExecutionCompletedEvent,
+)
+from syn_domain.contexts.orchestration.domain.events.ArtifactsCollectedForPhaseEvent import (
+    ArtifactsCollectedForPhaseEvent,
+)
 from syn_domain.contexts.orchestration.domain.events.CommandExecutedEvent import (
     CommandExecutedEvent,
 )
@@ -23,6 +29,9 @@ from syn_domain.contexts.orchestration.domain.events.ExecutionResumedEvent impor
 )
 from syn_domain.contexts.orchestration.domain.events.IsolationStartedEvent import (
     IsolationStartedEvent,
+)
+from syn_domain.contexts.orchestration.domain.events.NextPhaseReadyEvent import (
+    NextPhaseReadyEvent,
 )
 from syn_domain.contexts.orchestration.domain.events.PhaseCompletedEvent import (
     PhaseCompletedEvent,
@@ -51,6 +60,9 @@ from syn_domain.contexts.orchestration.domain.events.WorkflowTemplateCreatedEven
 from syn_domain.contexts.orchestration.domain.events.WorkspaceCommandExecutedEvent import (
     WorkspaceCommandExecutedEvent,
 )
+from syn_domain.contexts.orchestration.domain.events.WorkspaceProvisionedForPhaseEvent import (
+    WorkspaceProvisionedForPhaseEvent,
+)
 from syn_domain.contexts.orchestration.domain.events.WorkspaceCreatedEvent import (
     WorkspaceCreatedEvent,
 )
@@ -71,22 +83,26 @@ from syn_domain.contexts.orchestration.domain.events.WorkspaceTerminatedEvent im
 )
 
 __all__ = [
-    # Workspace events
-    "CommandExecutedEvent",
-    "CommandFailedEvent",
     # Workflow execution events
+    "AgentExecutionCompletedEvent",
+    "ArtifactsCollectedForPhaseEvent",
     "ExecutionCancelledEvent",
     "ExecutionPausedEvent",
     "ExecutionResumedEvent",
-    "IsolationStartedEvent",
+    "NextPhaseReadyEvent",
     "PhaseCompletedEvent",
     "PhaseStartedEvent",
-    "TokensInjectedEvent",
     "WorkflowCompletedEvent",
     "WorkflowExecutionStartedEvent",
     "WorkflowFailedEvent",
     "WorkflowInterruptedEvent",
     "WorkflowTemplateCreatedEvent",
+    "WorkspaceProvisionedForPhaseEvent",
+    # Workspace events
+    "CommandExecutedEvent",
+    "CommandFailedEvent",
+    "IsolationStartedEvent",
+    "TokensInjectedEvent",
     "WorkspaceCommandExecutedEvent",
     "WorkspaceCreatedEvent",
     "WorkspaceCreatingEvent",

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ArtifactCollector.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ArtifactCollector.py
@@ -130,6 +130,53 @@ class ArtifactCollector:
                 ctx.completed_phase_ids,
             )
 
+    async def inject_from_previous_phases_explicit(
+        self,
+        workspace: ArtifactWorkspace,
+        completed_phase_ids: list[str],
+        phase_outputs: dict[str, str],
+    ) -> None:
+        """Inject artifacts using explicit parameters (ISS-196).
+
+        Same logic as inject_from_previous_phases but without ExecutionContext.
+        Used by WorkspaceProvisionHandler in the Processor To-Do List pattern.
+        """
+        if not completed_phase_ids:
+            return
+
+        outputs: dict[str, str] = {}
+
+        # 1. Get from in-memory cache
+        for pid in completed_phase_ids:
+            if pid in phase_outputs:
+                outputs[pid] = phase_outputs[pid]
+
+        # 2. Query projection for missing
+        missing = [pid for pid in completed_phase_ids if pid not in outputs]
+        if missing and self._query_service:
+            projection_outputs = await self._query_service.get_for_phase_injection(
+                execution_id="",  # Not available in explicit mode
+                completed_phase_ids=missing,
+            )
+            outputs.update(projection_outputs)
+
+        files_to_inject = [
+            (f"artifacts/input/{prev_id}.md", content.encode())
+            for prev_id, content in outputs.items()
+        ]
+        if files_to_inject:
+            await workspace.inject_files(files_to_inject)
+            logger.info(
+                "Injected %d artifact(s) from previous phases: %s",
+                len(files_to_inject),
+                list(outputs.keys()),
+            )
+        elif completed_phase_ids:
+            logger.warning(
+                "No artifacts found for completed phases: %s",
+                completed_phase_ids,
+            )
+
     async def collect_from_workspace(
         self,
         workspace: ArtifactWorkspace,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/EventStreamProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/EventStreamProcessor.py
@@ -1,9 +1,10 @@
 """Event stream processor for workflow execution.
 
 Processes Claude CLI JSONL output stream, dispatching events to
-TokenAccumulator, SubagentTracker, and observability writer.
+TokenAccumulator, SubagentTracker, and ObservabilityCollector.
 
 Extracted from WorkflowExecutionEngine._execute_phase_in_container().
+Refactored in ISS-196 to delegate telemetry to ObservabilityCollector (Lane 2).
 """
 
 from __future__ import annotations
@@ -26,6 +27,9 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from syn_adapters.control import ExecutionController
+    from syn_domain.contexts.orchestration.slices.execute_workflow.ObservabilityCollector import (
+        ObservabilityCollector,
+    )
     from syn_domain.contexts.orchestration.slices.execute_workflow.SubagentTracker import (
         SubagentTracker,
     )
@@ -71,7 +75,7 @@ class EventStreamProcessor:
     """Processes Claude CLI JSONL event stream.
 
     Dispatches events to TokenAccumulator and SubagentTracker,
-    records observations, and accumulates conversation lines.
+    delegates telemetry recording to ObservabilityCollector (Lane 2).
     """
 
     def __init__(
@@ -85,16 +89,33 @@ class EventStreamProcessor:
         session_id: str,
         workspace_id: str | None,
         agent_model: str,
+        collector: ObservabilityCollector | None = None,
     ) -> None:
         self._tokens = tokens
         self._subagents = subagents
-        self._observability = observability
         self._controller = controller
         self._execution_id = execution_id
         self._phase_id = phase_id
         self._session_id = session_id
         self._workspace_id = workspace_id
         self._agent_model = agent_model
+
+        # ISS-196: Use collector if provided, else create one from raw writer
+        if collector is not None:
+            self._collector = collector
+        else:
+            from syn_domain.contexts.orchestration.slices.execute_workflow.ObservabilityCollector import (
+                ObservabilityCollector as OC,
+            )
+
+            self._collector = OC(
+                writer=observability,
+                session_id=session_id,
+                execution_id=execution_id,
+                phase_id=phase_id,
+                workspace_id=workspace_id,
+                agent_model=agent_model,
+            )
 
     async def process_stream(
         self,
@@ -267,24 +288,10 @@ class EventStreamProcessor:
         )
         logger.debug("Hook event: %s", enriched.get("event_type"))
 
-        # Store via observability writer
-        if self._observability is not None:
-            hook_data = {
-                **(enriched.get("context") or {}),
-                **(enriched.get("metadata") or {}),
-            }
-            await self._observability.record_observation(
-                session_id=self._session_id,
-                observation_type=enriched.get("event_type", "unknown"),
-                data=hook_data,
-                execution_id=self._execution_id,
-                phase_id=self._phase_id,
-                workspace_id=self._workspace_id,
-            )
+        # Lane 2: Record via collector
+        await self._collector.record_hook_event(enriched)
 
         # ADR-037: Detect subagent lifecycle from Task tool events.
-        # Hook events use "event_type" (not "type") with values from
-        # agentic_events.types.EventType (e.g. "tool_execution_started").
         hook_event_type = hook_event.get("event_type", "")
         ctx_data = enriched.get("context", {})
         tool_name = ctx_data.get("tool_name", "")
@@ -302,48 +309,18 @@ class EventStreamProcessor:
             if hook_event_type == EventType.TOOL_EXECUTION_STARTED:
                 input_preview = ctx_data.get("input_preview", "")
                 event = self._subagents.on_task_started_from_hook(tool_use_id, input_preview)
-                if self._observability is not None:
-                    await self._observability.record_observation(
-                        session_id=self._session_id,
-                        observation_type=ObservationType.SUBAGENT_STARTED,
-                        data={
-                            "agent_name": event.agent_name,
-                            "subagent_tool_use_id": tool_use_id,
-                        },
-                        execution_id=self._execution_id,
-                        phase_id=self._phase_id,
-                        workspace_id=self._workspace_id,
-                    )
-                    logger.info(
-                        "Subagent started: %s (id=%s)",
-                        event.agent_name,
-                        tool_use_id,
-                    )
+                await self._collector.record_subagent_started(event.agent_name, tool_use_id)
 
             elif hook_event_type == EventType.TOOL_EXECUTION_COMPLETED:
                 success = ctx_data.get("success", True)
                 stopped_event = self._subagents.on_task_completed(tool_use_id, success=success)
-                if stopped_event and self._observability is not None:
-                    await self._observability.record_observation(
-                        session_id=self._session_id,
-                        observation_type=ObservationType.SUBAGENT_STOPPED,
-                        data={
-                            "agent_name": stopped_event.agent_name,
-                            "subagent_tool_use_id": tool_use_id,
-                            "duration_ms": stopped_event.duration_ms,
-                            "success": stopped_event.success,
-                            "tools_used": stopped_event.tools_used,
-                        },
-                        execution_id=self._execution_id,
-                        phase_id=self._phase_id,
-                        workspace_id=self._workspace_id,
-                    )
-                    logger.info(
-                        "Subagent stopped: %s (id=%s, duration=%dms, tools=%s)",
-                        stopped_event.agent_name,
-                        tool_use_id,
-                        stopped_event.duration_ms or 0,
-                        stopped_event.tools_used,
+                if stopped_event:
+                    await self._collector.record_subagent_stopped(
+                        agent_name=stopped_event.agent_name,
+                        tool_use_id=tool_use_id,
+                        duration_ms=stopped_event.duration_ms,
+                        success=stopped_event.success,
+                        tools_used=stopped_event.tools_used,
                     )
 
     async def _process_cli_event(self, line: str) -> dict[str, Any] | None:
@@ -405,28 +382,12 @@ class EventStreamProcessor:
         if input_tokens > 0 or output_tokens > 0:
             self._tokens.record(input_tokens, output_tokens)
 
-            if self._observability is not None:
-                cache_creation = usage.get("cache_creation_input_tokens", 0)
-                cache_read = usage.get("cache_read_input_tokens", 0)
-                await self._observability.record_observation(
-                    session_id=self._session_id,
-                    observation_type=ObservationType.TOKEN_USAGE,
-                    data={
-                        "input_tokens": input_tokens,
-                        "output_tokens": output_tokens,
-                        "cache_creation_tokens": cache_creation,
-                        "cache_read_tokens": cache_read,
-                        "model": self._agent_model,
-                    },
-                    execution_id=self._execution_id,
-                    phase_id=self._phase_id,
-                    workspace_id=self._workspace_id,
-                )
-                logger.info(
-                    "Result token usage: %d in, %d out",
-                    input_tokens,
-                    output_tokens,
-                )
+            cache_creation = usage.get("cache_creation_input_tokens", 0)
+            cache_read = usage.get("cache_read_input_tokens", 0)
+            await self._collector.record_token_usage(
+                input_tokens, output_tokens, cache_creation, cache_read,
+            )
+            logger.info("Result token usage: %d in, %d out", input_tokens, output_tokens)
 
         return task_result
 
@@ -444,30 +405,18 @@ class EventStreamProcessor:
             if input_tokens > 0 or output_tokens > 0:
                 self._tokens.record(input_tokens, output_tokens)
 
-                if self._observability is not None:
-                    cache_creation = usage.get("cache_creation_input_tokens", 0)
-                    cache_read = usage.get("cache_read_input_tokens", 0)
-                    await self._observability.record_observation(
-                        session_id=self._session_id,
-                        observation_type=ObservationType.TOKEN_USAGE,
-                        data={
-                            "input_tokens": input_tokens,
-                            "output_tokens": output_tokens,
-                            "cache_creation_tokens": cache_creation,
-                            "cache_read_tokens": cache_read,
-                            "model": self._agent_model,
-                        },
-                        execution_id=self._execution_id,
-                        phase_id=self._phase_id,
-                        workspace_id=self._workspace_id,
-                    )
-                    logger.info(
-                        "Per-turn token usage: %d in, %d out (cache: %d read, %d create)",
-                        input_tokens,
-                        output_tokens,
-                        cache_read,
-                        cache_creation,
-                    )
+                cache_creation = usage.get("cache_creation_input_tokens", 0)
+                cache_read = usage.get("cache_read_input_tokens", 0)
+                await self._collector.record_token_usage(
+                    input_tokens, output_tokens, cache_creation, cache_read,
+                )
+                logger.info(
+                    "Per-turn token usage: %d in, %d out (cache: %d read, %d create)",
+                    input_tokens,
+                    output_tokens,
+                    cache_read,
+                    cache_creation,
+                )
 
         # Process tool_use items
         for item in content:
@@ -488,41 +437,17 @@ class EventStreamProcessor:
         # Cache tool_name for enriching tool_result events
         self._subagents.register_tool_use(tool_use_id, tool_name)
 
-        if self._observability is not None:
-            await self._observability.record_observation(
-                session_id=self._session_id,
-                observation_type=ObservationType.TOOL_EXECUTION_STARTED,
-                data={
-                    "tool_name": tool_name,
-                    "tool_use_id": tool_use_id,
-                    "input_preview": json.dumps(tool_input)[:500],
-                },
-                execution_id=self._execution_id,
-                phase_id=self._phase_id,
-                workspace_id=self._workspace_id,
-            )
-            logger.debug("Tool started: %s", tool_name)
+        await self._collector.record_tool_started(
+            tool_name=tool_name,
+            tool_use_id=tool_use_id,
+            input_preview=json.dumps(tool_input)[:500],
+        )
+        logger.debug("Tool started: %s", tool_name)
 
         # ADR-037: Detect Task/Agent tool as subagent start (raw CLI format)
         if tool_name in (ClaudeToolName.SUBAGENT, ClaudeToolName.SUBAGENT_LEGACY) and tool_use_id:
             event = self._subagents.on_task_started(tool_use_id, tool_input)
-            if self._observability is not None:
-                await self._observability.record_observation(
-                    session_id=self._session_id,
-                    observation_type=ObservationType.SUBAGENT_STARTED,
-                    data={
-                        "agent_name": event.agent_name,
-                        "subagent_tool_use_id": tool_use_id,
-                    },
-                    execution_id=self._execution_id,
-                    phase_id=self._phase_id,
-                    workspace_id=self._workspace_id,
-                )
-                logger.info(
-                    "Subagent started (CLI): %s (id=%s)",
-                    event.agent_name,
-                    tool_use_id,
-                )
+            await self._collector.record_subagent_started(event.agent_name, tool_use_id)
 
     async def _handle_user_event(self, cli_event: dict[str, Any]) -> None:
         """Handle user event — process tool results."""
@@ -548,7 +473,7 @@ class EventStreamProcessor:
         tool_name = self._subagents.resolve_tool_name(tool_use_id)
 
         # Scan tool output for embedded git hook JSONL (ADR-043)
-        if tool_content and self._observability is not None:
+        if tool_content:
             for tl in str(tool_content).splitlines():
                 tl = tl.strip()
                 if not tl:
@@ -565,18 +490,7 @@ class EventStreamProcessor:
                     execution_id=self._execution_id,
                     phase_id=self._phase_id,
                 )
-                hd = {
-                    **(enriched.get("context") or {}),
-                    **(enriched.get("metadata") or {}),
-                }
-                await self._observability.record_observation(
-                    session_id=self._session_id,
-                    observation_type=et,
-                    data=hd,
-                    execution_id=self._execution_id,
-                    phase_id=self._phase_id,
-                    workspace_id=self._workspace_id,
-                )
+                await self._collector.record_embedded_event(et, enriched)
                 logger.info(
                     "Git hook event from tool output: %s (tool=%s)",
                     et,
@@ -584,52 +498,25 @@ class EventStreamProcessor:
                 )
 
         # Record tool completion
-        if self._observability is not None:
-            await self._observability.record_observation(
-                session_id=self._session_id,
-                observation_type=ObservationType.TOOL_EXECUTION_COMPLETED,
-                data={
-                    "tool_name": tool_name,
-                    "tool_use_id": tool_use_id,
-                    "success": not is_error,
-                    "output_preview": output_preview,
-                },
-                execution_id=self._execution_id,
-                phase_id=self._phase_id,
-                workspace_id=self._workspace_id,
-            )
-            logger.debug(
-                "Tool completed: %s (%s) success=%s",
-                tool_use_id,
-                tool_name,
-                not is_error,
-            )
+        await self._collector.record_tool_completed(
+            tool_name=tool_name,
+            tool_use_id=tool_use_id,
+            success=not is_error,
+            output_preview=output_preview,
+        )
+        logger.debug("Tool completed: %s (%s) success=%s", tool_use_id, tool_name, not is_error)
 
         # ADR-037: Detect Task/Agent tool completion as subagent stop (raw CLI format)
         _is_subagent = tool_name in (ClaudeToolName.SUBAGENT, ClaudeToolName.SUBAGENT_LEGACY)
         if _is_subagent:
             event = self._subagents.on_task_completed(tool_use_id, success=not is_error)
-            if event and self._observability is not None:
-                await self._observability.record_observation(
-                    session_id=self._session_id,
-                    observation_type=ObservationType.SUBAGENT_STOPPED,
-                    data={
-                        "agent_name": event.agent_name,
-                        "subagent_tool_use_id": tool_use_id,
-                        "duration_ms": event.duration_ms,
-                        "success": event.success,
-                        "tools_used": event.tools_used,
-                    },
-                    execution_id=self._execution_id,
-                    phase_id=self._phase_id,
-                    workspace_id=self._workspace_id,
-                )
-                logger.info(
-                    "Subagent stopped (CLI): %s (id=%s, duration=%dms, tools=%s)",
-                    event.agent_name,
-                    tool_use_id,
-                    event.duration_ms or 0,
-                    event.tools_used,
+            if event:
+                await self._collector.record_subagent_stopped(
+                    agent_name=event.agent_name,
+                    tool_use_id=tool_use_id,
+                    duration_ms=event.duration_ms,
+                    success=event.success,
+                    tools_used=event.tools_used,
                 )
         elif not _is_subagent:
             # Attribute non-subagent tool to the most recently started subagent

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ObservabilityCollector.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ObservabilityCollector.py
@@ -1,0 +1,222 @@
+"""ObservabilityCollector — Lane 2 telemetry recording (ISS-196).
+
+Encapsulates all observability recording calls. Never touches domain
+aggregates — purely writes to the observability backend.
+
+Extracted from EventStreamProcessor to enforce two-lane separation.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from syn_domain.contexts.agent_sessions.domain.events.agent_observation import (
+    ObservationType,
+)
+
+if TYPE_CHECKING:
+    from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProcessor import (
+        ObservabilityRecorder,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class ObservabilityCollector:
+    """Lane 2: Records telemetry to observability backend.
+
+    Never touches domain aggregates. All methods are no-op
+    when the writer is None (e.g., in tests or local dev).
+    """
+
+    def __init__(
+        self,
+        writer: ObservabilityRecorder | None,
+        session_id: str,
+        execution_id: str,
+        phase_id: str,
+        workspace_id: str | None,
+        agent_model: str,
+    ) -> None:
+        self._writer = writer
+        self._session_id = session_id
+        self._execution_id = execution_id
+        self._phase_id = phase_id
+        self._workspace_id = workspace_id
+        self._agent_model = agent_model
+
+    @property
+    def has_writer(self) -> bool:
+        """Whether this collector has an active writer."""
+        return self._writer is not None
+
+    async def record_hook_event(self, enriched: dict[str, Any]) -> None:
+        """Record an enriched hook event to observability."""
+        if self._writer is None:
+            return
+
+        hook_data = {
+            **(enriched.get("context") or {}),
+            **(enriched.get("metadata") or {}),
+        }
+        await self._writer.record_observation(
+            session_id=self._session_id,
+            observation_type=enriched.get("event_type", "unknown"),
+            data=hook_data,
+            execution_id=self._execution_id,
+            phase_id=self._phase_id,
+            workspace_id=self._workspace_id,
+        )
+
+    async def record_token_usage(
+        self,
+        input_tokens: int,
+        output_tokens: int,
+        cache_creation: int = 0,
+        cache_read: int = 0,
+    ) -> None:
+        """Record token usage observation."""
+        if self._writer is None:
+            return
+
+        await self._writer.record_observation(
+            session_id=self._session_id,
+            observation_type=ObservationType.TOKEN_USAGE,
+            data={
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_tokens": cache_creation,
+                "cache_read_tokens": cache_read,
+                "model": self._agent_model,
+            },
+            execution_id=self._execution_id,
+            phase_id=self._phase_id,
+            workspace_id=self._workspace_id,
+        )
+
+    async def record_tool_started(
+        self,
+        tool_name: str,
+        tool_use_id: str,
+        input_preview: str,
+    ) -> None:
+        """Record tool execution started."""
+        if self._writer is None:
+            return
+
+        await self._writer.record_observation(
+            session_id=self._session_id,
+            observation_type=ObservationType.TOOL_EXECUTION_STARTED,
+            data={
+                "tool_name": tool_name,
+                "tool_use_id": tool_use_id,
+                "input_preview": input_preview,
+            },
+            execution_id=self._execution_id,
+            phase_id=self._phase_id,
+            workspace_id=self._workspace_id,
+        )
+
+    async def record_tool_completed(
+        self,
+        tool_name: str,
+        tool_use_id: str,
+        success: bool,
+        output_preview: str | None,
+    ) -> None:
+        """Record tool execution completed."""
+        if self._writer is None:
+            return
+
+        await self._writer.record_observation(
+            session_id=self._session_id,
+            observation_type=ObservationType.TOOL_EXECUTION_COMPLETED,
+            data={
+                "tool_name": tool_name,
+                "tool_use_id": tool_use_id,
+                "success": success,
+                "output_preview": output_preview,
+            },
+            execution_id=self._execution_id,
+            phase_id=self._phase_id,
+            workspace_id=self._workspace_id,
+        )
+
+    async def record_subagent_started(
+        self,
+        agent_name: str,
+        tool_use_id: str,
+    ) -> None:
+        """Record subagent started."""
+        if self._writer is None:
+            return
+
+        await self._writer.record_observation(
+            session_id=self._session_id,
+            observation_type=ObservationType.SUBAGENT_STARTED,
+            data={
+                "agent_name": agent_name,
+                "subagent_tool_use_id": tool_use_id,
+            },
+            execution_id=self._execution_id,
+            phase_id=self._phase_id,
+            workspace_id=self._workspace_id,
+        )
+        logger.info("Subagent started: %s (id=%s)", agent_name, tool_use_id)
+
+    async def record_subagent_stopped(
+        self,
+        agent_name: str,
+        tool_use_id: str,
+        duration_ms: int | None,
+        success: bool | None,
+        tools_used: dict[str, int] | None,
+    ) -> None:
+        """Record subagent stopped."""
+        if self._writer is None:
+            return
+
+        await self._writer.record_observation(
+            session_id=self._session_id,
+            observation_type=ObservationType.SUBAGENT_STOPPED,
+            data={
+                "agent_name": agent_name,
+                "subagent_tool_use_id": tool_use_id,
+                "duration_ms": duration_ms,
+                "success": success,
+                "tools_used": tools_used,
+            },
+            execution_id=self._execution_id,
+            phase_id=self._phase_id,
+            workspace_id=self._workspace_id,
+        )
+        logger.info(
+            "Subagent stopped: %s (id=%s, duration=%dms, tools=%s)",
+            agent_name,
+            tool_use_id,
+            duration_ms or 0,
+            tools_used,
+        )
+
+    async def record_embedded_event(
+        self,
+        event_type: str,
+        enriched: dict[str, Any],
+    ) -> None:
+        """Record an embedded event (e.g., git hook events from tool output)."""
+        if self._writer is None:
+            return
+
+        data = {
+            **(enriched.get("context") or {}),
+            **(enriched.get("metadata") or {}),
+        }
+        await self._writer.record_observation(
+            session_id=self._session_id,
+            observation_type=event_type,
+            data=data,
+            execution_id=self._execution_id,
+            phase_id=self._phase_id,
+            workspace_id=self._workspace_id,
+        )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -1,0 +1,537 @@
+"""WorkflowExecutionProcessor — reads to-do list, dispatches to handlers (ISS-196).
+
+Replaces the imperative loop in WorkflowExecutionEngine. Zero business logic.
+All decisions are made by the aggregate (phase sequencing) and the projection
+(to-do list).
+
+Uses in-process synchronous projection for immediate feedback after each save.
+See AGENTS.md "Projection Consistency in Processor Loops".
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+    ExecutablePhase,
+    ExecutionMetrics,
+    PhaseDefinition,
+    PhaseResult,
+)
+from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    CompleteExecutionCommand,
+    CompletePhaseCommand,
+    FailExecutionCommand,
+    StartExecutionCommand,
+    StartPhaseCommand,
+    WorkflowExecutionAggregate,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.ArtifactCollector import (
+    ArtifactCollector,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.ConversationRecorder import (
+    ConversationRecorder,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
+    AgentExecutionHandler,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.ArtifactCollectionHandler import (
+    ArtifactCollectionHandler,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.WorkspaceProvisionHandler import (
+    WorkspaceProvisionHandler,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.ObservabilityCollector import (
+    ObservabilityCollector,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.PhaseResultBuilder import (
+    PhaseResultBuilder,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+    TokenAccumulator,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.SessionLifecycleManager import (
+    SessionLifecycleManager,
+)
+from syn_domain.contexts.orchestration.slices.execution_todo.projection import (
+    ExecutionTodoProjection,
+)
+from syn_domain.contexts.orchestration.slices.execution_todo.value_objects import (
+    TodoAction,
+    TodoItem,
+)
+
+if TYPE_CHECKING:
+    from syn_adapters.control import ExecutionController
+    from syn_adapters.conversations import ConversationStoragePort
+    from syn_adapters.workspace_backends.service import WorkspaceService
+    from syn_domain.contexts.agent_sessions.domain.aggregate_session.AgentSessionAggregate import (
+        AgentSessionAggregate,
+    )
+    from syn_domain.contexts.artifacts.domain.aggregate_artifact.ArtifactAggregate import (
+        ArtifactAggregate,
+    )
+    from syn_domain.contexts.artifacts.domain.ports.artifact_storage import (
+        ArtifactContentStoragePort,
+    )
+    from syn_domain.contexts.artifacts.domain.services.artifact_query_service import (
+        ArtifactQueryServiceProtocol,
+    )
+    from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProcessor import (
+        ObservabilityRecorder,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class WorkflowExecutionRepository:
+    """Protocol for WorkflowExecution aggregate repository."""
+
+    async def save(self, aggregate: WorkflowExecutionAggregate) -> None: ...
+    async def get_by_id(self, execution_id: str) -> WorkflowExecutionAggregate | None: ...
+
+
+@dataclass(frozen=True)
+class WorkflowExecutionResult:
+    """Immutable execution outcome."""
+
+    workflow_id: str
+    execution_id: str
+    status: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    phase_results: list[PhaseResult] = field(default_factory=list)
+    artifact_ids: list[str] = field(default_factory=list)
+    metrics: ExecutionMetrics = field(default_factory=ExecutionMetrics)
+    error_message: str | None = None
+
+
+class WorkflowExecutionProcessor:
+    """Reads the to-do list and dispatches to handlers. Zero business logic.
+
+    Uses an in-process synchronous projection for immediate feedback.
+    After each aggregate save, uncommitted events are applied directly
+    to the local todo projection.
+    """
+
+    def __init__(
+        self,
+        execution_repository: Any,
+        session_repository: Any,
+        workspace_service: WorkspaceService,
+        artifact_repository: Any,
+        artifact_content_storage: ArtifactContentStoragePort | None,
+        artifact_query: ArtifactQueryServiceProtocol | None,
+        conversation_storage: ConversationStoragePort | None,
+        observability_writer: ObservabilityRecorder | None,
+        controller: ExecutionController | None,
+        prompt_builder: Any,
+        command_builder: Any,
+    ) -> None:
+        self._execution_repo = execution_repository
+        self._session_repo = session_repository
+        self._workspace_service = workspace_service
+        self._artifact_repo = artifact_repository
+        self._artifact_content_storage = artifact_content_storage
+        self._artifact_query = artifact_query
+        self._conversation_storage = conversation_storage
+        self._observability_writer = observability_writer
+        self._controller = controller
+        self._prompt_builder = prompt_builder
+        self._command_builder = command_builder
+
+        # In-process synchronous projection — immediate feedback
+        self._todo_projection = ExecutionTodoProjection()
+
+        # Infrastructure state (not domain state — ephemeral)
+        self._active_workspaces: dict[str, Any] = {}  # phase_id → workspace
+        self._active_envs: dict[str, dict[str, str]] = {}  # phase_id → env
+        self._active_cmds: dict[str, list[str]] = {}  # phase_id → cmd
+
+    async def run(
+        self,
+        workflow_id: str,
+        workflow_name: str,
+        phases: list[ExecutablePhase],
+        inputs: dict[str, Any],
+        execution_id: str,
+        repo_url: str | None = None,
+        expected_completion_at: datetime | None = None,
+    ) -> WorkflowExecutionResult:
+        """Execute a workflow using the Processor To-Do List pattern.
+
+        Args:
+            workflow_id: Workflow template ID
+            workflow_name: Workflow name
+            phases: Ordered list of executable phases
+            inputs: Workflow inputs
+            execution_id: Pre-generated execution ID
+            repo_url: Optional repository URL
+            expected_completion_at: For stale detection
+
+        Returns:
+            WorkflowExecutionResult with final state
+        """
+        started_at = datetime.now(UTC)
+        aggregate = WorkflowExecutionAggregate()
+
+        # Build phase definitions for aggregate intelligence
+        phase_definitions = [
+            PhaseDefinition(
+                phase_id=p.phase_id,
+                name=p.name,
+                order=p.order,
+                timeout_seconds=p.timeout_seconds or p.agent_config.timeout_seconds,
+            )
+            for p in phases
+        ]
+        phase_map = {p.phase_id: p for p in phases}
+
+        # Start execution
+        start_cmd = StartExecutionCommand(
+            execution_id=execution_id,
+            workflow_id=workflow_id,
+            workflow_name=workflow_name,
+            total_phases=len(phases),
+            inputs=inputs,
+            expected_completion_at=expected_completion_at,
+            phase_definitions=phase_definitions,
+        )
+        aggregate._handle_command(start_cmd)
+        await self._save_and_sync(aggregate)
+
+        # Tracking state derived from events during processing
+        phase_results: list[PhaseResult] = []
+        all_artifact_ids: list[str] = []
+        completed_phase_ids: list[str] = []
+        phase_outputs: dict[str, str] = {}
+
+        try:
+            # Main processor loop
+            while True:
+                todos = self._todo_projection.get_pending(execution_id)
+                if not todos:
+                    break
+
+                todo = todos[0]
+                await self._dispatch(
+                    todo=todo,
+                    aggregate=aggregate,
+                    phase_map=phase_map,
+                    phase_results=phase_results,
+                    all_artifact_ids=all_artifact_ids,
+                    completed_phase_ids=completed_phase_ids,
+                    phase_outputs=phase_outputs,
+                    repo_url=repo_url,
+                )
+
+            # Complete execution
+            metrics = ExecutionMetrics.from_results(phase_results)
+            complete_cmd = CompleteExecutionCommand(
+                execution_id=execution_id,
+                completed_phases=metrics.completed_phases,
+                total_phases=len(phases),
+                total_input_tokens=metrics.total_input_tokens,
+                total_output_tokens=metrics.total_output_tokens,
+                total_cost_usd=metrics.total_cost_usd,
+                duration_seconds=metrics.total_duration_seconds,
+                artifact_ids=all_artifact_ids,
+            )
+            aggregate._handle_command(complete_cmd)
+            await self._save_and_sync(aggregate)
+
+            return WorkflowExecutionResult(
+                workflow_id=workflow_id,
+                execution_id=execution_id,
+                status="completed",
+                started_at=started_at,
+                completed_at=datetime.now(UTC),
+                phase_results=phase_results,
+                artifact_ids=all_artifact_ids,
+                metrics=metrics,
+            )
+
+        except Exception as e:
+            # Fail execution
+            fail_cmd = FailExecutionCommand(
+                execution_id=execution_id,
+                error=str(e),
+                error_type=type(e).__name__,
+                failed_phase_id=None,
+                completed_phases=len(completed_phase_ids),
+                total_phases=len(phases),
+            )
+            try:
+                aggregate._handle_command(fail_cmd)
+                await self._save_and_sync(aggregate)
+            except Exception as save_err:
+                logger.error("Failed to save failure event: %s", save_err)
+
+            return WorkflowExecutionResult(
+                workflow_id=workflow_id,
+                execution_id=execution_id,
+                status="failed",
+                started_at=started_at,
+                completed_at=datetime.now(UTC),
+                phase_results=phase_results,
+                artifact_ids=all_artifact_ids,
+                metrics=ExecutionMetrics.from_results(phase_results),
+                error_message=str(e),
+            )
+
+    async def _dispatch(
+        self,
+        todo: TodoItem,
+        aggregate: WorkflowExecutionAggregate,
+        phase_map: dict[str, ExecutablePhase],
+        phase_results: list[PhaseResult],
+        all_artifact_ids: list[str],
+        completed_phase_ids: list[str],
+        phase_outputs: dict[str, str],
+        repo_url: str | None,
+    ) -> None:
+        """Dispatch a single to-do item to its handler."""
+        assert todo.phase_id is not None
+        phase = phase_map[todo.phase_id]
+
+        if todo.action == TodoAction.PROVISION_WORKSPACE:
+            await self._handle_provision(todo, phase, aggregate, repo_url,
+                                         completed_phase_ids, phase_outputs)
+
+        elif todo.action == TodoAction.RUN_AGENT:
+            await self._handle_run_agent(todo, phase, aggregate)
+
+        elif todo.action == TodoAction.COLLECT_ARTIFACTS:
+            await self._handle_collect_artifacts(
+                todo, phase, aggregate, all_artifact_ids, phase_outputs,
+            )
+
+        elif todo.action == TodoAction.COMPLETE_PHASE:
+            await self._handle_complete_phase(
+                todo, phase, aggregate, phase_results, completed_phase_ids,
+            )
+
+        elif todo.action == TodoAction.COMPLETE_EXECUTION:
+            pass  # Handled in the main loop after todos are empty
+
+    async def _handle_provision(
+        self,
+        todo: TodoItem,
+        phase: ExecutablePhase,
+        aggregate: WorkflowExecutionAggregate,
+        repo_url: str | None,
+        completed_phase_ids: list[str],
+        phase_outputs: dict[str, str],
+    ) -> None:
+        """Dispatch PROVISION_WORKSPACE."""
+        assert todo.phase_id is not None
+        session_id = str(uuid4())
+
+        # Start phase in aggregate
+        start_cmd = StartPhaseCommand(
+            execution_id=todo.execution_id,
+            workflow_id=aggregate.workflow_id or "",
+            phase_id=todo.phase_id,
+            phase_name=phase.name,
+            phase_order=phase.order,
+            session_id=session_id,
+        )
+        aggregate._handle_command(start_cmd)
+
+        # Start session for observability
+        session_mgr = SessionLifecycleManager(
+            repository=self._session_repo,
+            session_id=session_id,
+            workflow_id=aggregate.workflow_id or "",
+            execution_id=todo.execution_id,
+            phase_id=todo.phase_id,
+            agent_provider=phase.agent_config.provider,
+            agent_model=phase.agent_config.model,
+        )
+        await session_mgr.start()
+
+        # Create provision handler and run
+        artifacts = ArtifactCollector(
+            self._artifact_repo, self._artifact_content_storage, self._artifact_query,
+        )
+        provision_handler = WorkspaceProvisionHandler(
+            workspace_service=self._workspace_service,
+            prompt_builder=self._prompt_builder,
+            command_builder=self._command_builder,
+        )
+
+        result = await provision_handler.handle(
+            todo=todo,
+            phase=phase,
+            workflow_id=aggregate.workflow_id or "",
+            session_id=session_id,
+            repo_url=repo_url,
+            artifacts=artifacts,
+            completed_phase_ids=completed_phase_ids,
+            phase_outputs=phase_outputs,
+        )
+
+        # Store infrastructure state
+        self._active_workspaces[todo.phase_id] = result.workspace
+        self._active_envs[todo.phase_id] = result.agent_env
+        self._active_cmds[todo.phase_id] = result.claude_cmd
+
+        # Report to aggregate
+        aggregate._handle_command(result.command)
+        await self._save_and_sync(aggregate)
+
+    async def _handle_run_agent(
+        self,
+        todo: TodoItem,
+        phase: ExecutablePhase,
+        aggregate: WorkflowExecutionAggregate,
+    ) -> None:
+        """Dispatch RUN_AGENT."""
+        assert todo.phase_id is not None
+        workspace = self._active_workspaces[todo.phase_id]
+        agent_env = self._active_envs[todo.phase_id]
+        claude_cmd = self._active_cmds[todo.phase_id]
+
+        # Create collector for Lane 2
+        collector = ObservabilityCollector(
+            writer=self._observability_writer,
+            session_id=todo.session_id or "",
+            execution_id=todo.execution_id,
+            phase_id=todo.phase_id,
+            workspace_id=getattr(workspace, "id", None),
+            agent_model=phase.agent_config.model,
+        )
+
+        agent_handler = AgentExecutionHandler(controller=self._controller)
+        result = await agent_handler.handle(
+            todo=todo,
+            workspace=workspace,
+            agent_env=agent_env,
+            claude_cmd=claude_cmd,
+            session_id=todo.session_id or "",
+            agent_model=phase.agent_config.model,
+            timeout_seconds=phase.timeout_seconds or phase.agent_config.timeout_seconds,
+            collector=collector,
+        )
+
+        # Report to aggregate
+        aggregate._handle_command(result.command)
+        await self._save_and_sync(aggregate)
+
+    async def _handle_collect_artifacts(
+        self,
+        todo: TodoItem,
+        phase: ExecutablePhase,
+        aggregate: WorkflowExecutionAggregate,
+        all_artifact_ids: list[str],
+        phase_outputs: dict[str, str],
+    ) -> None:
+        """Dispatch COLLECT_ARTIFACTS."""
+        assert todo.phase_id is not None
+        workspace = self._active_workspaces[todo.phase_id]
+
+        artifacts = ArtifactCollector(
+            self._artifact_repo, self._artifact_content_storage, self._artifact_query,
+        )
+        collection_handler = ArtifactCollectionHandler(artifact_collector=artifacts)
+        result = await collection_handler.handle(
+            todo=todo,
+            workspace=workspace,
+            workflow_id=aggregate.workflow_id or "",
+            session_id=todo.session_id or "",
+            phase_name=phase.name,
+            output_artifact_type=phase.output_artifact_type,
+        )
+
+        all_artifact_ids.extend(result.artifact_ids)
+        if result.first_content:
+            phase_outputs[todo.phase_id] = result.first_content
+
+        # Report to aggregate — this triggers NextPhaseReady decision
+        aggregate._handle_command(result.command)
+        await self._save_and_sync(aggregate)
+
+    async def _handle_complete_phase(
+        self,
+        todo: TodoItem,
+        phase: ExecutablePhase,
+        aggregate: WorkflowExecutionAggregate,
+        phase_results: list[PhaseResult],
+        completed_phase_ids: list[str],
+    ) -> None:
+        """Dispatch COMPLETE_PHASE."""
+        assert todo.phase_id is not None
+
+        # Build phase result
+        # TODO(#196): Track started_at and tokens from aggregate events
+        result = PhaseResultBuilder.success(
+            phase_id=todo.phase_id,
+            started_at=datetime.now(UTC),
+            session_id=todo.session_id or "",
+            artifact_ids=[],
+            tokens=TokenAccumulator(),
+        )
+        phase_results.append(result)
+        completed_phase_ids.append(todo.phase_id)
+
+        # Emit CompletePhaseCommand
+        complete_cmd = CompletePhaseCommand(
+            execution_id=todo.execution_id,
+            workflow_id=aggregate.workflow_id or "",
+            phase_id=todo.phase_id,
+            session_id=todo.session_id,
+            artifact_id=None,
+            input_tokens=0,
+            output_tokens=0,
+            total_tokens=0,
+            cost_usd=Decimal("0"),
+            duration_seconds=0.0,
+        )
+        aggregate._handle_command(complete_cmd)
+        await self._save_and_sync(aggregate)
+
+        # Clean up infrastructure state
+        self._active_workspaces.pop(todo.phase_id, None)
+        self._active_envs.pop(todo.phase_id, None)
+        self._active_cmds.pop(todo.phase_id, None)
+
+    async def _save_and_sync(self, aggregate: WorkflowExecutionAggregate) -> None:
+        """Save aggregate and synchronously update local projection.
+
+        This is the key to immediate feedback — we don't wait for the
+        persistent projection to catch up. Instead, we apply uncommitted
+        events directly to our local projection instance.
+        """
+        # Read uncommitted events BEFORE save (save clears them)
+        uncommitted = list(aggregate._uncommitted_events)
+
+        await self._execution_repo.save(aggregate)
+
+        # Apply to local projection for immediate feedback
+        for envelope in uncommitted:
+            event = envelope.event
+            event_type = getattr(event, "event_type", type(event).__name__)
+            # Convert to dict for projection handler
+            event_data = event.model_dump() if hasattr(event, "model_dump") else {}
+            # Use auto-dispatch — the projection has on_<snake_case> methods
+            handler_name = self._event_type_to_handler(event_type)
+            handler = getattr(self._todo_projection, handler_name, None)
+            if handler:
+                await handler(event_data)
+
+    @staticmethod
+    def _event_type_to_handler(event_type: str) -> str:
+        """Convert CamelCase event type to on_snake_case handler name.
+
+        E.g., 'WorkflowExecutionStarted' → 'on_workflow_execution_started'
+        """
+        import re
+
+        # Insert underscore before uppercase letters (except first)
+        snake = re.sub(r"(?<!^)(?=[A-Z])", "_", event_type).lower()
+        return f"on_{snake}"

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
@@ -1,0 +1,137 @@
+"""AgentExecutionHandler — launches container, streams output (ISS-196).
+
+Extracted from WorkflowExecutionEngine stream processing section (lines 961-1001).
+Delegates telemetry to ObservabilityCollector.
+
+Reports AgentExecutionCompletedCommand to the aggregate.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    AgentExecutionCompletedCommand,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProcessor import (
+    EventStreamProcessor,
+    StreamResult,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.SubagentTracker import (
+    SubagentTracker,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+    TokenAccumulator,
+)
+
+if TYPE_CHECKING:
+    from syn_adapters.control import ExecutionController
+    from syn_domain.contexts.orchestration.slices.execute_workflow.ObservabilityCollector import (
+        ObservabilityCollector,
+    )
+    from syn_domain.contexts.orchestration.slices.execution_todo.value_objects import (
+        TodoItem,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class AgentExecutionResult:
+    """Result of agent execution."""
+
+    __slots__ = ("stream_result", "tokens", "subagents", "command")
+
+    def __init__(
+        self,
+        stream_result: StreamResult,
+        tokens: TokenAccumulator,
+        subagents: SubagentTracker,
+        command: AgentExecutionCompletedCommand,
+    ) -> None:
+        self.stream_result = stream_result
+        self.tokens = tokens
+        self.subagents = subagents
+        self.command = command
+
+
+class AgentExecutionHandler:
+    """Launches agent in container, streams output via EventStreamProcessor.
+
+    Reports AgentExecutionCompletedCommand.
+    """
+
+    def __init__(
+        self,
+        controller: ExecutionController | None,
+    ) -> None:
+        self._controller = controller
+
+    async def handle(
+        self,
+        todo: TodoItem,
+        workspace: Any,
+        agent_env: dict[str, str],
+        claude_cmd: list[str],
+        session_id: str,
+        agent_model: str,
+        timeout_seconds: int,
+        collector: ObservabilityCollector | None = None,
+    ) -> AgentExecutionResult:
+        """Run agent in workspace and stream output.
+
+        Args:
+            todo: The to-do item being processed
+            workspace: Active workspace with stream() method
+            agent_env: Environment variables for the agent
+            claude_cmd: Claude CLI command to execute
+            session_id: Session ID for observability
+            agent_model: Agent model name
+            timeout_seconds: Phase timeout
+            collector: Observability collector for Lane 2 telemetry
+
+        Returns:
+            AgentExecutionResult with stream result, tokens, and aggregate command
+        """
+        assert todo.phase_id is not None
+
+        tokens = TokenAccumulator()
+        subagents = SubagentTracker()
+
+        processor = EventStreamProcessor(
+            tokens=tokens,
+            subagents=subagents,
+            observability=None,  # Not used when collector is provided
+            controller=self._controller,
+            execution_id=todo.execution_id,
+            phase_id=todo.phase_id,
+            session_id=session_id,
+            workspace_id=getattr(workspace, "id", None),
+            agent_model=agent_model,
+            collector=collector,
+        )
+
+        stream_result = await processor.process_stream(
+            workspace.stream(
+                claude_cmd,
+                timeout_seconds=timeout_seconds,
+                environment=agent_env,
+            ),
+            workspace,
+        )
+
+        command = AgentExecutionCompletedCommand(
+            execution_id=todo.execution_id,
+            phase_id=todo.phase_id,
+            session_id=session_id,
+            exit_code=0 if not stream_result.interrupt_requested else 1,
+            input_tokens=tokens.input_tokens,
+            output_tokens=tokens.output_tokens,
+        )
+
+        return AgentExecutionResult(
+            stream_result=stream_result,
+            tokens=tokens,
+            subagents=subagents,
+            command=command,
+        )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/ArtifactCollectionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/ArtifactCollectionHandler.py
@@ -1,0 +1,98 @@
+"""ArtifactCollectionHandler — gathers outputs, creates artifact aggregates (ISS-196).
+
+Extracted from WorkflowExecutionEngine artifact collection (lines 1017-1036).
+
+Reports ArtifactsCollectedCommand to the aggregate.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    ArtifactsCollectedCommand,
+)
+
+if TYPE_CHECKING:
+    from syn_domain.contexts.orchestration.slices.execute_workflow.ArtifactCollector import (
+        ArtifactCollector,
+    )
+    from syn_domain.contexts.orchestration.slices.execution_todo.value_objects import (
+        TodoItem,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class ArtifactCollectionResult:
+    """Result of artifact collection."""
+
+    __slots__ = ("artifact_ids", "first_content", "command")
+
+    def __init__(
+        self,
+        artifact_ids: list[str],
+        first_content: str | None,
+        command: ArtifactsCollectedCommand,
+    ) -> None:
+        self.artifact_ids = artifact_ids
+        self.first_content = first_content
+        self.command = command
+
+
+class ArtifactCollectionHandler:
+    """Gathers outputs from workspace, creates artifact aggregates.
+
+    Reports ArtifactsCollectedCommand.
+    """
+
+    def __init__(self, artifact_collector: ArtifactCollector) -> None:
+        self._collector = artifact_collector
+
+    async def handle(
+        self,
+        todo: TodoItem,
+        workspace: Any,
+        workflow_id: str,
+        session_id: str,
+        phase_name: str,
+        output_artifact_type: str,
+    ) -> ArtifactCollectionResult:
+        """Collect artifacts from workspace after agent execution.
+
+        Args:
+            todo: The to-do item being processed
+            workspace: Active workspace with file access
+            workflow_id: Workflow ID
+            session_id: Session ID
+            phase_name: Phase name for artifact metadata
+            output_artifact_type: Type of output artifact
+
+        Returns:
+            ArtifactCollectionResult with artifact IDs and aggregate command
+        """
+        assert todo.phase_id is not None
+
+        collected = await self._collector.collect_from_workspace(
+            workspace=workspace,
+            workflow_id=workflow_id,
+            phase_id=todo.phase_id,
+            execution_id=todo.execution_id,
+            session_id=session_id,
+            phase_name=phase_name,
+            output_artifact_type=output_artifact_type,
+        )
+
+        command = ArtifactsCollectedCommand(
+            execution_id=todo.execution_id,
+            phase_id=todo.phase_id,
+            artifact_ids=collected.artifact_ids,
+            first_content_preview=collected.first_content[:500] if collected.first_content else None,
+        )
+
+        return ArtifactCollectionResult(
+            artifact_ids=collected.artifact_ids,
+            first_content=collected.first_content,
+            command=command,
+        )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/WorkspaceProvisionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/WorkspaceProvisionHandler.py
@@ -1,0 +1,189 @@
+"""WorkspaceProvisionHandler — creates workspace and injects secrets/artifacts (ISS-196).
+
+Extracted from WorkflowExecutionEngine._setup_workspace_for_phase() and
+workspace creation (lines 944-958, 1147-1217).
+
+Reports ProvisionWorkspaceCompletedCommand to the aggregate.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Protocol
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    ProvisionWorkspaceCompletedCommand,
+)
+
+if TYPE_CHECKING:
+    from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+        ExecutablePhase,
+    )
+    from syn_domain.contexts.orchestration.slices.execute_workflow.ArtifactCollector import (
+        ArtifactCollector,
+    )
+    from syn_domain.contexts.orchestration.slices.execution_todo.value_objects import (
+        TodoItem,
+    )
+
+logger = logging.getLogger(__name__)
+
+_SKIP_URLS = frozenset(
+    {
+        "https://github.com/placeholder/not-configured",
+        "https://github.com/example/repo",
+    }
+)
+
+
+class WorkspaceServiceProtocol(Protocol):
+    """Protocol for workspace creation."""
+
+    def create_workspace(
+        self,
+        execution_id: str,
+        workflow_id: str,
+        phase_id: str,
+        with_sidecar: bool = False,
+        inject_tokens: bool = False,
+    ) -> Any: ...
+
+
+class ProvisionResult:
+    """Result of workspace provisioning."""
+
+    __slots__ = ("workspace", "agent_env", "claude_cmd", "command")
+
+    def __init__(
+        self,
+        workspace: Any,
+        agent_env: dict[str, str],
+        claude_cmd: list[str],
+        command: ProvisionWorkspaceCompletedCommand,
+    ) -> None:
+        self.workspace = workspace
+        self.agent_env = agent_env
+        self.claude_cmd = claude_cmd
+        self.command = command
+
+
+class WorkspaceProvisionHandler:
+    """Creates workspace, injects secrets/artifacts, builds CLI command.
+
+    Reports ProvisionWorkspaceCompletedCommand.
+    """
+
+    def __init__(
+        self,
+        workspace_service: WorkspaceServiceProtocol,
+        prompt_builder: Any,
+        command_builder: Any,
+    ) -> None:
+        self._workspace_service = workspace_service
+        self._prompt_builder = prompt_builder
+        self._command_builder = command_builder
+
+    async def handle(
+        self,
+        todo: TodoItem,
+        phase: ExecutablePhase,
+        workflow_id: str,
+        session_id: str,
+        repo_url: str | None,
+        artifacts: ArtifactCollector,
+        completed_phase_ids: list[str],
+        phase_outputs: dict[str, str],
+    ) -> ProvisionResult:
+        """Provision workspace for a phase.
+
+        Args:
+            todo: The to-do item being processed
+            phase: Phase definition
+            workflow_id: Workflow ID
+            session_id: Session ID for observability
+            repo_url: Repository URL (if configured)
+            artifacts: Artifact collector for injection
+            completed_phase_ids: Previously completed phase IDs
+            phase_outputs: Phase output cache for injection
+
+        Returns:
+            ProvisionResult with workspace, env, command, and aggregate command
+        """
+        from syn_adapters.workspace_backends.service import SetupPhaseSecrets
+
+        assert todo.phase_id is not None
+
+        workspace = await self._workspace_service.create_workspace(
+            execution_id=todo.execution_id,
+            workflow_id=workflow_id,
+            phase_id=todo.phase_id,
+            with_sidecar=False,
+            inject_tokens=False,
+        )
+
+        # Parse repo for secrets
+        _repo = self._parse_repo(repo_url)
+
+        secrets = await SetupPhaseSecrets.create(
+            repository=_repo,
+            require_github=_repo is not None,
+        )
+
+        setup_result = await workspace.run_setup_phase(secrets)
+        if setup_result.exit_code != 0:
+            msg = f"Setup phase failed: {setup_result.stderr}"
+            raise RuntimeError(msg)
+        logger.info("Setup phase completed, secrets cleared")
+
+        # Inject artifacts from previous phases
+        await artifacts.inject_from_previous_phases_explicit(
+            workspace, completed_phase_ids, phase_outputs,
+        )
+
+        # Build prompt and CLI command
+        prompt = await self._prompt_builder(phase, todo.execution_id, workflow_id, repo_url, phase_outputs)
+        claude_cmd = self._command_builder(phase, prompt)
+
+        # Validate authentication
+        if not secrets.claude_code_oauth_token and not secrets.anthropic_api_key:
+            msg = (
+                "No Claude authentication configured. "
+                "Set CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY in environment."
+            )
+            raise RuntimeError(msg)
+
+        agent_env: dict[str, str] = {
+            "CLAUDE_SESSION_ID": session_id,
+        }
+        if secrets.claude_code_oauth_token:
+            agent_env["CLAUDE_CODE_OAUTH_TOKEN"] = secrets.claude_code_oauth_token
+        if secrets.anthropic_api_key:
+            agent_env["ANTHROPIC_API_KEY"] = secrets.anthropic_api_key
+
+        workspace_id = getattr(workspace, "id", todo.phase_id)
+
+        command = ProvisionWorkspaceCompletedCommand(
+            execution_id=todo.execution_id,
+            phase_id=todo.phase_id,
+            workspace_id=str(workspace_id),
+        )
+
+        return ProvisionResult(
+            workspace=workspace,
+            agent_env=agent_env,
+            claude_cmd=claude_cmd,
+            command=command,
+        )
+
+    @staticmethod
+    def _parse_repo(repo_url: str | None) -> str | None:
+        """Parse owner/repo from URL."""
+        if not repo_url:
+            return None
+        normalized = repo_url.rstrip("/")
+        if normalized in _SKIP_URLS:
+            return None
+        parts = normalized.split("/")
+        if len(parts) >= 2:
+            return f"{parts[-2]}/{parts[-1]}"
+        return None

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/__init__.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/__init__.py
@@ -1,0 +1,33 @@
+"""Infrastructure handlers for the Processor To-Do List pattern (ISS-196).
+
+Each handler is single-responsibility, <200 LOC, and independently testable.
+Handlers do infrastructure work and report results back via aggregate commands.
+"""
+
+from __future__ import annotations
+
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.ArtifactCollectionHandler import (
+    ArtifactCollectionHandler,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
+    AgentExecutionHandler,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.WorkspaceProvisionHandler import (
+    WorkspaceProvisionHandler,
+)
+from syn_domain.contexts.orchestration.slices.execution_todo.value_objects import (
+    TodoAction,
+)
+
+HANDLER_REGISTRY: dict[TodoAction, type] = {
+    TodoAction.PROVISION_WORKSPACE: WorkspaceProvisionHandler,
+    TodoAction.RUN_AGENT: AgentExecutionHandler,
+    TodoAction.COLLECT_ARTIFACTS: ArtifactCollectionHandler,
+}
+
+__all__ = [
+    "HANDLER_REGISTRY",
+    "AgentExecutionHandler",
+    "ArtifactCollectionHandler",
+    "WorkspaceProvisionHandler",
+]

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_handlers.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_handlers.py
@@ -1,0 +1,238 @@
+"""Unit tests for infrastructure handlers (ISS-196).
+
+Tests that each handler is independently testable and issues
+correct commands back to the aggregate.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    AgentExecutionCompletedCommand,
+    ArtifactsCollectedCommand,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProcessor import (
+    StreamResult,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
+    AgentExecutionHandler,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.ArtifactCollectionHandler import (
+    ArtifactCollectionHandler,
+)
+from syn_domain.contexts.orchestration.slices.execution_todo.value_objects import (
+    TodoAction,
+    TodoItem,
+)
+
+
+# =========================================================================
+# AgentExecutionHandler
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestAgentExecutionHandler:
+    """Tests for AgentExecutionHandler."""
+
+    @pytest.mark.anyio
+    async def test_issues_completed_command(self) -> None:
+        """Handler returns AgentExecutionCompletedCommand after execution."""
+        handler = AgentExecutionHandler(controller=None)
+
+        # Mock workspace
+        workspace = MagicMock()
+
+        async def _fake_stream() -> None:
+            return  # yields nothing
+
+        # Patch EventStreamProcessor to avoid actual streaming
+        mock_stream_result = StreamResult(
+            line_count=10,
+            interrupt_requested=False,
+            interrupt_reason=None,
+            agent_task_result=None,
+            conversation_lines=["line1"],
+        )
+
+        with patch(
+            "syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler.EventStreamProcessor"
+        ) as MockProcessor:
+            mock_instance = AsyncMock()
+            mock_instance.process_stream.return_value = mock_stream_result
+            MockProcessor.return_value = mock_instance
+
+            todo = TodoItem(
+                execution_id="exec-1",
+                action=TodoAction.RUN_AGENT,
+                phase_id="p-1",
+                workspace_id="ws-1",
+            )
+
+            result = await handler.handle(
+                todo=todo,
+                workspace=workspace,
+                agent_env={"CLAUDE_SESSION_ID": "sess-1"},
+                claude_cmd=["claude", "--model", "haiku"],
+                session_id="sess-1",
+                agent_model="claude-haiku",
+                timeout_seconds=300,
+            )
+
+        assert isinstance(result.command, AgentExecutionCompletedCommand)
+        assert result.command.aggregate_id == "exec-1"
+        assert result.command.phase_id == "p-1"
+        assert result.command.session_id == "sess-1"
+        assert result.command.exit_code == 0
+
+    @pytest.mark.anyio
+    async def test_interrupt_sets_exit_code_1(self) -> None:
+        """Interrupted execution sets exit_code to 1."""
+        handler = AgentExecutionHandler(controller=None)
+        workspace = MagicMock()
+
+        mock_stream_result = StreamResult(
+            line_count=5,
+            interrupt_requested=True,
+            interrupt_reason="User cancelled",
+            agent_task_result=None,
+        )
+
+        with patch(
+            "syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler.EventStreamProcessor"
+        ) as MockProcessor:
+            mock_instance = AsyncMock()
+            mock_instance.process_stream.return_value = mock_stream_result
+            MockProcessor.return_value = mock_instance
+
+            todo = TodoItem(
+                execution_id="exec-1",
+                action=TodoAction.RUN_AGENT,
+                phase_id="p-1",
+            )
+
+            result = await handler.handle(
+                todo=todo,
+                workspace=workspace,
+                agent_env={},
+                claude_cmd=["claude"],
+                session_id="sess-1",
+                agent_model="claude-haiku",
+                timeout_seconds=300,
+            )
+
+        assert result.command.exit_code == 1
+        assert result.stream_result.interrupt_requested is True
+
+
+# =========================================================================
+# ArtifactCollectionHandler
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestArtifactCollectionHandler:
+    """Tests for ArtifactCollectionHandler."""
+
+    @pytest.mark.anyio
+    async def test_issues_artifacts_collected_command(self) -> None:
+        """Handler returns ArtifactsCollectedCommand after collection."""
+        from syn_domain.contexts.orchestration.slices.execute_workflow.ArtifactCollector import (
+            CollectedArtifacts,
+        )
+
+        mock_collector = AsyncMock()
+        mock_collector.collect_from_workspace.return_value = CollectedArtifacts(
+            artifact_ids=["art-1", "art-2"],
+            first_content="Result content here",
+        )
+
+        handler = ArtifactCollectionHandler(artifact_collector=mock_collector)
+
+        todo = TodoItem(
+            execution_id="exec-1",
+            action=TodoAction.COLLECT_ARTIFACTS,
+            phase_id="p-1",
+        )
+
+        result = await handler.handle(
+            todo=todo,
+            workspace=MagicMock(),
+            workflow_id="wf-1",
+            session_id="sess-1",
+            phase_name="Research",
+            output_artifact_type="text",
+        )
+
+        assert isinstance(result.command, ArtifactsCollectedCommand)
+        assert result.command.aggregate_id == "exec-1"
+        assert result.command.phase_id == "p-1"
+        assert result.command.artifact_ids == ["art-1", "art-2"]
+        assert result.command.first_content_preview == "Result content here"
+        assert result.artifact_ids == ["art-1", "art-2"]
+        assert result.first_content == "Result content here"
+
+    @pytest.mark.anyio
+    async def test_empty_artifacts(self) -> None:
+        """Handler handles case with no artifacts collected."""
+        from syn_domain.contexts.orchestration.slices.execute_workflow.ArtifactCollector import (
+            CollectedArtifacts,
+        )
+
+        mock_collector = AsyncMock()
+        mock_collector.collect_from_workspace.return_value = CollectedArtifacts(
+            artifact_ids=[],
+            first_content=None,
+        )
+
+        handler = ArtifactCollectionHandler(artifact_collector=mock_collector)
+
+        todo = TodoItem(
+            execution_id="exec-1",
+            action=TodoAction.COLLECT_ARTIFACTS,
+            phase_id="p-1",
+        )
+
+        result = await handler.handle(
+            todo=todo,
+            workspace=MagicMock(),
+            workflow_id="wf-1",
+            session_id="sess-1",
+            phase_name="Research",
+            output_artifact_type="text",
+        )
+
+        assert result.command.artifact_ids == []
+        assert result.command.first_content_preview is None
+
+
+# =========================================================================
+# Handler registry
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestHandlerRegistry:
+    """Tests for the handler registry."""
+
+    def test_registry_has_all_actions(self) -> None:
+        """HANDLER_REGISTRY maps all infrastructure actions."""
+        from syn_domain.contexts.orchestration.slices.execute_workflow.handlers import (
+            HANDLER_REGISTRY,
+        )
+
+        assert TodoAction.PROVISION_WORKSPACE in HANDLER_REGISTRY
+        assert TodoAction.RUN_AGENT in HANDLER_REGISTRY
+        assert TodoAction.COLLECT_ARTIFACTS in HANDLER_REGISTRY
+
+    def test_registry_excludes_domain_actions(self) -> None:
+        """COMPLETE_PHASE and COMPLETE_EXECUTION are domain-only (no handler)."""
+        from syn_domain.contexts.orchestration.slices.execute_workflow.handlers import (
+            HANDLER_REGISTRY,
+        )
+
+        assert TodoAction.COMPLETE_PHASE not in HANDLER_REGISTRY
+        assert TodoAction.COMPLETE_EXECUTION not in HANDLER_REGISTRY

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_observability_collector.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_observability_collector.py
@@ -1,0 +1,177 @@
+"""Unit tests for ObservabilityCollector (ISS-196).
+
+Tests Lane 2 telemetry recording — never touches domain aggregates.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from syn_domain.contexts.agent_sessions.domain.events.agent_observation import (
+    ObservationType,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.ObservabilityCollector import (
+    ObservabilityCollector,
+)
+
+
+def _make_collector(
+    writer: Any = None,
+) -> ObservabilityCollector:
+    """Create a collector with default test values."""
+    return ObservabilityCollector(
+        writer=writer,
+        session_id="sess-1",
+        execution_id="exec-1",
+        phase_id="phase-1",
+        workspace_id="ws-1",
+        agent_model="claude-haiku",
+    )
+
+
+@pytest.mark.unit
+class TestObservabilityCollectorWithWriter:
+    """Tests with an active writer."""
+
+    @pytest.mark.anyio
+    async def test_record_hook_event(self) -> None:
+        """record_hook_event delegates to writer."""
+        writer = AsyncMock()
+        collector = _make_collector(writer=writer)
+
+        enriched = {
+            "event_type": "tool_execution_started",
+            "context": {"tool_name": "Read", "tool_use_id": "t-1"},
+            "metadata": {"model": "claude-haiku"},
+        }
+        await collector.record_hook_event(enriched)
+
+        writer.record_observation.assert_called_once()
+        call = writer.record_observation.call_args
+        assert call.kwargs["observation_type"] == "tool_execution_started"
+        assert call.kwargs["session_id"] == "sess-1"
+        assert call.kwargs["execution_id"] == "exec-1"
+
+    @pytest.mark.anyio
+    async def test_record_token_usage(self) -> None:
+        """record_token_usage writes TOKEN_USAGE observation."""
+        writer = AsyncMock()
+        collector = _make_collector(writer=writer)
+
+        await collector.record_token_usage(100, 50, cache_creation=10, cache_read=20)
+
+        writer.record_observation.assert_called_once()
+        call = writer.record_observation.call_args
+        assert call.kwargs["observation_type"] == ObservationType.TOKEN_USAGE
+        data = call.kwargs["data"]
+        assert data["input_tokens"] == 100
+        assert data["output_tokens"] == 50
+        assert data["cache_creation_tokens"] == 10
+        assert data["cache_read_tokens"] == 20
+        assert data["model"] == "claude-haiku"
+
+    @pytest.mark.anyio
+    async def test_record_tool_started(self) -> None:
+        """record_tool_started writes TOOL_EXECUTION_STARTED."""
+        writer = AsyncMock()
+        collector = _make_collector(writer=writer)
+
+        await collector.record_tool_started("Read", "t-1", '{"file_path": "/foo"}')
+
+        call = writer.record_observation.call_args
+        assert call.kwargs["observation_type"] == ObservationType.TOOL_EXECUTION_STARTED
+        assert call.kwargs["data"]["tool_name"] == "Read"
+
+    @pytest.mark.anyio
+    async def test_record_tool_completed(self) -> None:
+        """record_tool_completed writes TOOL_EXECUTION_COMPLETED."""
+        writer = AsyncMock()
+        collector = _make_collector(writer=writer)
+
+        await collector.record_tool_completed("Read", "t-1", success=True, output_preview="ok")
+
+        call = writer.record_observation.call_args
+        assert call.kwargs["observation_type"] == ObservationType.TOOL_EXECUTION_COMPLETED
+        assert call.kwargs["data"]["success"] is True
+
+    @pytest.mark.anyio
+    async def test_record_subagent_started(self) -> None:
+        """record_subagent_started writes SUBAGENT_STARTED."""
+        writer = AsyncMock()
+        collector = _make_collector(writer=writer)
+
+        await collector.record_subagent_started("test-agent", "t-1")
+
+        call = writer.record_observation.call_args
+        assert call.kwargs["observation_type"] == ObservationType.SUBAGENT_STARTED
+        assert call.kwargs["data"]["agent_name"] == "test-agent"
+
+    @pytest.mark.anyio
+    async def test_record_subagent_stopped(self) -> None:
+        """record_subagent_stopped writes SUBAGENT_STOPPED."""
+        writer = AsyncMock()
+        collector = _make_collector(writer=writer)
+
+        await collector.record_subagent_stopped(
+            agent_name="test-agent",
+            tool_use_id="t-1",
+            duration_ms=500,
+            success=True,
+            tools_used={"Read": 2, "Edit": 1},
+        )
+
+        call = writer.record_observation.call_args
+        assert call.kwargs["observation_type"] == ObservationType.SUBAGENT_STOPPED
+        assert call.kwargs["data"]["duration_ms"] == 500
+
+    @pytest.mark.anyio
+    async def test_record_embedded_event(self) -> None:
+        """record_embedded_event writes arbitrary event type."""
+        writer = AsyncMock()
+        collector = _make_collector(writer=writer)
+
+        enriched = {
+            "context": {"commit_sha": "abc123"},
+            "metadata": {"hook": "post-commit"},
+        }
+        await collector.record_embedded_event("git.commit", enriched)
+
+        call = writer.record_observation.call_args
+        assert call.kwargs["observation_type"] == "git.commit"
+        assert call.kwargs["data"]["commit_sha"] == "abc123"
+
+
+@pytest.mark.unit
+class TestObservabilityCollectorNullWriter:
+    """Tests with None writer — all methods are no-op."""
+
+    @pytest.mark.anyio
+    async def test_record_hook_event_noop(self) -> None:
+        """record_hook_event is no-op with None writer."""
+        collector = _make_collector(writer=None)
+        await collector.record_hook_event({"event_type": "test"})
+        # No exception = success
+
+    @pytest.mark.anyio
+    async def test_record_token_usage_noop(self) -> None:
+        """record_token_usage is no-op with None writer."""
+        collector = _make_collector(writer=None)
+        await collector.record_token_usage(100, 50)
+
+    @pytest.mark.anyio
+    async def test_record_tool_started_noop(self) -> None:
+        """All record methods are safe with None writer."""
+        collector = _make_collector(writer=None)
+        await collector.record_tool_started("Read", "t-1", "preview")
+        await collector.record_tool_completed("Read", "t-1", True, "output")
+        await collector.record_subagent_started("agent", "t-1")
+        await collector.record_subagent_stopped("agent", "t-1", 100, True, {"Read": 1})
+        await collector.record_embedded_event("test", {"context": {}})
+
+    def test_has_writer_property(self) -> None:
+        """has_writer reflects writer presence."""
+        assert not _make_collector(writer=None).has_writer
+        assert _make_collector(writer=AsyncMock()).has_writer

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_workflow_execution_processor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_workflow_execution_processor.py
@@ -1,0 +1,156 @@
+"""Unit tests for WorkflowExecutionProcessor (ISS-196).
+
+Tests the Processor To-Do List pattern end-to-end with mocked infrastructure.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from syn_domain.contexts.orchestration.slices.execute_workflow.WorkflowExecutionProcessor import (
+    WorkflowExecutionProcessor,
+)
+
+
+def _make_processor() -> WorkflowExecutionProcessor:
+    """Create a processor with mocked dependencies."""
+    return WorkflowExecutionProcessor(
+        execution_repository=AsyncMock(),
+        session_repository=AsyncMock(),
+        workspace_service=MagicMock(),
+        artifact_repository=AsyncMock(),
+        artifact_content_storage=None,
+        artifact_query=None,
+        conversation_storage=None,
+        observability_writer=None,
+        controller=None,
+        prompt_builder=AsyncMock(return_value="test prompt"),
+        command_builder=MagicMock(return_value=["claude", "--model", "haiku"]),
+    )
+
+
+@pytest.mark.unit
+class TestProcessorDispatching:
+    """Tests for processor dispatch logic."""
+
+    def test_event_type_to_handler_conversion(self) -> None:
+        """CamelCase event types convert to on_snake_case handlers."""
+        convert = WorkflowExecutionProcessor._event_type_to_handler
+        assert convert("WorkflowExecutionStarted") == "on_workflow_execution_started"
+        assert convert("PhaseCompleted") == "on_phase_completed"
+        assert convert("NextPhaseReady") == "on_next_phase_ready"
+        assert convert("WorkspaceProvisionedForPhase") == "on_workspace_provisioned_for_phase"
+        assert convert("ArtifactsCollectedForPhase") == "on_artifacts_collected_for_phase"
+        assert convert("AgentExecutionCompleted") == "on_agent_execution_completed"
+
+
+@pytest.mark.unit
+class TestProcessorTermination:
+    """Tests for processor termination."""
+
+    @pytest.mark.anyio
+    async def test_processor_terminates_when_no_todos(self) -> None:
+        """Processor terminates when to-do list is empty after start."""
+        processor = _make_processor()
+
+        # Mock save to be a no-op (aggregate events won't trigger real projection)
+        processor._execution_repo.save = AsyncMock()
+
+        # Patch _save_and_sync to just save without projection sync
+        # This simulates a scenario where no phase_definitions are provided (legacy)
+        from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+            ExecutablePhase,
+        )
+
+        result = await processor.run(
+            workflow_id="wf-1",
+            workflow_name="Test",
+            phases=[
+                ExecutablePhase(
+                    phase_id="p-1",
+                    name="Research",
+                    order=1,
+                    prompt_template="Do research",
+                ),
+            ],
+            inputs={"topic": "test"},
+            execution_id="exec-1",
+        )
+
+        # Legacy mode (no phase_definitions on ExecutablePhase) — processor
+        # creates PhaseDefinition from the phases list, so it WILL have
+        # phase_definitions and the projection WILL create todos.
+        # Since we haven't mocked the handlers, this will fail at provisioning.
+        # The important thing is that the processor caught the error and returned failed.
+        assert result.execution_id == "exec-1"
+        assert result.workflow_id == "wf-1"
+
+    @pytest.mark.anyio
+    async def test_processor_handles_failure_gracefully(self) -> None:
+        """Processor returns failed result on exception."""
+        processor = _make_processor()
+        processor._execution_repo.save = AsyncMock()
+
+        from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+            ExecutablePhase,
+        )
+
+        # This will fail at provisioning since workspace_service is a MagicMock
+        result = await processor.run(
+            workflow_id="wf-1",
+            workflow_name="Test",
+            phases=[
+                ExecutablePhase(
+                    phase_id="p-1",
+                    name="Research",
+                    order=1,
+                    prompt_template="Do research",
+                ),
+            ],
+            inputs={},
+            execution_id="exec-fail",
+        )
+
+        assert result.status == "failed"
+        assert result.error_message is not None
+
+
+@pytest.mark.unit
+class TestProcessorProjectionSync:
+    """Tests for in-process synchronous projection."""
+
+    @pytest.mark.anyio
+    async def test_save_and_sync_applies_events_to_projection(self) -> None:
+        """_save_and_sync applies uncommitted events to local projection."""
+        processor = _make_processor()
+        processor._execution_repo.save = AsyncMock()
+
+        from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+            PhaseDefinition,
+        )
+        from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+            StartExecutionCommand,
+            WorkflowExecutionAggregate,
+        )
+
+        aggregate = WorkflowExecutionAggregate()
+        cmd = StartExecutionCommand(
+            execution_id="exec-sync",
+            workflow_id="wf-1",
+            workflow_name="Test",
+            total_phases=1,
+            inputs={},
+            phase_definitions=[
+                PhaseDefinition(phase_id="p-1", name="Research", order=1),
+            ],
+        )
+        aggregate._handle_command(cmd)
+
+        await processor._save_and_sync(aggregate)
+
+        # The local projection should now have a todo
+        todos = processor._todo_projection.get_pending("exec-sync")
+        assert len(todos) == 1
+        assert todos[0].phase_id == "p-1"

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_todo/__init__.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_todo/__init__.py
@@ -1,0 +1,4 @@
+"""Execution to-do list projection (ISS-196).
+
+Drives the Processor To-Do List pattern for workflow execution.
+"""

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_todo/projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_todo/projection.py
@@ -1,0 +1,186 @@
+"""Execution to-do list projection (ISS-196).
+
+Builds a list of pending work items from domain events. The processor
+reads this list and dispatches to infrastructure handlers.
+
+Designed for two usage modes:
+1. In-process synchronous: processor applies events locally after each save
+2. Persistent: catches up asynchronously for external consumers
+
+See AGENTS.md "Projection Consistency in Processor Loops".
+"""
+
+from __future__ import annotations
+
+from event_sourcing import AutoDispatchProjection
+
+from syn_domain.contexts.orchestration.slices.execution_todo.value_objects import (
+    TodoAction,
+    TodoItem,
+)
+
+
+class ExecutionTodoProjection(AutoDispatchProjection):
+    """To-do list read model for workflow execution processing.
+
+    Maintains pending work items per execution. The processor reads
+    get_pending() and dispatches each item to its handler.
+
+    Thread-safety: designed for single-processor use. Each processor
+    instance owns its own projection instance.
+    """
+
+    PROJECTION_NAME = "execution_todo"
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Initialize with empty to-do state."""
+        # execution_id → list of pending TodoItems
+        self._todos: dict[str, list[TodoItem]] = {}
+
+    def get_name(self) -> str:
+        """Unique projection name for checkpoint tracking."""
+        return self.PROJECTION_NAME
+
+    def get_version(self) -> int:
+        """Schema version."""
+        return self.VERSION
+
+    async def clear_all_data(self) -> None:
+        """Clear all to-do data (for rebuild)."""
+        self._todos.clear()
+
+    # =========================================================================
+    # Query interface
+    # =========================================================================
+
+    def get_pending(self, execution_id: str) -> list[TodoItem]:
+        """Get all pending to-do items for an execution.
+
+        Returns items in insertion order (FIFO).
+        """
+        return list(self._todos.get(execution_id, []))
+
+    # =========================================================================
+    # Event handlers
+    # =========================================================================
+
+    async def on_workflow_execution_started(self, event_data: dict) -> None:
+        """Execution started → provision workspace for first phase."""
+        execution_id = event_data.get("execution_id", "")
+        if not execution_id:
+            return
+
+        phase_defs = event_data.get("phase_definitions") or []
+        if not phase_defs:
+            return  # Legacy mode — no to-do list management
+
+        # Sort by order, take first phase
+        sorted_phases = sorted(phase_defs, key=lambda p: p.get("order", 0))
+        first_phase = sorted_phases[0]
+
+        self._todos[execution_id] = [
+            TodoItem(
+                execution_id=execution_id,
+                action=TodoAction.PROVISION_WORKSPACE,
+                phase_id=first_phase["phase_id"],
+            ),
+        ]
+
+    async def on_workspace_provisioned_for_phase(self, event_data: dict) -> None:
+        """Workspace ready → run agent."""
+        execution_id = event_data.get("execution_id", "")
+        if not execution_id:
+            return
+
+        self._replace_todo(
+            execution_id,
+            TodoItem(
+                execution_id=execution_id,
+                action=TodoAction.RUN_AGENT,
+                phase_id=event_data.get("phase_id"),
+                workspace_id=event_data.get("workspace_id"),
+            ),
+        )
+
+    async def on_agent_execution_completed(self, event_data: dict) -> None:
+        """Agent finished → collect artifacts."""
+        execution_id = event_data.get("execution_id", "")
+        if not execution_id:
+            return
+
+        self._replace_todo(
+            execution_id,
+            TodoItem(
+                execution_id=execution_id,
+                action=TodoAction.COLLECT_ARTIFACTS,
+                phase_id=event_data.get("phase_id"),
+                session_id=event_data.get("session_id"),
+            ),
+        )
+
+    async def on_artifacts_collected_for_phase(self, event_data: dict) -> None:
+        """Artifacts collected → complete phase."""
+        execution_id = event_data.get("execution_id", "")
+        if not execution_id:
+            return
+
+        self._replace_todo(
+            execution_id,
+            TodoItem(
+                execution_id=execution_id,
+                action=TodoAction.COMPLETE_PHASE,
+                phase_id=event_data.get("phase_id"),
+            ),
+        )
+
+    async def on_phase_completed(self, event_data: dict) -> None:
+        """Phase completed → remove to-do (next phase decided by aggregate)."""
+        execution_id = event_data.get("execution_id", "")
+        if not execution_id:
+            return
+
+        # Clear current to-do — NextPhaseReady or COMPLETE_EXECUTION comes next
+        self._todos.pop(execution_id, None)
+
+    async def on_next_phase_ready(self, event_data: dict) -> None:
+        """Aggregate decided next phase → provision workspace for it."""
+        execution_id = event_data.get("execution_id", "")
+        if not execution_id:
+            return
+
+        self._todos[execution_id] = [
+            TodoItem(
+                execution_id=execution_id,
+                action=TodoAction.PROVISION_WORKSPACE,
+                phase_id=event_data.get("next_phase_id"),
+            ),
+        ]
+
+    async def on_workflow_completed(self, event_data: dict) -> None:
+        """Workflow completed → clear all todos."""
+        execution_id = event_data.get("execution_id", "")
+        self._todos.pop(execution_id, None)
+
+    async def on_workflow_failed(self, event_data: dict) -> None:
+        """Workflow failed → clear all todos."""
+        execution_id = event_data.get("execution_id", "")
+        self._todos.pop(execution_id, None)
+
+    async def on_execution_cancelled(self, event_data: dict) -> None:
+        """Execution cancelled → clear all todos."""
+        execution_id = event_data.get("execution_id", "")
+        self._todos.pop(execution_id, None)
+
+    async def on_workflow_interrupted(self, event_data: dict) -> None:
+        """Workflow interrupted → clear all todos."""
+        execution_id = event_data.get("execution_id", "")
+        self._todos.pop(execution_id, None)
+
+    # =========================================================================
+    # Internal
+    # =========================================================================
+
+    def _replace_todo(self, execution_id: str, new_todo: TodoItem) -> None:
+        """Replace all pending todos for an execution with a single new one."""
+        self._todos[execution_id] = [new_todo]

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_todo/test_execution_todo_projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_todo/test_execution_todo_projection.py
@@ -1,0 +1,227 @@
+"""Unit tests for ExecutionTodoProjection (ISS-196).
+
+Tests the to-do list read model that drives the Processor To-Do List pattern.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from syn_domain.contexts.orchestration.slices.execution_todo.projection import (
+    ExecutionTodoProjection,
+)
+from syn_domain.contexts.orchestration.slices.execution_todo.value_objects import (
+    TodoAction,
+)
+
+# =========================================================================
+# Test data
+# =========================================================================
+
+TWO_PHASE_STARTED_EVENT = {
+    "execution_id": "exec-1",
+    "workflow_id": "wf-1",
+    "workflow_name": "Test",
+    "total_phases": 2,
+    "started_at": "2026-03-10T00:00:00Z",
+    "inputs": {},
+    "phase_definitions": [
+        {"phase_id": "p-1", "name": "Research", "order": 1, "timeout_seconds": 300},
+        {"phase_id": "p-2", "name": "Implement", "order": 2, "timeout_seconds": 300},
+    ],
+}
+
+LEGACY_STARTED_EVENT = {
+    "execution_id": "exec-legacy",
+    "workflow_id": "wf-1",
+    "workflow_name": "Legacy",
+    "total_phases": 1,
+    "started_at": "2026-03-10T00:00:00Z",
+    "inputs": {},
+    # No phase_definitions — legacy mode
+}
+
+
+# =========================================================================
+# Full lifecycle test
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestFullLifecycle:
+    """Test complete multi-phase workflow produces correct todo sequence."""
+
+    @pytest.mark.anyio
+    async def test_two_phase_lifecycle(self) -> None:
+        """Full lifecycle: 2-phase workflow produces correct todo sequence."""
+        proj = ExecutionTodoProjection()
+
+        # 1. Execution started → PROVISION_WORKSPACE for phase 1
+        await proj.on_workflow_execution_started(TWO_PHASE_STARTED_EVENT)
+        todos = proj.get_pending("exec-1")
+        assert len(todos) == 1
+        assert todos[0].action == TodoAction.PROVISION_WORKSPACE
+        assert todos[0].phase_id == "p-1"
+
+        # 2. Workspace provisioned → RUN_AGENT
+        await proj.on_workspace_provisioned_for_phase(
+            {"execution_id": "exec-1", "phase_id": "p-1", "workspace_id": "ws-1"}
+        )
+        todos = proj.get_pending("exec-1")
+        assert len(todos) == 1
+        assert todos[0].action == TodoAction.RUN_AGENT
+        assert todos[0].workspace_id == "ws-1"
+
+        # 3. Agent completed → COLLECT_ARTIFACTS
+        await proj.on_agent_execution_completed(
+            {"execution_id": "exec-1", "phase_id": "p-1", "session_id": "sess-1"}
+        )
+        todos = proj.get_pending("exec-1")
+        assert len(todos) == 1
+        assert todos[0].action == TodoAction.COLLECT_ARTIFACTS
+        assert todos[0].session_id == "sess-1"
+
+        # 4. Artifacts collected → COMPLETE_PHASE
+        await proj.on_artifacts_collected_for_phase(
+            {"execution_id": "exec-1", "phase_id": "p-1", "artifact_ids": ["art-1"]}
+        )
+        todos = proj.get_pending("exec-1")
+        assert len(todos) == 1
+        assert todos[0].action == TodoAction.COMPLETE_PHASE
+
+        # 5. Phase completed → cleared
+        await proj.on_phase_completed(
+            {"execution_id": "exec-1", "phase_id": "p-1"}
+        )
+        todos = proj.get_pending("exec-1")
+        assert len(todos) == 0
+
+        # 6. Next phase ready → PROVISION_WORKSPACE for phase 2
+        await proj.on_next_phase_ready(
+            {"execution_id": "exec-1", "next_phase_id": "p-2", "next_phase_order": 2}
+        )
+        todos = proj.get_pending("exec-1")
+        assert len(todos) == 1
+        assert todos[0].action == TodoAction.PROVISION_WORKSPACE
+        assert todos[0].phase_id == "p-2"
+
+        # 7-10. Second phase goes through same lifecycle
+        await proj.on_workspace_provisioned_for_phase(
+            {"execution_id": "exec-1", "phase_id": "p-2", "workspace_id": "ws-2"}
+        )
+        await proj.on_agent_execution_completed(
+            {"execution_id": "exec-1", "phase_id": "p-2", "session_id": "sess-2"}
+        )
+        await proj.on_artifacts_collected_for_phase(
+            {"execution_id": "exec-1", "phase_id": "p-2", "artifact_ids": ["art-2"]}
+        )
+        await proj.on_phase_completed(
+            {"execution_id": "exec-1", "phase_id": "p-2"}
+        )
+        todos = proj.get_pending("exec-1")
+        assert len(todos) == 0
+
+        # 11. Workflow completed → all cleared
+        await proj.on_workflow_completed({"execution_id": "exec-1"})
+        assert proj.get_pending("exec-1") == []
+
+
+# =========================================================================
+# Terminal events clear all todos
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestTerminalEventsClearTodos:
+    """Terminal events should clear all pending todos."""
+
+    @pytest.mark.anyio
+    async def test_workflow_failed_clears(self) -> None:
+        """WorkflowFailed clears all todos."""
+        proj = ExecutionTodoProjection()
+        await proj.on_workflow_execution_started(TWO_PHASE_STARTED_EVENT)
+        assert len(proj.get_pending("exec-1")) == 1
+
+        await proj.on_workflow_failed({"execution_id": "exec-1"})
+        assert proj.get_pending("exec-1") == []
+
+    @pytest.mark.anyio
+    async def test_execution_cancelled_clears(self) -> None:
+        """ExecutionCancelled clears all todos."""
+        proj = ExecutionTodoProjection()
+        await proj.on_workflow_execution_started(TWO_PHASE_STARTED_EVENT)
+        await proj.on_execution_cancelled({"execution_id": "exec-1"})
+        assert proj.get_pending("exec-1") == []
+
+    @pytest.mark.anyio
+    async def test_workflow_interrupted_clears(self) -> None:
+        """WorkflowInterrupted clears all todos."""
+        proj = ExecutionTodoProjection()
+        await proj.on_workflow_execution_started(TWO_PHASE_STARTED_EVENT)
+        await proj.on_workflow_interrupted({"execution_id": "exec-1"})
+        assert proj.get_pending("exec-1") == []
+
+
+# =========================================================================
+# Legacy mode
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestLegacyMode:
+    """Without phase_definitions, projection is no-op."""
+
+    @pytest.mark.anyio
+    async def test_no_phase_definitions_no_todos(self) -> None:
+        """Legacy mode: no phase_definitions → no todos created."""
+        proj = ExecutionTodoProjection()
+        await proj.on_workflow_execution_started(LEGACY_STARTED_EVENT)
+        assert proj.get_pending("exec-legacy") == []
+
+
+# =========================================================================
+# Edge cases
+# =========================================================================
+
+
+@pytest.mark.unit
+class TestEdgeCases:
+    """Edge cases and error handling."""
+
+    @pytest.mark.anyio
+    async def test_empty_execution_id_ignored(self) -> None:
+        """Events with empty execution_id are ignored."""
+        proj = ExecutionTodoProjection()
+        await proj.on_workflow_execution_started({"execution_id": "", "phase_definitions": []})
+        assert proj._todos == {}
+
+    @pytest.mark.anyio
+    async def test_get_pending_unknown_execution(self) -> None:
+        """get_pending for unknown execution returns empty list."""
+        proj = ExecutionTodoProjection()
+        assert proj.get_pending("nonexistent") == []
+
+    @pytest.mark.anyio
+    async def test_clear_all_data(self) -> None:
+        """clear_all_data removes all state."""
+        proj = ExecutionTodoProjection()
+        await proj.on_workflow_execution_started(TWO_PHASE_STARTED_EVENT)
+        assert len(proj.get_pending("exec-1")) == 1
+
+        await proj.clear_all_data()
+        assert proj.get_pending("exec-1") == []
+
+    @pytest.mark.anyio
+    async def test_phases_sorted_by_order(self) -> None:
+        """First phase is determined by order, not list position."""
+        event = {
+            **TWO_PHASE_STARTED_EVENT,
+            "phase_definitions": [
+                {"phase_id": "p-2", "name": "Second", "order": 2},
+                {"phase_id": "p-1", "name": "First", "order": 1},
+            ],
+        }
+        proj = ExecutionTodoProjection()
+        await proj.on_workflow_execution_started(event)
+        todos = proj.get_pending("exec-1")
+        assert todos[0].phase_id == "p-1"

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_todo/value_objects.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_todo/value_objects.py
@@ -1,0 +1,37 @@
+"""Value objects for the execution to-do list projection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class TodoAction(str, Enum):
+    """Action the processor should dispatch for a to-do item.
+
+    Lifecycle per phase:
+        PROVISION_WORKSPACE → RUN_AGENT → COLLECT_ARTIFACTS → COMPLETE_PHASE
+            ↓ (NextPhaseReady? → back to PROVISION_WORKSPACE)
+            ↓ (No more phases? → COMPLETE_EXECUTION)
+    """
+
+    PROVISION_WORKSPACE = "provision_workspace"
+    RUN_AGENT = "run_agent"
+    COLLECT_ARTIFACTS = "collect_artifacts"
+    COMPLETE_PHASE = "complete_phase"
+    COMPLETE_EXECUTION = "complete_execution"
+
+
+@dataclass(frozen=True)
+class TodoItem:
+    """A single pending work item for the processor.
+
+    The processor reads these and dispatches to the appropriate handler.
+    Zero business logic in the processor — all decisions made by the aggregate.
+    """
+
+    execution_id: str
+    action: TodoAction
+    phase_id: str | None = None
+    workspace_id: str | None = None
+    session_id: str | None = None

--- a/uv.lock
+++ b/uv.lock
@@ -1506,7 +1506,7 @@ wheels = [
 
 [[package]]
 name = "syn-adapters"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/syn-adapters" }
 dependencies = [
     { name = "agentic-events" },
@@ -1576,7 +1576,7 @@ provides-extras = ["postgres", "claude", "openai", "agents", "minio", "all"]
 
 [[package]]
 name = "syn-api"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "apps/syn-api" }
 dependencies = [
     { name = "agentic-logging" },
@@ -1605,7 +1605,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-cli"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "apps/syn-cli" }
 dependencies = [
     { name = "httpx" },
@@ -1622,7 +1622,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-collector"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/syn-collector" }
 dependencies = [
     { name = "click" },
@@ -1662,7 +1662,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "syn-domain"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/syn-domain" }
 dependencies = [
     { name = "agentic-events" },
@@ -1683,7 +1683,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-perf"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/syn-perf" }
 dependencies = [
     { name = "rich" },
@@ -1711,7 +1711,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "syn-shared"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/syn-shared" }
 dependencies = [
     { name = "pydantic" },
@@ -1730,7 +1730,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-tokens"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "packages/syn-tokens" }
 dependencies = [
     { name = "pydantic" },
@@ -1747,7 +1747,7 @@ requires-dist = [
 
 [[package]]
 name = "syntropic137"
-version = "0.7.1"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "event-sourcing-python" },


### PR DESCRIPTION
## Summary

- Replaces imperative engine loop with event-driven **Processor To-Do List pattern** (Martin Dilger, Ch. 37)
- Aggregate now owns phase sequencing decisions — emits `NextPhaseReadyEvent` when more phases exist
- Processor reads to-do list projection and dispatches to single-responsibility infrastructure handlers
- ObservabilityCollector enforces Lane 2 separation (telemetry never touches aggregates)

### Milestones Implemented

| # | What | Key Files |
|---|------|-----------|
| M0 | AGENTS.md architecture docs | `AGENTS.md` |
| M1 | 4 new domain events + aggregate phase intelligence | `WorkflowExecutionAggregate.py`, 4 new event files |
| M2 | ExecutionTodoProjection (in-memory to-do list) | `slices/execution_todo/` |
| M3 | ObservabilityCollector (Lane 2 split) | `ObservabilityCollector.py`, refactored `EventStreamProcessor.py` |
| M4 | Infrastructure handlers (<200 LOC each) | `handlers/WorkspaceProvision`, `AgentExecution`, `ArtifactCollection` |
| M5 | WorkflowExecutionProcessor (to-do list driver) | `WorkflowExecutionProcessor.py` |

M6 (legacy engine cleanup) follows separately after E2E validation.

### Stats
- **27 files changed**, 3,247 insertions, 202 deletions
- **47 new tests**, 1,450 total pass, 0 failures
- Existing `WorkflowExecutionEngine` untouched — fully backward compatible

## Test plan

- [x] 47 new unit tests across all milestones
- [x] 263 orchestration context tests pass
- [x] 1,450 project-wide tests pass (0 failures)
- [ ] `just qa` on CI (lint, format, typecheck, test, coverage, vsa-validate)
- [ ] E2E: trigger workflow via API after M6 rewire, verify phases execute in order