### PR TITLE
chore: update AGENTS.md architecture docs + gitignore planning files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,6 @@ HANDOFF-*.md
 /workspaces/
 .playwright-mcp/
 .agentic/
+
+# Root-level planning voice notes (scratch — not committed per AGENTS.md policy)
+/*.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,9 @@ syntropic137/
 ├── apps/
 │   ├── syn-api/               # FastAPI HTTP server (routes + v1 application services)
 │   ├── syn-cli/               # CLI tool ("syn") — HTTP client for syn-api
-│   └── syn-dashboard-ui/      # Dashboard frontend (Vite + React)
+│   ├── syn-dashboard-ui/      # Dashboard frontend (Vite + React) — operational UI
+│   ├── syn-docs/              # Public-facing documentation site (Next.js + Fumadocs)
+│   └── syn-pulse-ui/          # Pulse/heatmap UI
 ├── packages/
 │   ├── syn-domain/            # Domain events, aggregates, ports
 │   ├── syn-adapters/          # Orchestration + observability adapters
@@ -35,8 +37,12 @@ syntropic137/
 │   ├── agentic-primitives/    # Composable agent building blocks, isolation providers
 │   └── event-sourcing-platform/ # ES infrastructure, VSA tool, projections
 ├── infra/                     # Docker Compose, setup wizard, secrets
+├── docs/                      # Internal/local development docs (ADRs, architecture notes,
+│                              #   deployment guides) — NOT the public docs site
 └── docs/adrs/                 # Architecture Decision Records
 ```
+
+> **Docs vs syn-docs:** `docs/` is internal — local dev guides, ADRs, architecture references for contributors. `apps/syn-docs/` is the public-facing documentation site deployed externally. Content for the public docs site lives in `apps/syn-docs/content/`.
 
 ### Submodules (`lib/`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dev = [
     "asyncpg>=0.31.0",
     "testcontainers>=4.13.3",
     "pyright>=1.1.408",
+    "playwright>=1.58.0",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary

- Document `syn-docs` and `syn-pulse-ui` in AGENTS.md repo structure
- Clarify `docs/` (internal dev docs) vs `apps/syn-docs/` (public Fumadocs site) — agents and contributors were missing this distinction
- Add `playwright` to root dev deps (used by `scripts/capture_codecity.py` for codecity flythrough capture)
- Gitignore root-level `*.txt` planning/voice-note files (scratch per AGENTS.md policy)

## Test plan

- [ ] AGENTS.md renders correctly on GitHub
- [ ] `*.txt` files at root no longer show in `git status`