### PR TITLE
fix(health): restore subscription payload + use get_status() (ISS-256)

### DIFF
--- a/apps/syn-api/src/syn_api/v1/lifecycle.py
+++ b/apps/syn-api/src/syn_api/v1/lifecycle.py
@@ -174,9 +174,10 @@ async def health_check(
                 **sub_status,
                 "status": "healthy" if sub_healthy else "degraded",
             }
-            if not sub_healthy and mode == "full":
-                response["mode"] = "degraded"
+            if not sub_healthy:
                 response.setdefault("degraded_reasons", []).append("subscription_coordinator")
+                if mode == "full":
+                    response["mode"] = "degraded"
         except Exception:
             response["subscription"] = {"status": "unknown"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.14.0"
+version = "0.14.1"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Problem

PR #252 (ISS-220) introduced two bugs caught by Copilot review on #254:

1. `_subscription_service.is_healthy` — attribute doesn't exist on the coordinator. Raises `AttributeError` silently swallowed by `except Exception`, so health always returned `{"status": "unknown"}`.
2. The subscription payload was stripped to `{"status": ...}` only, dropping `running`, `projection_count`, `realtime_enabled` — breaking any client reading those fields.

## Fix

- Use `get_status()["running"]` to derive healthy/degraded
- Spread the full `get_status()` payload and add a derived `"status"` field on top
- Append `"subscription_coordinator"` to `degraded_reasons` when not running

Closes #256