### PR TITLE
fix(ci): correct osv-scanner-action path for v1.9.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,9 +356,10 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Run OSV Scanner
-        # TODO(#259): Pin to commit SHA once we confirm v1.9.0 SHA.
-        # Use: gh api repos/google/osv-scanner-action/git/ref/tags/v1.9.0
-        uses: google/osv-scanner-action@v1.9.0
+        # v1.9.0 restructured the repo — root action.yml lost its `runs:` section.
+        # The actual action now lives in the osv-scanner-action/ subdirectory.
+        # SHA confirmed: gh api repos/google/osv-scanner-action/git/ref/tags/v1.9.0
+        uses: google/osv-scanner-action/osv-scanner-action@19ec1116569a47416e11a45848722b1af31a857b # v1.9.0
         continue-on-error: true  # TODO(#259): remove after first clean baseline run
         with:
           scan-args: |-


### PR DESCRIPTION
## Root Cause

`google/osv-scanner-action` restructured their repo in v1.9.0. The root `action.yml` no longer has a `runs:` section — it's now just branding metadata. The actual action moved to the `osv-scanner-action/` subdirectory.

Error seen on all open PRs:
```
##[error]Top level 'runs:' section is required for google/osv-scanner-action/v1.9.0/action.yml
```

## Fix

Change `uses` to point to the correct subdirectory path:
```
google/osv-scanner-action/osv-scanner-action@<SHA> # v1.9.0
```

SHA is identical (`19ec1116...`) — same tag, just the correct path within the repo. Also replaces the TODO comment with an explanation of the v1.9.0 restructure and documents the SHA.

## Impact

Unblocks all open PRs (#264, #266, #267) — they can rebase onto main once this merges.