### PR TITLE
chore: bump version to v0.15.1-beta.1

### DIFF
--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.15.0"
+version = "0.15.1"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli/pyproject.toml
+++ b/apps/syn-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-cli"
-version = "0.15.0"
+version = "0.15.1"
 description = "CLI for Syntropic137 — thin wrapper over syn-api"
 requires-python = ">=3.12"
 

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.15.0",
+  "version": "0.15.1",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-pulse-ui/package.json
+++ b/apps/syn-pulse-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-pulse-ui",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.15.1",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.15.0"
+version = "0.15.1"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.15.0"
+version = "0.15.1"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.15.0"
+version = "0.15.1"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.15.0"
+version = "0.15.1"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 


### PR DESCRIPTION
## Summary
Patch version bump: `0.15.0` → `0.15.1`

Massive fitness refactoring — 107 exceptions eliminated down to 3. Tightened thresholds to industry standards (cognitive ≤15, cyclomatic ≤10). All 5 fitness rules pass with 0 stale exceptions.

## Updated packages
- syn-api, syn-cli, syn-domain, syn-adapters, syn-shared, syn-collector (pyproject.toml)
- syn-dashboard-ui, syn-pulse-ui (package.json)

## Test plan
- [x] `just fitness-check` — 5/5 pass
- [ ] CI passes