### PR TITLE
chore: sync package-lock.json with v0.15.1

### DIFF
--- a/apps/syn-dashboard-ui/package-lock.json
+++ b/apps/syn-dashboard-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "syn-dashboard-ui",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "syn-dashboard-ui",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "clsx": "^2.1.1",
         "html2canvas": "^1.4.1",

--- a/apps/syn-pulse-ui/package-lock.json
+++ b/apps/syn-pulse-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "syn-pulse-ui",
-  "version": "0.12.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "syn-pulse-ui",
-      "version": "0.12.0",
+      "version": "0.15.1",
       "dependencies": {
         "@nivo/calendar": "^0.99.0",
         "@nivo/core": "^0.99.0",


### PR DESCRIPTION
Version bump updated package.json but package-lock.json files weren't committed.