### PR TITLE
fix(ci): cosign v2 bundle format for release assets signing

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -380,7 +380,7 @@ jobs:
         env:
           COSIGN_YES: "true"
         working-directory: /tmp/release-assets
-        run: cosign sign-blob --output-signature SHA256SUMS.sig --output-certificate SHA256SUMS.pem SHA256SUMS
+        run: cosign sign-blob --bundle SHA256SUMS.bundle SHA256SUMS
 
       # -----------------------------------------------------------------------
       # Attach assets to GitHub release
@@ -395,8 +395,7 @@ jobs:
             /tmp/release-assets/selfhost-entrypoint.sh \
             /tmp/release-assets/syn-ctl \
             /tmp/release-assets/SHA256SUMS \
-            /tmp/release-assets/SHA256SUMS.sig \
-            /tmp/release-assets/SHA256SUMS.pem \
+            /tmp/release-assets/SHA256SUMS.bundle \
             --clobber
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

cosign v2 deprecated `--output-signature`/`--output-certificate` flags. Use `--bundle` instead.

All 8 container images built and pushed successfully — this only fixes the release assets signing step.

## Test plan

- [ ] Merge, retag v0.16.2, re-run release — release assets should attach to the GitHub release