### PR TITLE
chore: add screenshots/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,7 @@ DEEP-DIVE_*.md
 .topology/
 
 # Browser testing screenshots
+screenshots/
 /assets/
 build/
 HANDOFF-*.md


### PR DESCRIPTION
## Summary
- Add `screenshots/` to `.gitignore` to exclude browser QA screenshots from version control

## Test plan
- Verify `screenshots/` directory is no longer tracked