### PR TITLE
feat(adapters): accept file: path, raw PEM, and base64 for private key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,9 +113,10 @@ LOG_FORMAT=json
 # AGENT CONFIGURATION
 # ============================================================================
 
-# Anthropic API key for Claude models. Get from:
-# https://console.anthropic.com/settings/keys Required when using Claude agent
-# adapter (unless CLAUDE_CODE_OAUTH_TOKEN is set).
+# Anthropic API key. Used when CLAUDE_CODE_OAUTH_TOKEN is not set. Get from:
+# https://console.anthropic.com/settings/keys. At least one of
+# ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN is required for agent
+# execution.
 ANTHROPIC_API_KEY=
 
 # Default timeout for agent operations in seconds.
@@ -177,8 +178,10 @@ SYN_WORKSPACE_CONTAINER_DIR=
 # Docker. Example: /Users/user/repo/workspaces or ${PWD}/workspaces
 SYN_WORKSPACE_HOST_DIR=
 
-# Claude Code OAuth token for Claude models. Obtained via Claude Code OAuth
-# flow. If set, takes priority over ANTHROPIC_API_KEY.
+# Claude Code OAuth token. Takes priority over ANTHROPIC_API_KEY when both are
+# set. Obtain via: claude setup (Claude Code OAuth flow). At least one of
+# CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY is required for agent
+# execution.
 CLAUDE_CODE_OAUTH_TOKEN=
 
 # URL for the Collector service (Pattern 2: Event Log + CQRS). Format:
@@ -223,9 +226,11 @@ SYN_GITHUB_APP_ID=
 # '<app_name>[bot]'.
 SYN_GITHUB_APP_NAME=syn-app
 
-# GitHub App private key, base64-encoded. Download the .pem from:
-# https://github.com/settings/apps/<app>/privatekeys Encode it: cat your-
-# app.pem | base64 | tr -d '\n' | pbcopy Paste the result as the value. Never
+# GitHub App private key. Supports three formats: (1) file:<path> — read PEM
+# from file, e.g. file:infra/docker/secrets/github-private-key.pem; (2) raw
+# PEM starting with '-----BEGIN'; (3) base64-encoded PEM string. Download the
+# .pem from: https://github.com/settings/apps/<app>/privatekeys Simplest:
+# place the .pem in infra/docker/secrets/ and use a file: reference. Never
 # commit the raw key to git!
 SYN_GITHUB_PRIVATE_KEY=
 
@@ -249,42 +254,34 @@ DEV__SMEE_URL=
 # ============================================================================
 # All workspaces are isolated by default. These settings control HOW.
 
-# Isolation backend to use. Default: firecracker (Linux) or gvisor (macOS).
-# Options: firecracker, kata, gvisor, docker_hardened, cloud
+# Isolation backend to use.
 SYN_WORKSPACE_ISOLATION_BACKEND=
 
-# Number of pre-warmed workspace instances. Higher = faster allocation, more
-# memory usage. Set to 0 to disable pre-warming.
+# Number of pre-warmed workspace instances.
 SYN_WORKSPACE_POOL_SIZE=100
 
-# Maximum concurrent workspaces. Requests beyond this will queue or overflow
-# to cloud.
+# Maximum concurrent workspaces.
 SYN_WORKSPACE_MAX_CONCURRENT=1000
 
-# Enable cloud overflow when local capacity exceeded. Requires cloud_api_key
-# to be set.
+# Enable cloud overflow when local capacity exceeded.
 SYN_WORKSPACE_ENABLE_CLOUD_OVERFLOW=true
 
 # Cloud provider for overflow: e2b or modal.
 SYN_WORKSPACE_CLOUD_PROVIDER=e2b
 
-# API key for cloud sandbox provider. Required when enable_cloud_overflow is
-# True. Get from: https://e2b.dev or https://modal.com
+# API key for cloud sandbox provider.
 SYN_WORKSPACE_CLOUD_API_KEY=
 
 # Cloud sandbox template/environment name.
 SYN_WORKSPACE_CLOUD_TEMPLATE=syn-workspace
 
-# Docker image for Claude agent execution. Includes Claude CLI with
-# agentic_events hooks (ADR-029). Build with: just workspace-build
+# Docker image for Claude agent execution.
 SYN_WORKSPACE_DOCKER_IMAGE=agentic-workspace-claude-cli:latest
 
-# Docker runtime to use. runsc = gVisor (stronger isolation), runc = native
-# (faster, weaker isolation)
+# Docker runtime to use (runsc = gVisor, runc = native).
 SYN_WORKSPACE_DOCKER_RUNTIME=runsc
 
-# Docker network for containers. Default: none (full network isolation). Use
-# 'bridge' with allowed_hosts for controlled access.
+# Docker network for containers.
 SYN_WORKSPACE_DOCKER_NETWORK=none
 
 # ============================================================================
@@ -330,18 +327,13 @@ SYN_SECURITY_MAX_EXECUTION_TIME=3600
 # ============================================================================
 # Git identity for agent commits. Prefer GitHub App for authentication.
 
-# Git committer name (user.name). Example: 'syn-bot[bot]' for automated
-# commits. Required for commits - will fail if not configured.
+# Git committer name (user.name).
 SYN_GIT_USER_NAME=
 
-# Git committer email (user.email). Example: 'bot@syntropic137.com' or GitHub
-# noreply address. Required for commits - will fail if not configured.
+# Git committer email (user.email).
 SYN_GIT_USER_EMAIL=
 
-# GitHub Personal Access Token for HTTPS authentication. Required scopes: repo
-# (for private repos). Get from: https://github.com/settings/tokens Stored in
-# ~/.git-credentials inside container. NOTE: For production, prefer GitHub App
-# (SYN_GITHUB_*) over PAT.
+# GitHub PAT for HTTPS authentication.
 SYN_GIT_TOKEN=
 
 # ============================================================================
@@ -349,12 +341,10 @@ SYN_GIT_TOKEN=
 # ============================================================================
 # Controls logging inside isolated containers for observability.
 
-# Minimum log level for container logs. DEBUG for development, INFO for
-# production.
+# Minimum log level for container logs.
 SYN_LOGGING_LEVEL=INFO
 
-# Log format: 'json' for structured logs (parsing), 'text' for human-readable
-# (debugging).
+# Log format: 'json' for structured, 'text' for human-readable.
 SYN_LOGGING_FORMAT=json
 
 # Log shell commands executed in container.
@@ -366,14 +356,13 @@ SYN_LOGGING_LOG_TOOL_CALLS=true
 # Log API calls (Claude, GitHub, etc). Disabled by default - can be verbose.
 SYN_LOGGING_LOG_API_CALLS=false
 
-# Redact sensitive data in logs (API keys, tokens, passwords). ALWAYS enabled
-# in production. Cannot be disabled in prod.
+# Redact sensitive data in logs (API keys, tokens, passwords).
 SYN_LOGGING_REDACT_SECRETS=true
 
 # Regex patterns for secret redaction.
 SYN_LOGGING_REDACTION_PATTERNS=
 
-# Log file path inside container. Directory is created on workspace startup.
+# Log file path inside container.
 SYN_LOGGING_LOG_FILE_PATH=/workspace/.logs/agent.jsonl
 
 # Max log file size in MB before rotation.

--- a/docs/deployment/github-app-security.md
+++ b/docs/deployment/github-app-security.md
@@ -61,13 +61,17 @@ This document describes how Syn137 securely integrates with GitHub using GitHub 
 ### 1. Private Key (Master Secret)
 
 - **What**: RSA private key in PEM format
-- **Where**: Vault, AWS Secrets Manager, or base64-encoded in env
+- **Where**: Vault, AWS Secrets Manager, or `file:` path / base64 in env
 - **Lifetime**: Until rotated (recommend: 90 days)
 - **Access**: Control plane only, never in containers
 
 ```bash
-# Generate new private key (done in GitHub App settings)
-# Download .pem file, base64 encode for storage
+# Download .pem from GitHub App settings, then either:
+# Option 1 (recommended): file reference
+cp syn-app.pem infra/docker/secrets/github-private-key.pem
+# SYN_GITHUB_PRIVATE_KEY=file:infra/docker/secrets/github-private-key.pem
+
+# Option 2: base64 encode for inline storage
 cat syn-app.pem | base64 | tr -d '\n'
 ```
 
@@ -234,7 +238,7 @@ See GitHub Issue #24 for multi-tenancy implementation details.
 # Required
 SYN_GITHUB_APP_ID=2461312
 SYN_GITHUB_APP_NAME=aef-engineer-beta
-SYN_GITHUB_PRIVATE_KEY=<base64-encoded-pem>
+SYN_GITHUB_PRIVATE_KEY=file:infra/docker/secrets/github-private-key.pem
 
 # Optional
 SYN_GITHUB_WEBHOOK_SECRET=<hmac-secret>

--- a/docs/deployment/github-app-setup.md
+++ b/docs/deployment/github-app-setup.md
@@ -230,15 +230,16 @@ SYN_GITHUB_WEBHOOK_SECRET=your-webhook-secret
 
 #### For Docker Self-Host
 
-The private key is base64-encoded and stored in `infra/.env` (or resolved
-from 1Password). The `just onboard` wizard handles this automatically.
+The private key is stored in `.env` as a `file:` path reference, raw PEM, or
+base64-encoded string (or resolved from 1Password). The `just onboard` wizard
+handles this automatically.
 
-To encode manually:
+Simplest approach — place the `.pem` in the secrets directory:
 
 ```bash
-# Base64-encode the PEM and add to infra/.env
-base64 < private-key.pem | tr -d '\n'
-# → paste the output as: SYN_GITHUB_PRIVATE_KEY=<base64>
+cp private-key.pem infra/docker/secrets/github-private-key.pem
+# Then set in .env:
+# SYN_GITHUB_PRIVATE_KEY=file:infra/docker/secrets/github-private-key.pem
 ```
 
 Docker Compose passes the env var to the dashboard container. No file-based

--- a/docs/development/1password-secrets.md
+++ b/docs/development/1password-secrets.md
@@ -49,7 +49,7 @@ configured, 1Password takes precedence (existing env vars are never overwritten)
 
 | Secret | Docker secret file | 1Password field | Notes |
 |--------|-------------------|-----------------|-------|
-| **GitHub App PEM** | `github-private-key.pem` (raw PEM) | `SYN_GITHUB_PRIVATE_KEY` (base64-encoded) | Entrypoint auto-encodes the PEM to base64 |
+| **GitHub App PEM** | `github-private-key.pem` (raw PEM) | `SYN_GITHUB_PRIVATE_KEY` (`file:` path, raw PEM, or base64) | Entrypoint reads PEM via `file:` reference |
 | **GitHub webhook secret** | `github-webhook-secret.txt` | `SYN_GITHUB_WEBHOOK_SECRET` | Plain text |
 | **DB password** | `db-password.txt` | Not needed — entrypoint builds `DATABASE_URL` from the file | |
 | **Redis password** | `redis-password.txt` | Not needed — entrypoint builds `REDIS_URL` from the file | |
@@ -89,7 +89,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 That's it. The selfhost entrypoint reads the secret files and exports:
-- `github-private-key.pem` → base64-encodes → `SYN_GITHUB_PRIVATE_KEY`
+- `github-private-key.pem` → `file:` reference → `SYN_GITHUB_PRIVATE_KEY`
 - `github-webhook-secret.txt` → `SYN_GITHUB_WEBHOOK_SECRET`
 - `db-password.txt` → builds `DATABASE_URL`
 - `redis-password.txt` → builds `REDIS_URL`
@@ -101,17 +101,16 @@ The `.pem` file you download from GitHub is a multi-line RSA key file.
 **For Docker secrets (Path A):** Just copy the raw `.pem` file as-is. The
 entrypoint handles the base64 encoding automatically.
 
-**For 1Password (Path B):** You need to base64-encode it first:
+**For 1Password (Path B):** You can store the base64-encoded key or the raw PEM:
 
 ```bash
-# Encode and copy to clipboard (macOS)
+# Option 1: base64-encode and copy to clipboard (macOS)
 cat ~/Downloads/your-app.pem | base64 | tr -d '\n' | pbcopy
 
-# Or encode to stdout (Linux)
-cat ~/Downloads/your-app.pem | base64 -w0
+# Option 2: store raw PEM directly (1Password handles multiline)
 ```
 
-Paste the resulting base64 string as the `SYN_GITHUB_PRIVATE_KEY` field value
+Paste the value as the `SYN_GITHUB_PRIVATE_KEY` field value
 in 1Password.
 
 > **Note:** You still need the raw `.pem` file in `infra/docker/secrets/` even
@@ -221,7 +220,7 @@ op item edit "syntropic137-config" \
   --vault "syn137-dev" \
   'SYN_GITHUB_APP_ID=123456' \
   'SYN_GITHUB_APP_NAME=your-app-name' \
-  'SYN_GITHUB_PRIVATE_KEY=<base64-encoded-pem>' \
+  'SYN_GITHUB_PRIVATE_KEY=file:infra/docker/secrets/github-private-key.pem' \
   'SYN_GITHUB_WEBHOOK_SECRET=<webhook-secret>'
 ```
 
@@ -242,7 +241,7 @@ Each secret is a field on that item, labeled after its env var.
 | `CLAUDE_CODE_OAUTH_TOKEN` | Claude Code OAuth token (alternative) | Claude Code settings |
 | `SYN_GITHUB_APP_ID` | GitHub App numeric ID | GitHub → Settings → Developer Settings → Your App → App ID |
 | `SYN_GITHUB_APP_NAME` | GitHub App slug | Same page, the URL slug (e.g. `syn-engineer-beta`) |
-| `SYN_GITHUB_PRIVATE_KEY` | GitHub App signing key (**base64-encoded**) | `cat your-app.pem \| base64 \| tr -d '\n'` |
+| `SYN_GITHUB_PRIVATE_KEY` | GitHub App signing key (`file:` path, raw PEM, or base64) | Place `.pem` in secrets dir and use `file:` reference |
 | `SYN_GITHUB_WEBHOOK_SECRET` | GitHub webhook HMAC secret | `openssl rand -hex 32` (must match GitHub App settings) |
 | `CLOUDFLARE_TUNNEL_TOKEN` | Cloudflare Tunnel token | Zero Trust → Networks → Connectors → your tunnel → Install |
 

--- a/docs/env-configuration.md
+++ b/docs/env-configuration.md
@@ -107,7 +107,7 @@ For secure, auto-rotating tokens with clear audit trails. See [GitHub App Setup 
 |----------|----------|---------|-------------|--------------|
 | `SYN_GITHUB_APP_ID` | For GitHub App | None | GitHub App ID | [github.com/settings/apps](https://github.com/settings/apps) |
 | `SYN_GITHUB_APP_NAME` | No | `syn-app` | App name for commit attribution (shows as `<name>[bot]`) | Your app's slug |
-| `SYN_GITHUB_PRIVATE_KEY` | For GitHub App | None | PEM-format private key | Generate from app settings |
+| `SYN_GITHUB_PRIVATE_KEY` | For GitHub App | None | `file:` path, raw PEM, or base64 | Download `.pem` from app settings |
 | `SYN_GITHUB_WEBHOOK_SECRET` | For webhooks | None | Webhook signature secret | Set during app creation |
 
 > **Note:** If either of `SYN_GITHUB_APP_ID` or `SYN_GITHUB_PRIVATE_KEY` is set, both are required. Installation IDs are resolved dynamically via `get_installation_for_repo()`.

--- a/docs/testing/e2e_acceptance_tests.md
+++ b/docs/testing/e2e_acceptance_tests.md
@@ -2002,7 +2002,7 @@ Secure token management for agentic operations at scale:
 # GitHub App environment variables
 export SYN_GITHUB_APP_ID=2461312
 export SYN_GITHUB_APP_NAME=aef-engineer-beta
-export SYN_GITHUB_PRIVATE_KEY=$(cat path/to/private-key.pem | base64)
+export SYN_GITHUB_PRIVATE_KEY=file:path/to/private-key.pem
 
 # Verify configuration
 just cli config show | grep GITHUB

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -169,7 +169,7 @@ PG_WORK_MEM=16MB
 ES_BATCH_SIZE=100
 
 # Backup cron schedule.
-BACKUP_SCHEDULE="0 3 * * *"
+BACKUP_SCHEDULE=0 3 * * *
 
 # Number of days to retain backups.
 BACKUP_RETENTION_DAYS=7

--- a/infra/README.md
+++ b/infra/README.md
@@ -114,7 +114,7 @@ Open `infra/.env` and fill in (at minimum):
 # Required for GitHub integration
 SYN_GITHUB_APP_ID=123456
 SYN_GITHUB_APP_NAME=your-app-name
-SYN_GITHUB_PRIVATE_KEY=<base64-encoded PEM>
+SYN_GITHUB_PRIVATE_KEY=file:infra/docker/secrets/github-private-key.pem
 SYN_GITHUB_WEBHOOK_SECRET=<your-webhook-secret>
 
 # Required for agent execution (at least one)
@@ -215,7 +215,7 @@ All configuration lives in `infra/.env`. Copy from `infra/.env.example` to get s
 |----------|----------|---------|-------------|
 | `SYN_GITHUB_APP_ID` | **Yes** | — | Numeric App ID from GitHub Settings |
 | `SYN_GITHUB_APP_NAME` | **Yes** | — | App slug (e.g., `syn-engineer-beta`) |
-| `SYN_GITHUB_PRIVATE_KEY` | **Yes** | — | Base64-encoded RSA PEM. Generate: `base64 < app.pem \| tr -d '\n'` |
+| `SYN_GITHUB_PRIVATE_KEY` | **Yes** | — | `file:` path, raw PEM, or base64-encoded. Simplest: `file:infra/docker/secrets/github-private-key.pem` |
 | `SYN_GITHUB_WEBHOOK_SECRET` | **Yes** | — | Webhook HMAC secret. Generate: `openssl rand -hex 32` |
 
 ### Agent Credentials
@@ -384,7 +384,7 @@ APP_ENVIRONMENT (from root .env — see § Environment Files above)
 |-------------|-------|
 | `SYN_GITHUB_APP_ID` | Your GitHub App numeric ID |
 | `SYN_GITHUB_APP_NAME` | Your GitHub App slug |
-| `SYN_GITHUB_PRIVATE_KEY` | Base64-encoded RSA PEM |
+| `SYN_GITHUB_PRIVATE_KEY` | `file:` path, raw PEM, or base64 |
 | `SYN_GITHUB_WEBHOOK_SECRET` | Webhook HMAC secret |
 | `CLOUDFLARE_TUNNEL_TOKEN` | Cloudflare tunnel token |
 | `ANTHROPIC_API_KEY` | Anthropic API key |

--- a/infra/docs/selfhost-deployment.md
+++ b/infra/docs/selfhost-deployment.md
@@ -67,7 +67,7 @@ just onboard
 ```
 
 This handles:
-- GitHub App private key (base64-encoded into `.env` or resolved from 1Password)
+- GitHub App private key (`file:` path reference, base64, or raw PEM in `.env` — or resolved from 1Password)
 - Webhook secret (generated and stored in `.env` or resolved from 1Password)
 - Cloudflare tunnel token (stored in `.env` or resolved from 1Password)
 
@@ -259,7 +259,7 @@ they never touch the filesystem at all.
 
 | Secret | Env Var | Description |
 |--------|---------|-------------|
-| GitHub private key | `SYN_GITHUB_PRIVATE_KEY` | Base64-encoded PEM |
+| GitHub private key | `SYN_GITHUB_PRIVATE_KEY` | `file:` path, raw PEM, or base64 |
 | Webhook secret | `SYN_GITHUB_WEBHOOK_SECRET` | HMAC signing key |
 | Tunnel token | `CLOUDFLARE_TUNNEL_TOKEN` | Cloudflare tunnel auth |
 
@@ -325,7 +325,7 @@ just selfhost-up
 **What to store in your 1Password `syntropic137-config` item:**
 - `SYN_GITHUB_APP_ID`
 - `SYN_GITHUB_APP_NAME`
-- `SYN_GITHUB_PRIVATE_KEY` (base64-encoded PEM)
+- `SYN_GITHUB_PRIVATE_KEY` (`file:` path, raw PEM, or base64)
 - `SYN_GITHUB_WEBHOOK_SECRET`
 - `CLOUDFLARE_TUNNEL_TOKEN`
 - `ANTHROPIC_API_KEY` or `CLAUDE_CODE_OAUTH_TOKEN`

--- a/infra/scripts/setup.py
+++ b/infra/scripts/setup.py
@@ -114,6 +114,7 @@ class SetupContext:
       github_app_id          — configure_github_app → configure_env
       github_app_name        — configure_github_app → configure_env
       github_private_key_b64 — configure_github_app → configure_env
+      github_private_key_file_ref — configure_github_app → configure_env (preferred over b64)
       github_webhook_secret  — configure_github_app → configure_env
       cloudflare_tunnel_token — configure_cloudflare → configure_env, configure_smee
       syn_domain             — configure_cloudflare → configure_env, print_summary
@@ -131,6 +132,7 @@ class SetupContext:
     github_app_id: str = ""
     github_app_name: str = ""
     github_private_key_b64: str = ""
+    github_private_key_file_ref: str = ""
     github_webhook_secret: str = ""
     cloudflare_tunnel_token: str = ""
     syn_domain: str = ""
@@ -577,7 +579,9 @@ def _persist_github_app_to_env(ctx: SetupContext) -> None:
         env_updates[ENV_GITHUB_APP_ID] = ctx.github_app_id
     if ctx.github_app_name:
         env_updates[ENV_GITHUB_APP_NAME] = ctx.github_app_name
-    if ctx.github_private_key_b64:
+    if ctx.github_private_key_file_ref:
+        env_updates[ENV_GITHUB_PRIVATE_KEY] = ctx.github_private_key_file_ref
+    elif ctx.github_private_key_b64:
         env_updates[ENV_GITHUB_PRIVATE_KEY] = ctx.github_private_key_b64
     if ctx.github_webhook_secret:
         env_updates[ENV_GITHUB_WEBHOOK_SECRET] = ctx.github_webhook_secret
@@ -628,11 +632,14 @@ def _configure_github_app_manifest(ctx: SetupContext) -> bool:
     ctx.github_app_name = result.get("slug", app_name)
 
     # Extract crown-jewel secrets into ctx for .env injection
-    import base64 as _b64
-
     pem = result.get("pem", "")
     if pem:
-        ctx.github_private_key_b64 = _b64.b64encode(pem.encode()).decode()
+        pem_dest = SECRETS_DIR / "github-private-key.pem"
+        SECRETS_DIR.mkdir(parents=True, exist_ok=True)
+        pem_dest.write_text(pem)
+        pem_dest.chmod(0o600)
+        rel_path = pem_dest.relative_to(PROJECT_ROOT)
+        ctx.github_private_key_file_ref = f"file:{rel_path}"
     webhook_secret = result.get("webhook_secret", "")
     if webhook_secret:
         ctx.github_webhook_secret = webhook_secret
@@ -645,8 +652,6 @@ def _configure_github_app_manifest(ctx: SetupContext) -> bool:
 
 def _configure_github_app_manual(ctx: SetupContext) -> bool:
     """Manual GitHub App configuration (existing app)."""
-    import base64
-
     print()
     print("  Enter your existing GitHub App credentials.")
     print("  (Find them at https://github.com/settings/apps)")
@@ -655,28 +660,25 @@ def _configure_github_app_manual(ctx: SetupContext) -> bool:
     ctx.github_app_id = prompt("GitHub App ID (numeric)")
     ctx.github_app_name = prompt("GitHub App name (slug)")
 
-    # Private key — base64-encode and store in ctx for .env
+    # Private key — save to secrets dir and use file: reference in .env
     print()
     pem_dest = SECRETS_DIR / "github-private-key.pem"
-    pem_text = ""
     if pem_dest.exists():
         ok("Private key found at infra/docker/secrets/github-private-key.pem")
-        pem_text = pem_dest.read_text()
     else:
         pem_path = prompt("Path to .pem private key file")
         if pem_path and Path(pem_path).expanduser().exists():
             src = Path(pem_path).expanduser()
-            pem_text = src.read_text()
-            # Keep a backup copy in secrets dir (not consumed by Docker Compose)
             SECRETS_DIR.mkdir(parents=True, exist_ok=True)
             shutil.copy2(src, pem_dest)
-            ok(f"Private key backup saved to {pem_dest}")
+            ok(f"Private key saved to {pem_dest}")
         else:
             warn("Private key not found — you'll need to add it to .env manually")
-            hint("  base64 < /path/to/your-app.pem | tr -d '\\n'")
+            hint("  SYN_GITHUB_PRIVATE_KEY=file:infra/docker/secrets/github-private-key.pem")
 
-    if pem_text:
-        ctx.github_private_key_b64 = base64.b64encode(pem_text.encode()).decode()
+    if pem_dest.exists():
+        rel_path = pem_dest.relative_to(PROJECT_ROOT)
+        ctx.github_private_key_file_ref = f"file:{rel_path}"
 
     # Webhook secret — generate or read existing, store in ctx for .env
     import secrets as _secrets
@@ -744,7 +746,9 @@ def configure_env(ctx: SetupContext) -> bool:
         root_subs[ENV_GITHUB_APP_ID] = ctx.github_app_id
     if ctx.github_app_name:
         root_subs[ENV_GITHUB_APP_NAME] = ctx.github_app_name
-    if ctx.github_private_key_b64:
+    if ctx.github_private_key_file_ref:
+        root_subs[ENV_GITHUB_PRIVATE_KEY] = ctx.github_private_key_file_ref
+    elif ctx.github_private_key_b64:
         root_subs[ENV_GITHUB_PRIVATE_KEY] = ctx.github_private_key_b64
     if ctx.github_webhook_secret:
         root_subs[ENV_GITHUB_WEBHOOK_SECRET] = ctx.github_webhook_secret
@@ -893,8 +897,26 @@ def _audit_github_app(ctx: SetupContext) -> tuple[int, int]:
     )
     pem_path = SECRETS_DIR / "github-private-key.pem"
 
-    if pem_b64:
-        # Env var path: base64-encoded PEM — decode and validate
+    if pem_b64 and pem_b64.startswith("file:"):
+        # file: reference — validate the referenced file
+        ref_path = Path(pem_b64[len("file:") :].strip())
+        if not ref_path.is_absolute():
+            ref_path = PROJECT_ROOT / ref_path
+        if ref_path.exists():
+            content = ref_path.read_text()
+            if "BEGIN RSA PRIVATE KEY" in content or "BEGIN PRIVATE KEY" in content:
+                ok(f"Private key (file: → {ref_path.name}) — valid PEM")
+            else:
+                warn(f"Private key file {ref_path} missing PEM header")
+                warnings += 1
+        else:
+            warn(f"Private key file: reference points to missing file: {ref_path}")
+            warnings += 1
+    elif pem_b64 and pem_b64.startswith("-----BEGIN"):
+        # Raw PEM passthrough
+        ok("Private key (raw PEM in env) — valid")
+    elif pem_b64:
+        # Base64-encoded PEM — decode and validate
         try:
             decoded = _b64.b64decode(pem_b64).decode("utf-8", errors="replace")
             if "BEGIN RSA PRIVATE KEY" in decoded or "BEGIN PRIVATE KEY" in decoded:
@@ -2135,7 +2157,9 @@ def _print_op_summary(ctx: SetupContext) -> None:
         fields.append((ENV_GITHUB_APP_ID, ctx.github_app_id))
     if ctx.github_app_name:
         fields.append((ENV_GITHUB_APP_NAME, ctx.github_app_name))
-    if ctx.github_private_key_b64:
+    if ctx.github_private_key_file_ref:
+        fields.append((ENV_GITHUB_PRIVATE_KEY, ctx.github_private_key_file_ref))
+    elif ctx.github_private_key_b64:
         fields.append((ENV_GITHUB_PRIVATE_KEY, ctx.github_private_key_b64))
     if ctx.github_webhook_secret:
         fields.append((ENV_GITHUB_WEBHOOK_SECRET, ctx.github_webhook_secret))

--- a/packages/syn-adapters/src/syn_adapters/github/client_jwt.py
+++ b/packages/syn-adapters/src/syn_adapters/github/client_jwt.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import base64
 import logging
 import time
+from pathlib import Path
 
 import jwt
 
@@ -23,24 +24,80 @@ JWT_EXPIRY_SECONDS = 10 * 60
 # Clock skew buffer (issue JWT 60 seconds in the past)
 CLOCK_SKEW_SECONDS = 60
 
+# Format detection constants
+_FILE_PREFIX = "file:"
+_PEM_HEADER = "-----BEGIN"
 
-def decode_private_key(encoded_key: str) -> str:
-    """Decode a base64-encoded PEM private key.
+
+def decode_private_key(key: str) -> str:
+    """Resolve a private key from a file reference, raw PEM, or base64.
+
+    Supports three formats (checked in order):
+      1. ``file:<path>`` — read PEM from file (relative paths resolve from CWD)
+      2. Value starting with ``-----BEGIN`` — raw PEM, returned as-is
+      3. Base64-encoded PEM string — decoded and returned
 
     Args:
-        encoded_key: Base64-encoded private key string
+        key: Private key in any of the supported formats.
 
     Returns:
         PEM-formatted private key string.
 
     Raises:
-        ValueError: If decoding fails.
+        ValueError: If the key cannot be resolved.
     """
+    stripped = key.strip()
+
+    if stripped.startswith(_FILE_PREFIX):
+        return _read_key_file(stripped[len(_FILE_PREFIX) :])
+
+    if stripped.startswith(_PEM_HEADER):
+        return stripped
+
     try:
-        return base64.b64decode(encoded_key).decode("utf-8")
+        return base64.b64decode(stripped).decode("utf-8")
     except Exception as e:
         msg = f"Failed to decode private key: {e}"
         raise ValueError(msg) from e
+
+
+def _read_key_file(raw_path: str) -> str:
+    """Read a PEM private key from a file path.
+
+    Args:
+        raw_path: File path (may have leading/trailing whitespace).
+            Relative paths resolve from CWD.
+
+    Returns:
+        PEM file contents.
+
+    Raises:
+        ValueError: If file does not exist, is not readable, or
+            does not contain a PEM header.
+    """
+    path = Path(raw_path.strip())
+    if not path.is_absolute():
+        path = Path.cwd() / path
+
+    if not path.exists():
+        msg = f"Private key file not found: {path}"
+        raise ValueError(msg)
+
+    if not path.is_file():
+        msg = f"Private key path is not a file: {path}"
+        raise ValueError(msg)
+
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError as e:
+        msg = f"Cannot read private key file {path}: {e}"
+        raise ValueError(msg) from e
+
+    if _PEM_HEADER not in content:
+        msg = f"Private key file {path} does not contain a valid PEM header"
+        raise ValueError(msg)
+
+    return content
 
 
 def generate_jwt(app_id: str, private_key: str) -> str:

--- a/packages/syn-adapters/tests/github/test_client_jwt.py
+++ b/packages/syn-adapters/tests/github/test_client_jwt.py
@@ -1,0 +1,70 @@
+"""Tests for decode_private_key() format dispatch."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from syn_adapters.github.client_jwt import decode_private_key
+
+# Minimal valid PEM for testing format detection (not a real key)
+TEST_PEM = "-----BEGIN PRIVATE KEY-----\nMIIBVAIBADANBgkqhki\n-----END PRIVATE KEY-----\n"
+
+
+class TestDecodeBase64:
+    def test_base64_key(self) -> None:
+        encoded = base64.b64encode(TEST_PEM.encode()).decode()
+        result = decode_private_key(encoded)
+        assert result == TEST_PEM
+
+    def test_invalid_base64(self) -> None:
+        with pytest.raises(ValueError, match="Failed to decode"):
+            decode_private_key("not-valid-base64!!!")
+
+
+class TestDecodeRawPem:
+    def test_raw_pem_passthrough(self) -> None:
+        result = decode_private_key(TEST_PEM)
+        assert result == TEST_PEM.strip()
+
+    def test_raw_pem_with_whitespace(self) -> None:
+        result = decode_private_key(f"  {TEST_PEM}  ")
+        assert result == TEST_PEM.strip()
+
+
+class TestDecodeFileReference:
+    def test_file_reference_absolute(self, tmp_path: Path) -> None:
+        key_file = tmp_path / "test-key.pem"
+        key_file.write_text(TEST_PEM)
+        result = decode_private_key(f"file:{key_file}")
+        assert result == TEST_PEM
+
+    def test_file_reference_relative(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        key_file = tmp_path / "secrets" / "key.pem"
+        key_file.parent.mkdir()
+        key_file.write_text(TEST_PEM)
+        monkeypatch.chdir(tmp_path)
+        result = decode_private_key("file:secrets/key.pem")
+        assert result == TEST_PEM
+
+    def test_file_reference_with_whitespace(self, tmp_path: Path) -> None:
+        key_file = tmp_path / "key.pem"
+        key_file.write_text(TEST_PEM)
+        result = decode_private_key(f"  file: {key_file} ")
+        assert result == TEST_PEM
+
+    def test_file_not_found(self) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            decode_private_key("file:/nonexistent/key.pem")
+
+    def test_file_is_directory(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="not a file"):
+            decode_private_key(f"file:{tmp_path}")
+
+    def test_file_missing_pem_header(self, tmp_path: Path) -> None:
+        bad_file = tmp_path / "bad.pem"
+        bad_file.write_text("this is not a valid file")
+        with pytest.raises(ValueError, match="does not contain a valid PEM header"):
+            decode_private_key(f"file:{bad_file}")

--- a/packages/syn-shared/src/syn_shared/settings/github.py
+++ b/packages/syn-shared/src/syn_shared/settings/github.py
@@ -70,10 +70,13 @@ class GitHubAppSettings(BaseSettings):
     private_key: SecretStr = Field(
         default=SecretStr(""),
         description=(
-            "GitHub App private key, base64-encoded. "
+            "GitHub App private key. Supports three formats: "
+            "(1) file:<path> — read PEM from file, e.g. file:infra/docker/secrets/github-private-key.pem; "
+            "(2) raw PEM starting with '-----BEGIN'; "
+            "(3) base64-encoded PEM string. "
             "Download the .pem from: https://github.com/settings/apps/<app>/privatekeys "
-            "Encode it: cat your-app.pem | base64 | tr -d '\\n' | pbcopy "
-            "Paste the result as the value. Never commit the raw key to git!"
+            "Simplest: place the .pem in infra/docker/secrets/ and use a file: reference. "
+            "Never commit the raw key to git!"
         ),
     )
 

--- a/uv.lock
+++ b/uv.lock
@@ -514,7 +514,7 @@ wheels = [
 
 [[package]]
 name = "event-sourcing-python"
-version = "0.7.2b0"
+version = "0.7.1b0"
 source = { editable = "lib/event-sourcing-platform/event-sourcing/python" }
 dependencies = [
     { name = "protobuf" },
@@ -533,7 +533,7 @@ requires-dist = [
     { name = "grpcio", marker = "extra == 'grpc'", specifier = ">=1.60" },
     { name = "grpcio-tools", marker = "extra == 'dev'", specifier = ">=1.60" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.7" },
-    { name = "protobuf", specifier = ">=6.33.5" },
+    { name = "protobuf", specifier = ">=4.25.0" },
     { name = "pydantic", specifier = ">=2.5" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.4" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21" },


### PR DESCRIPTION
## Summary

Closes #363

- `decode_private_key()` now supports three formats: `file:<path>` (reads PEM from file), raw PEM passthrough (`-----BEGIN`), and base64 (existing behavior)
- Setup wizard defaults to `file:` references — no more base64 encoding step
- Updated all docs (10 files) to reflect the new format support

## Motivation

The Claude Code plugin needs to simply move a downloaded `.pem` to `infra/docker/secrets/` and point to it — no encoding step. This makes onboarding frictionless.

## Test plan

- [x] 10 new unit tests for all three formats + error cases
- [x] 16 existing client tests still pass
- [x] pyright clean (0 errors)
- [x] `.env.example` auto-regenerated correctly via `just gen-env`