### PR TITLE
ci: use 8-core runners for release container builds

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -54,7 +54,7 @@ jobs:
 
   build-scan-push:
     name: "Build & Scan: ${{ matrix.image }}"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-core
     timeout-minutes: 45
 
     permissions:


### PR DESCRIPTION
## Summary

Upgrades release container build jobs to `ubuntu-latest-8-core` runners.

- Only affects `release-containers.yaml` (tag-triggered builds)
- CI workflows stay on free `ubuntu-latest` runners
- Estimated speedup: ~18min → ~6-8min wall clock per release
- Estimated cost: ~$0.50 per release (vs ~$0.32 on free runners)

## Test plan

- [x] Only one `runs-on` changed — the build matrix job in release workflow
- [ ] Next release build will validate the speedup