### PR TITLE
fix(ci): correct larger runner label to ubuntu-latest-8-cores

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -54,7 +54,7 @@ jobs:
 
   build-scan-push:
     name: "Build & Scan: ${{ matrix.image }}"
-    runs-on: ubuntu-latest-8-core
+    runs-on: ubuntu-latest-8-cores
     timeout-minutes: 45
 
     permissions:


### PR DESCRIPTION
## Summary
- Fix `runs-on` label from `ubuntu-latest-8-core` (singular) to `ubuntu-latest-8-cores` (plural)
- GitHub's standard pre-defined larger runner labels use plural `cores`
- Next release would have failed without this fix