### PR TITLE
ci: use arm64 8-core runner for container builds

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -54,7 +54,7 @@ jobs:
 
   build-scan-push:
     name: "Build & Scan: ${{ matrix.image }}"
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-24.04-arm64-8-cores
     timeout-minutes: 45
 
     permissions:
@@ -143,12 +143,12 @@ jobs:
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
       # -----------------------------------------------------------------------
-      # QEMU (ARM64 emulation for cross-platform builds)
+      # QEMU (cross-platform emulation for multi-arch builds)
       # -----------------------------------------------------------------------
       - name: Set up QEMU
         uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
         with:
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm64
 
       # -----------------------------------------------------------------------
       # GHCR login


### PR DESCRIPTION
## Summary
- Switch release container builds to `ubuntu-24.04-arm64-8-cores` (org-provisioned runner)
- Update QEMU to emulate both platforms (arm64 native, amd64 via QEMU)
- Previous label `ubuntu-latest-8-cores` didn't match any runner, causing jobs to queue indefinitely

## Note
The v0.17.0-beta.3 release build is stuck. After this merges, we'll need to re-trigger or create beta.4.