### PR TITLE
ci: revert to ubuntu-latest for release builds

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -54,7 +54,7 @@ jobs:
 
   build-scan-push:
     name: "Build & Scan: ${{ matrix.image }}"
-    runs-on: ubuntu-24.04-arm64-8-cores
+    runs-on: ubuntu-latest
     timeout-minutes: 45
 
     permissions:


### PR DESCRIPTION
arm64 runner lacks Docker socket — revert to unblock builds.