### PR TITLE
fix(pulse-ui): resolve nivo CalendarSvgProps type error

### DIFF
--- a/apps/syn-pulse-ui/src/components/ContributionHeatmap.tsx
+++ b/apps/syn-pulse-ui/src/components/ContributionHeatmap.tsx
@@ -68,7 +68,7 @@ export function ContributionHeatmap({ days, startDate, endDate }: ContributionHe
 
   const calendarProps = {
     emptyColor: '#1a1a2e',
-    colors: ['#1a3366', '#2952a3', '#3d6dd9', '#4D80FF'] as const,
+    colors: ['#1a3366', '#2952a3', '#3d6dd9', '#4D80FF'] as string[],
     minValue: 0,
     maxValue,
     monthSpacing: 4,


### PR DESCRIPTION
## Summary
- `as const` on colors array produced `readonly string[]`, incompatible with nivo's `string[]`
- Changed to `as string[]` — no functional change
- Fixes syn-gateway and syn-pulse-ui container build failures