### PR TITLE
fix(dashboard-ui): exclude test files from production tsconfig

### DIFF
--- a/apps/syn-dashboard-ui/tsconfig.app.json
+++ b/apps/syn-dashboard-ui/tsconfig.app.json
@@ -33,5 +33,10 @@
   },
   "include": [
     "src"
+  ],
+  "exclude": [
+    "src/**/__tests__",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
Test files reference @testing-library/react (devDependency) which isn't installed in the Docker build. Exclude them from tsconfig.app.json.