### PR TITLE
feat(selfhost): add cloudflared to compose with profile guard, add local release recipes

### DIFF
--- a/docker/docker-compose.syntropic137.yaml
+++ b/docker/docker-compose.syntropic137.yaml
@@ -343,6 +343,45 @@ services:
       - syn-internal
 
   # ===========================================================================
+  # CLOUDFLARE TUNNEL (optional — profile: tunnel)
+  # ===========================================================================
+  # Only starts when COMPOSE_PROFILES=tunnel is set in .env (or --profile tunnel).
+  # Provides secure external access without port forwarding.
+  #
+  # Setup:
+  #   1. Create tunnel in Cloudflare Zero Trust dashboard
+  #   2. Set CLOUDFLARE_TUNNEL_TOKEN in .env
+  #   3. Set public hostname service URL to: http://gateway:80
+  cloudflared:
+    image: cloudflare/cloudflared:2026.2.0
+    container_name: syn137-cloudflared
+    profiles: [tunnel]
+    command: tunnel run
+    environment:
+      TUNNEL_TOKEN: ${CLOUDFLARE_TUNNEL_TOKEN:-}
+    depends_on:
+      gateway:
+        condition: service_healthy
+    restart: always
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    deploy:
+      resources:
+        limits:
+          memory: 128m
+          cpus: "0.25"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+    networks:
+      - syn-internal
+
+  # ===========================================================================
   # MINIO — S3-compatible Object Storage
   # ===========================================================================
   minio:

--- a/docker/selfhost.env.example
+++ b/docker/selfhost.env.example
@@ -42,7 +42,9 @@ SYN_GITHUB_WEBHOOK_SECRET=
 # CLOUDFLARE TUNNEL (optional — enables webhooks and remote access)
 # =============================================================================
 # Without a tunnel the gateway binds to 127.0.0.1 only (local access).
+# To enable: set COMPOSE_PROFILES=tunnel and provide your tunnel token.
 
+COMPOSE_PROFILES=
 CLOUDFLARE_TUNNEL_TOKEN=
 SYN_PUBLIC_HOSTNAME=
 

--- a/justfile
+++ b/justfile
@@ -1673,3 +1673,101 @@ _workspace-check:
         echo "   Rebuilding to include latest agentic-primitives changes..."
         just workspace-build
     fi
+
+# --- Release (Local) ---
+# Build and push container images to GHCR from your local machine.
+# Useful when CI is slow or broken. Requires: gh auth with write:packages scope.
+
+registry := "ghcr.io/syntropic137"
+
+# Build and push all container images locally (skips event-store by default)
+release-local version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "🚀 Local release: {{version}}"
+    echo ""
+
+    # Login to GHCR
+    gh auth token | docker login ghcr.io -u syntropic137 --password-stdin
+    echo ""
+
+    # Ensure buildx builder exists
+    docker buildx inspect multiarch >/dev/null 2>&1 || docker buildx create --name multiarch
+    docker buildx use multiarch
+
+    # Images to build (order: fast first)
+    declare -A IMAGES=(
+        ["token-injector"]="docker/token-injector/Dockerfile:docker/token-injector"
+        ["sidecar-proxy"]="docker/sidecar-proxy/Dockerfile:docker/sidecar-proxy"
+        ["syn-collector"]="packages/syn-collector/Dockerfile:."
+        ["syn-pulse-ui"]="apps/syn-pulse-ui/Dockerfile:."
+        ["syn-dashboard-ui"]="apps/syn-dashboard-ui/Dockerfile:."
+        ["syn-api"]="infra/docker/images/syn-api/Dockerfile:."
+        ["syn-gateway"]="infra/docker/images/gateway/Dockerfile:."
+    )
+
+    FAILED=()
+    for image in token-injector sidecar-proxy syn-collector syn-pulse-ui syn-dashboard-ui syn-api syn-gateway; do
+        IFS=: read -r dockerfile context <<< "${IMAGES[$image]}"
+        echo "📦 Building $image..."
+        if docker buildx build --platform linux/amd64,linux/arm64 \
+            -f "$dockerfile" \
+            -t "{{registry}}/$image:{{version}}" \
+            --push "$context"; then
+            echo "✅ $image pushed"
+        else
+            echo "❌ $image failed"
+            FAILED+=("$image")
+        fi
+        echo ""
+    done
+
+    # Summary
+    echo "=== Release Summary ==="
+    echo "Version: {{version}}"
+    echo "Registry: {{registry}}"
+    if [ ${#FAILED[@]} -eq 0 ]; then
+        echo "✅ All images pushed successfully"
+    else
+        echo "❌ Failed: ${FAILED[*]}"
+        exit 1
+    fi
+
+# Re-tag an existing image version without rebuilding (e.g., event-store)
+release-retag image from to:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "🏷️  Re-tagging {{registry}}/{{image}}:{{from}} → {{to}}"
+    gh auth token | docker login ghcr.io -u syntropic137 --password-stdin
+    docker buildx imagetools create \
+        "{{registry}}/{{image}}:{{from}}" \
+        --tag "{{registry}}/{{image}}:{{to}}"
+    echo "✅ Done"
+
+# Upload selfhost assets to a GitHub release
+release-assets version:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    echo "📎 Uploading selfhost assets to {{version}}"
+    gh release upload "{{version}}" \
+        docker/docker-compose.syntropic137.yaml \
+        docker/selfhost.env.example \
+        docker/selfhost-entrypoint.sh \
+        syn-ctl \
+        --repo syntropic137/syntropic137 --clobber
+    echo "✅ Assets uploaded"
+
+# Full local release: build images + re-tag event-store + upload assets
+# Usage: just release-local-full v0.17.1 v0.17.0
+#   version: the new tag to create
+#   from: existing tag to re-tag event-store/agentic-workspace from (they rarely change)
+release-local-full version from:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    just release-local "{{version}}"
+    just release-retag event-store "{{from}}" "{{version}}"
+    just release-retag agentic-workspace "{{from}}" "{{version}}"
+    just release-assets "{{version}}"
+    echo ""
+    echo "🎉 Full release complete: {{version}}"
+    echo "   Test with: SYN_VERSION={{version}} docker compose -f docker-compose.syntropic137.yaml pull"


### PR DESCRIPTION
## Summary
- Bake cloudflared into the main selfhost compose with `profiles: [tunnel]` — no dead containers, no overlay files
- Users set `COMPOSE_PROFILES=tunnel` + `CLOUDFLARE_TUNNEL_TOKEN` in `.env` to enable
- Add `just release-local`, `release-retag`, `release-assets`, `release-local-full` for building/pushing images without CI