### PR TITLE
chore: bump version to v0.18.0

### DIFF
--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.17.0"
+version = "0.18.0"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli/pyproject.toml
+++ b/apps/syn-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-cli"
-version = "0.17.0"
+version = "0.18.0"
 description = "CLI for Syntropic137 — thin wrapper over syn-api"
 requires-python = ">=3.12"
 

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-docs/package.json
+++ b/apps/syn-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-docs",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/syn-pulse-ui/package.json
+++ b/apps/syn-pulse-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-pulse-ui",
   "private": true,
-  "version": "0.17.0",
+  "version": "0.18.0",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.17.0"
+version = "0.18.0"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.17.0"
+version = "0.18.0"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.17.0"
+version = "0.18.0"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.17.0"
+version = "0.18.0"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.17.0"
+version = "0.18.0"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.17.0"
+version = "0.18.0"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.17.0-beta.3"
+version = "0.18.0"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Bumps all 12 package versions from 0.17.0 to 0.18.0

## Changes since v0.17.0
- **feat(selfhost):** add cloudflared to compose with profile guard, add local release recipes (#388)
- **feat(infra):** add syn-pulse-ui to selfhost stack (#373)
- **fix(selfhost):** address PR #388 Copilot review comments (#389)
- **fix(ui):** exclude test files from production tsconfig, fix nivo type error (#384)
- **fix(pulse-ui):** resolve nivo CalendarSvgProps type error (#383)
- **fix(github):** mount App private key as Docker secret (#375)
- **ci:** revert to ubuntu-latest for release builds (#381)
- **ci:** use arm64 8-core runner for container builds (#380, #376, #365)
- **docs(readme):** add community & feedback badges (#374)