### PR TITLE
ci(release): use upstream event-store image instead of building from source

### DIFF
--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -350,13 +350,14 @@ jobs:
               | jq -r '.[0].Descriptor.digest // empty') || true
           fi
 
-          if [[ -n "$DIGEST" ]]; then
-            echo "Resolved event-store digest: ${DIGEST}"
-            mkdir -p /tmp/digests
-            echo "$DIGEST" > /tmp/digests/event-store
-          else
-            echo "::warning::Could not resolve event-store digest — keeping tag reference"
+          if [[ -z "$DIGEST" ]]; then
+            echo "::error::Could not resolve event-store digest from GHCR — refusing to release without supply chain pinning"
+            exit 1
           fi
+
+          echo "Resolved event-store digest: ${DIGEST}"
+          mkdir -p /tmp/digests
+          echo "$DIGEST" > /tmp/digests/event-store
 
       - name: Pin image digests in compose file
         run: |


### PR DESCRIPTION
## Summary
- Removes event-store from the `release-containers.yaml` build matrix — no more Rust cross-compilation during syntropic137 releases (~15-20 min saved)
- The event-store image is now built and published by the [event-sourcing-platform repo](https://github.com/syntropic137/event-sourcing-platform) via its own `release-container.yml` workflow (syntropic137/event-sourcing-platform#226)
- Adds a digest resolution step in `release-assets` that fetches the event-store digest from GHCR, so compose files remain digest-pinned for supply chain security

Closes #366

## How it works
1. ESP repo publishes `ghcr.io/syntropic137/event-store:<version>` on release
2. This workflow's `release-assets` job resolves the digest via `docker manifest inspect --verbose`
3. Falls back to `latest` tag if the exact version isn't found, warns if neither exists
4. Digest pinning in the self-host compose file works the same as before

## Test plan
- [ ] Merge syntropic137/event-sourcing-platform#226 first and publish an event-store image
- [ ] Create a test release to exercise the full flow (note: `release-assets` only runs on `release` events, not manual dispatch — this is pre-existing behavior)
- [ ] Verify the self-host compose file has event-store pinned to a digest in the release assets