### PR TITLE
chore: bump version to v0.19.0

### DIFF
--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.18.0"
+version = "0.19.0"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli-node/package.json
+++ b/apps/syn-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntropic137/cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "Syntropic137 CLI - Event-sourced workflow engine for AI agents",
   "type": "module",
   "bin": {

--- a/apps/syn-cli/pyproject.toml
+++ b/apps/syn-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-cli"
-version = "0.18.0"
+version = "0.19.0"
 description = "CLI for Syntropic137 — thin wrapper over syn-api"
 requires-python = ">=3.12"
 

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-docs/package.json
+++ b/apps/syn-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-docs",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/syn-pulse-ui/package.json
+++ b/apps/syn-pulse-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-pulse-ui",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.19.0",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.18.0"
+version = "0.19.0"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.18.0"
+version = "0.19.0"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.18.0"
+version = "0.19.0"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.18.0"
+version = "0.19.0"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.18.0"
+version = "0.19.0"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.18.0"
+version = "0.19.0"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.18.0"
+version = "0.19.0"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary
- Bump all 13 packages from v0.18.0 → v0.19.0
- Prepares for release: container builds, CLI publish, E2E validation

## What's in v0.19.0
- 3 production bug fixes (boolean filter serialization, idempotent gRPC connect, CLI URL resolution)
- Comprehensive regression tests (subscription coordinator integration, poka-yoke handler parity)
- 42 flaky `asyncio.sleep()` test calls eliminated with deterministic alternatives
- Plugin JSON Schema generation pipeline (ADR-053)
- CLI docs regeneration

## Test plan
- [ ] CI green
- [ ] Merge, tag `v0.19.0`, create GitHub Release
- [ ] Container builds succeed (release-containers.yaml)
- [ ] CLI publishes to npm (release-cli.yaml)
- [ ] E2E validation against published stack