### PR TITLE
fix(docker): upgrade pnpm 9→10 in Dockerfiles

### DIFF
--- a/apps/syn-dashboard-ui/Dockerfile
+++ b/apps/syn-dashboard-ui/Dockerfile
@@ -9,8 +9,8 @@
 # =============================================================================
 FROM node:22-alpine AS builder
 
-# Install pnpm (lockfile is v9.0)
-RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@10.24.0 --activate
 
 WORKDIR /app
 

--- a/apps/syn-pulse-ui/Dockerfile
+++ b/apps/syn-pulse-ui/Dockerfile
@@ -9,8 +9,8 @@
 # =============================================================================
 FROM node:22-alpine AS builder
 
-# Install pnpm (lockfile is v9.0)
-RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@10.24.0 --activate
 
 WORKDIR /app
 

--- a/infra/docker/images/gateway/Dockerfile
+++ b/infra/docker/images/gateway/Dockerfile
@@ -9,8 +9,8 @@
 # =============================================================================
 FROM node:22-alpine AS dashboard-builder
 
-# Install pnpm (lockfile is v9.0)
-RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@10.24.0 --activate
 
 WORKDIR /workspace
 
@@ -39,7 +39,7 @@ RUN pnpm build
 # =============================================================================
 FROM node:22-alpine AS pulse-builder
 
-RUN corepack enable && corepack prepare pnpm@9.15.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.24.0 --activate
 
 WORKDIR /workspace
 

--- a/lib/ui-feedback/packages/ui-feedback-react/package.json
+++ b/lib/ui-feedback/packages/ui-feedback-react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "React feedback widget for capturing contextual UI feedback",
   "type": "module",
-  "packageManager": "pnpm@9.15.0",
+  "packageManager": "pnpm@10.24.0",
   "main": "./src/index.ts",
   "module": "./src/index.ts",
   "types": "./index.d.ts",


### PR DESCRIPTION
## Summary
- Upgrade pnpm from 9.15.0 → 10.24.0 in all frontend Dockerfiles (dashboard-ui, pulse-ui, gateway)
- Update `packageManager` field in ui-feedback-react

## Problem
v0.19.0 release containers failed with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. pnpm 10 reads `overrides` from `pnpm-workspace.yaml` while the Docker builds used pnpm 9 which expected them in `package.json`. The lockfile was generated by pnpm 10 locally, making it incompatible with pnpm 9's `--frozen-lockfile`.

## Test plan
- [ ] CI green
- [ ] Merge, then re-run release-containers workflow for v0.19.0