### PR TITLE
release: v0.19.6

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -146,15 +146,15 @@ jobs:
       - name: Verify build artifact
         working-directory: apps/syn-cli-node
         run: |
-          if [[ ! -f dist/syn.mjs ]]; then
-            echo "::error::Build artifact dist/syn.mjs not found"
+          if [[ ! -f dist/syn.js ]]; then
+            echo "::error::Build artifact dist/syn.js not found"
             exit 1
           fi
-          SIZE=$(wc -c < dist/syn.mjs | tr -d ' ')
-          echo "Build artifact: dist/syn.mjs ($SIZE bytes)"
+          SIZE=$(wc -c < dist/syn.js | tr -d ' ')
+          echo "Build artifact: dist/syn.js ($SIZE bytes)"
 
           # Smoke test: --version should print without errors
-          node dist/syn.mjs version
+          node dist/syn.js version
 
       # Uses npm Trusted Publishing (OIDC) — no stored npm token needed.
       # The npm registry exchanges the GitHub OIDC token for a short-lived

--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.19.5"
+version = "0.19.6"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli-node/package.json
+++ b/apps/syn-cli-node/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@syntropic137/cli",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "description": "Syntropic137 CLI - Event-sourced workflow engine for AI agents",
   "type": "module",
   "bin": {
-    "syn": "./dist/syn.mjs"
+    "syn": "./dist/syn.js"
   },
-  "main": "dist/syn.mjs",
+  "main": "dist/syn.js",
   "files": [
     "dist/",
     "README.md"

--- a/apps/syn-cli-node/tsup.config.ts
+++ b/apps/syn-cli-node/tsup.config.ts
@@ -10,5 +10,5 @@ export default defineConfig({
   sourcemap: false,
   dts: false,
   banner: { js: "#!/usr/bin/env node" },
-  outExtension: () => ({ js: ".mjs" }),
+  outExtension: () => ({ js: ".js" }),
 });

--- a/apps/syn-cli/pyproject.toml
+++ b/apps/syn-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-cli"
-version = "0.19.5"
+version = "0.19.6"
 description = "CLI for Syntropic137 — thin wrapper over syn-api"
 requires-python = ">=3.12"
 

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.19.5",
+  "version": "0.19.6",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-docs/package.json
+++ b/apps/syn-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-docs",
-  "version": "0.19.5",
+  "version": "0.19.6",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/syn-pulse-ui/package.json
+++ b/apps/syn-pulse-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-pulse-ui",
   "private": true,
-  "version": "0.19.5",
+  "version": "0.19.6",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.19.5"
+version = "0.19.6"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.19.5"
+version = "0.19.6"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.19.5"
+version = "0.19.6"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.19.5"
+version = "0.19.6"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.19.5"
+version = "0.19.6"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.19.5"
+version = "0.19.6"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.19.5"
+version = "0.19.6"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Release v0.19.6

### Changes since v0.19.0

**Release pipeline (new)**
- Automated release branch workflow with gate checks and reusable workflow orchestration
- Version bump script (`just bump-version` / `just check-version`)
- CLI npm Trusted Publishing (OIDC) — no stored tokens
- Docs drift check in release gate (pre-merge)
- Manual approval required before publish (release-publish environment)

**Bug fixes**
- Fix npm OIDC auth — Trusted Publisher workflow filename must be the caller (`release-create.yml`), not the callee
- Fix npm bin entry — `.mjs` rejected by npm 11.x, switched to `.js`
- Fix reusable workflow permissions — workflow-level `permissions` block was intersecting with caller, dropping `id-token:write`
- Fix reusable workflow `event_name` — callee sees caller's event, not `workflow_call`
- Fix npm provenance — add `repository.url` to CLI `package.json`
- Fix `created` output wiring in release-create
- Fix jq null guard when no merged PRs found
- Proper semver comparison in release gate
- Docs drift catches untracked files

**Other**
- CLI docs regenerated for marketplace/workflow commands
- Reduced cognitive complexity of trigger operator validator