### PR TITLE
fix: clean up CLI docs generator usage formatting

### DIFF
--- a/apps/syn-cli-node/scripts/generate-cli-docs.ts
+++ b/apps/syn-cli-node/scripts/generate-cli-docs.ts
@@ -191,23 +191,25 @@ function renderParamTable(params: ParamInfo[]): string {
   return lines.join("\n");
 }
 
-function formatParamUsage(p: ParamInfo): string | null {
-  if (p.paramType === "argument") {
-    return p.required ? `<${p.name}>` : `[${p.name}]`;
-  }
-  if (p.paramType === "option" && p.required && p.flags.length > 0) {
-    return `${p.flags[0]} <${p.name}>`;
-  }
-  return null;
-}
-
+/**
+ * Build the usage line for a command, mirroring the CLI's own
+ * `renderUsageLine` in src/framework/help.ts:
+ *   <prefix> <requiredArg> [optionalArg] [options]
+ *
+ * Arguments are rendered inline (<required> / [optional]).
+ * Options are never rendered individually — only the [options] suffix
+ * is appended when the command defines any options.
+ */
 function buildUsageLine(prefix: string, params: ParamInfo[]): string {
   const parts = [prefix];
   for (const p of params) {
-    const usage = formatParamUsage(p);
-    if (usage) parts.push(usage);
+    if (p.paramType === "argument") {
+      parts.push(p.required ? `<${p.name}>` : `[${p.name}]`);
+    }
   }
-  if (params.some((p) => p.paramType === "option")) parts.push("[options]");
+  if (params.some((p) => p.paramType === "option")) {
+    parts.push("[options]");
+  }
   return parts.join(" ");
 }
 


### PR DESCRIPTION
## Summary
- Remove dead `formatParamUsage` code path for required options (unreachable since `OptionDef` has no required field)
- Inline argument logic into `buildUsageLine` with JSDoc documenting the contract to match `renderUsageLine` in `src/framework/help.ts`

Follow-up to #468 — addresses remaining Copilot review comment about usage block formatting.

## Test plan
- [ ] `just cli-docs` generates correct usage lines with `[options]` suffix and `[optional]`/`<required>` args