### PR TITLE
fix: add apiGetPaginated for paginated API responses

### DIFF
--- a/apps/syn-cli-node/src/client/api.ts
+++ b/apps/syn-cli-node/src/client/api.ts
@@ -70,6 +70,23 @@ export async function apiGetList<T = Record<string, unknown>>(
   return data;
 }
 
+export async function apiGetPaginated<T = Record<string, unknown>>(
+  path: string,
+  key: string,
+  options?: {
+    params?: Record<string, string | number | boolean | undefined>;
+    expected?: readonly number[];
+  },
+): Promise<T[]> {
+  const client = new SynClient();
+  const { status, data } = await safeRequest(() =>
+    client.get<Record<string, unknown>>(path, options?.params),
+  );
+  checkResponse(status, data, options?.expected ?? [200]);
+  const items = data[key];
+  return Array.isArray(items) ? (items as T[]) : [];
+}
+
 export async function apiPost<T = Record<string, unknown>>(
   path: string,
   options?: {

--- a/apps/syn-cli-node/src/client/index.ts
+++ b/apps/syn-cli-node/src/client/index.ts
@@ -3,6 +3,7 @@ export type { ApiResponse, SynClientOptions } from "./http.js";
 export {
   apiGet,
   apiGetList,
+  apiGetPaginated,
   apiPost,
   apiPut,
   apiPatch,

--- a/apps/syn-cli-node/src/commands/observe.ts
+++ b/apps/syn-cli-node/src/commands/observe.ts
@@ -5,7 +5,7 @@
 
 import { CommandGroup, type CommandDef, type ParsedArgs } from "../framework/command.js";
 import { CLIError } from "../framework/errors.js";
-import { apiGet, apiGetList } from "../client/api.js";
+import { apiGet, apiGetPaginated } from "../client/api.js";
 import { print, printError, printDim } from "../output/console.js";
 import { style, BOLD, CYAN, DIM, GREEN, RED } from "../output/ansi.js";
 import { formatCost, formatDuration, formatTimestamp } from "../output/format.js";
@@ -27,7 +27,7 @@ const toolTimelineCommand: CommandDef = {
   handler: async (parsed: ParsedArgs) => {
     const sid = reqSessionId(parsed);
     const limit = (parsed.values["limit"] as string | undefined) ?? "100";
-    const entries = await apiGetList<Record<string, unknown>>(`/observe/sessions/${sid}/tools`, { params: { limit } });
+    const entries = await apiGetPaginated<Record<string, unknown>>(`/observe/sessions/${sid}/tools`, "executions", { params: { limit } });
     if (entries.length === 0) { printDim("No tool timeline entries."); return; }
 
     const table = new Table({ title: `Tool Timeline: ${sid.slice(0, 12)}` });

--- a/apps/syn-cli-node/src/commands/org.ts
+++ b/apps/syn-cli-node/src/commands/org.ts
@@ -5,7 +5,7 @@
 
 import { CommandGroup, type CommandDef, type ParsedArgs } from "../framework/command.js";
 import { CLIError } from "../framework/errors.js";
-import { apiGet, apiGetList, apiPost, apiPut, apiDelete } from "../client/api.js";
+import { apiGet, apiGetPaginated, apiPost, apiPut, apiDelete } from "../client/api.js";
 import { print, printError, printDim, printSuccess } from "../output/console.js";
 import { style, BOLD, CYAN, DIM } from "../output/ansi.js";
 import { Table } from "../output/table.js";
@@ -42,7 +42,7 @@ const listCommand: CommandDef = {
   name: "list",
   description: "List all organizations",
   handler: async () => {
-    const items = await apiGetList<Record<string, unknown>>("/organizations");
+    const items = await apiGetPaginated<Record<string, unknown>>("/organizations", "organizations");
     if (items.length === 0) { printDim("No organizations found."); return; }
 
     const table = new Table({ title: "Organizations" });

--- a/apps/syn-cli-node/src/commands/repo.ts
+++ b/apps/syn-cli-node/src/commands/repo.ts
@@ -5,7 +5,7 @@
 
 import { CommandGroup, type CommandDef, type ParsedArgs } from "../framework/command.js";
 import { CLIError } from "../framework/errors.js";
-import { apiGet, apiGetList, apiPost, apiPut, buildParams } from "../client/api.js";
+import { apiGet, apiGetPaginated, apiPost, apiPut, buildParams } from "../client/api.js";
 import { print, printError, printDim, printSuccess } from "../output/console.js";
 import { style, BOLD, CYAN, DIM, GREEN, RED, YELLOW } from "../output/ansi.js";
 import { formatCost, formatDuration, formatStatus, formatTimestamp, formatTokens } from "../output/format.js";
@@ -54,7 +54,7 @@ const listCommand: CommandDef = {
       organization_id: (parsed.values["org"] as string | undefined) ?? null,
       system_id: (parsed.values["system"] as string | undefined) ?? null,
     });
-    const items = await apiGetList<Record<string, unknown>>("/repos", { params });
+    const items = await apiGetPaginated<Record<string, unknown>>("/repos", "repos", { params });
     if (items.length === 0) { printDim("No repositories found."); return; }
 
     const table = new Table({ title: "Repositories" });
@@ -193,7 +193,7 @@ const activityCommand: CommandDef = {
   handler: async (parsed: ParsedArgs) => {
     const id = reqRepoId(parsed);
     const limit = (parsed.values["limit"] as string | undefined) ?? "20";
-    const items = await apiGetList<Record<string, unknown>>(`/repos/${id}/activity`, { params: { limit } });
+    const items = await apiGetPaginated<Record<string, unknown>>(`/repos/${id}/activity`, "entries", { params: { limit } });
     if (items.length === 0) { printDim("No recent activity."); return; }
 
     const table = new Table({ title: `Activity: ${id}` });
@@ -228,7 +228,7 @@ const failuresCommand: CommandDef = {
   handler: async (parsed: ParsedArgs) => {
     const id = reqRepoId(parsed);
     const limit = (parsed.values["limit"] as string | undefined) ?? "10";
-    const items = await apiGetList<Record<string, unknown>>(`/repos/${id}/failures`, { params: { limit } });
+    const items = await apiGetPaginated<Record<string, unknown>>(`/repos/${id}/failures`, "failures", { params: { limit } });
     if (items.length === 0) { printDim("No recent failures."); return; }
 
     const table = new Table({ title: `Failures: ${id}` });
@@ -259,7 +259,7 @@ const sessionsCommand: CommandDef = {
   handler: async (parsed: ParsedArgs) => {
     const id = reqRepoId(parsed);
     const limit = (parsed.values["limit"] as string | undefined) ?? "20";
-    const items = await apiGetList<Record<string, unknown>>(`/repos/${id}/sessions`, { params: { limit } });
+    const items = await apiGetPaginated<Record<string, unknown>>(`/repos/${id}/sessions`, "sessions", { params: { limit } });
     if (items.length === 0) { printDim("No sessions found."); return; }
 
     const table = new Table({ title: `Sessions: ${id}` });

--- a/apps/syn-cli-node/src/commands/system.ts
+++ b/apps/syn-cli-node/src/commands/system.ts
@@ -5,7 +5,7 @@
 
 import { CommandGroup, type CommandDef, type ParsedArgs } from "../framework/command.js";
 import { CLIError } from "../framework/errors.js";
-import { apiGet, apiGetList, apiPost, apiPut, apiDelete, buildParams } from "../client/api.js";
+import { apiGet, apiGetPaginated, apiPost, apiPut, apiDelete, buildParams } from "../client/api.js";
 import { print, printError, printDim, printSuccess } from "../output/console.js";
 import { style, BOLD, CYAN, DIM, GREEN, RED, YELLOW } from "../output/ansi.js";
 import { formatCost, formatDuration, formatStatus, formatTimestamp, formatTokens } from "../output/format.js";
@@ -53,7 +53,7 @@ const listCommand: CommandDef = {
     const params = buildParams({
       organization_id: (parsed.values["org"] as string | undefined) ?? null,
     });
-    const items = await apiGetList<Record<string, unknown>>("/systems", { params });
+    const items = await apiGetPaginated<Record<string, unknown>>("/systems", "systems", { params });
     if (items.length === 0) { printDim("No systems found."); return; }
 
     const table = new Table({ title: "Systems" });
@@ -212,7 +212,7 @@ const activityCommand: CommandDef = {
   handler: async (parsed: ParsedArgs) => {
     const id = reqId(parsed);
     const limit = (parsed.values["limit"] as string | undefined) ?? "20";
-    const items = await apiGetList<Record<string, unknown>>(`/systems/${id}/activity`, { params: { limit } });
+    const items = await apiGetPaginated<Record<string, unknown>>(`/systems/${id}/activity`, "entries", { params: { limit } });
     if (items.length === 0) { printDim("No recent activity."); return; }
 
     const table = new Table({ title: `Activity: ${id}` });
@@ -297,7 +297,7 @@ const historyCommand: CommandDef = {
       limit: (parsed.values["limit"] as string | undefined) ?? "50",
       status: (parsed.values["status"] as string | undefined) ?? null,
     });
-    const items = await apiGetList<Record<string, unknown>>(`/systems/${id}/history`, { params });
+    const items = await apiGetPaginated<Record<string, unknown>>(`/systems/${id}/history`, "entries", { params });
     if (items.length === 0) { printDim("No execution history."); return; }
 
     const table = new Table({ title: `History: ${id}` });

--- a/apps/syn-cli-node/src/commands/triggers.ts
+++ b/apps/syn-cli-node/src/commands/triggers.ts
@@ -5,7 +5,7 @@
 
 import { CommandGroup, type CommandDef, type ParsedArgs } from "../framework/command.js";
 import { CLIError } from "../framework/errors.js";
-import { apiGet, apiGetList, apiPost, apiDelete, buildParams } from "../client/api.js";
+import { apiGet, apiGetPaginated, apiPost, apiDelete, buildParams } from "../client/api.js";
 import { print, printError, printDim, printSuccess } from "../output/console.js";
 import { style, BOLD, CYAN, DIM } from "../output/ansi.js";
 import { formatCost, formatStatus, formatTimestamp } from "../output/format.js";
@@ -99,7 +99,7 @@ const listCommand: CommandDef = {
       repo_id: (parsed.values["repo"] as string | undefined) ?? null,
       status: (parsed.values["status"] as string | undefined) ?? null,
     });
-    const items = await apiGetList<Record<string, unknown>>("/triggers", { params });
+    const items = await apiGetPaginated<Record<string, unknown>>("/triggers", "triggers", { params });
     if (items.length === 0) { printDim("No triggers found."); return; }
 
     const table = new Table({ title: "Triggers" });
@@ -162,7 +162,7 @@ const historyCommand: CommandDef = {
   handler: async (parsed: ParsedArgs) => {
     const id = reqId(parsed);
     const limit = (parsed.values["limit"] as string | undefined) ?? "20";
-    const items = await apiGetList<Record<string, unknown>>(`/triggers/${id}/history`, { params: { limit } });
+    const items = await apiGetPaginated<Record<string, unknown>>(`/triggers/${id}/history`, "entries", { params: { limit } });
     if (items.length === 0) { printDim("No trigger history."); return; }
 
     const table = new Table({ title: `Trigger History: ${id.slice(0, 12)}` });

--- a/apps/syn-cli-node/tests/commands/org.test.ts
+++ b/apps/syn-cli-node/tests/commands/org.test.ts
@@ -43,7 +43,7 @@ describe("org commands", () => {
 
   it("list shows organizations", async () => {
     mockFetch.mockResolvedValue(
-      jsonResponse([{ organization_id: "org-1", name: "Acme", slug: "acme", system_count: 2, repo_count: 5 }]),
+      jsonResponse({ organizations: [{ organization_id: "org-1", name: "Acme", slug: "acme", system_count: 2, repo_count: 5 }], total: 1 }),
     );
     const handler = orgGroup.getCommand("list")!.handler;
     await handler({ positionals: [], values: {} });

--- a/apps/syn-cli-node/tests/commands/repo.test.ts
+++ b/apps/syn-cli-node/tests/commands/repo.test.ts
@@ -43,7 +43,7 @@ describe("repo commands", () => {
 
   it("list shows repos", async () => {
     mockFetch.mockResolvedValue(
-      jsonResponse([{ repo_id: "repo-1", repo_url: "owner/repo", status: "active" }]),
+      jsonResponse({ repos: [{ repo_id: "repo-1", repo_url: "owner/repo", status: "active" }], total: 1 }),
     );
     await repoGroup.getCommand("list")!.handler({ positionals: [], values: {} });
     expect(stdout()).toContain("owner/repo");

--- a/apps/syn-cli-node/tests/commands/system.test.ts
+++ b/apps/syn-cli-node/tests/commands/system.test.ts
@@ -43,7 +43,7 @@ describe("system commands", () => {
 
   it("list shows systems", async () => {
     mockFetch.mockResolvedValue(
-      jsonResponse([{ system_id: "sys-1", name: "Backend", repo_count: 3, status: "active" }]),
+      jsonResponse({ systems: [{ system_id: "sys-1", name: "Backend", repo_count: 3, status: "active" }], total: 1 }),
     );
     await systemGroup.getCommand("list")!.handler({ positionals: [], values: {} });
     expect(stdout()).toContain("Backend");

--- a/apps/syn-cli-node/tests/commands/triggers.test.ts
+++ b/apps/syn-cli-node/tests/commands/triggers.test.ts
@@ -48,9 +48,9 @@ describe("triggers commands", () => {
 
   it("list shows triggers table", async () => {
     mockFetch.mockResolvedValue(
-      jsonResponse([
+      jsonResponse({ triggers: [
         { trigger_id: "trig-1", event_type: "push", repo_id: "r1", workflow_id: "w1", status: "active", fire_count: 3 },
-      ]),
+      ], total: 1 }),
     );
     await triggersGroup.getCommand("list")!.handler({ positionals: [], values: {} });
     expect(stdout()).toContain("trig-1");


### PR DESCRIPTION
## Summary

- 11 of 17 `apiGetList` call sites were broken — API returns paginated objects like `{triggers: [], total: 0}` but `apiGetList` expected raw arrays, causing `TypeError: items is not iterable`
- Add `apiGetPaginated(path, key)` helper that unwraps the named array from paginated responses
- Migrate all 11 broken call sites to use `apiGetPaginated`
- Keep `apiGetList` for the 6 endpoints that return raw arrays
- Update test mocks to match actual API response shapes

Closes #483

### Fixed commands
`triggers list`, `triggers history`, `org list`, `system list`, `system activity`, `system history`, `repo list`, `repo activity`, `repo failures`, `repo sessions`, `observe tools`

## Test plan
- [x] All 137 CLI tests pass
- [x] `tsc --noEmit` clean
- [x] Verified against running stack: `syn triggers list`, `syn org list`, `syn system list`, `syn repo list` all return clean output