### PR TITLE
feat: add openapi-fetch typed client and document type pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,36 @@ Treat Python like TypeScript. Strict type safety everywhere.
 - **All public interfaces fully typed** — no implicit signatures
 - **API routes MUST use Pydantic response models** — never `-> dict[str, Any]`. FastAPI generates the OpenAPI spec from return type annotations. Untyped routes are invisible to the spec, which breaks the CLI type generation pipeline (`openAPI spec → openapi-typescript → CLI types`). Always define a response model and use it: `async def list_foos() -> FooListResponse:`
 
+### API → CLI Type Pipeline
+
+Single source of truth for the API contract, fully automated:
+
+```
+Pydantic models (syn-api/types.py)
+  → FastAPI generates OpenAPI spec (/openapi.json)
+    → openapi-typescript generates TypeScript types (syn-cli-node/src/generated/api-types.ts)
+      → CLI commands use typed client (compile-time path + response validation)
+```
+
+**Key files:**
+- `apps/syn-api/src/syn_api/types.py` — All response/request models (single source)
+- `apps/syn-cli-node/src/generated/api-types.ts` — Auto-generated, never hand-edit
+- `apps/syn-cli-node/scripts/generate-types.ts` — Regeneration script
+- `apps/syn-cli-node/scripts/check-api-drift.ts` — CI drift detection
+
+**Workflow — adding/changing an endpoint:**
+1. Define Pydantic response model in `apps/syn-api/src/syn_api/types.py`
+2. Use it as the route return type: `async def list_foos() -> FooListResponse:`
+3. Regenerate OpenAPI spec: start API, fetch `/openapi.json` → `apps/syn-docs/openapi.json`
+4. Regenerate CLI types: `pnpm --filter @syntropic137/cli generate:types`
+5. Use the typed client in CLI commands: `import { api } from "../client/typed.js";`
+
+**Rules:**
+- CLI field names MUST match API response model field names exactly — never use legacy/alias names
+- Domain model field names (e.g. `event`, `repository`) flow through to API responses and CLI — keep them consistent across all three layers
+- CI `check:api-drift` fails if generated types are stale
+- New CLI commands SHOULD use the typed client (`api.GET`, `api.POST`) — existing commands are being migrated incrementally
+
 ### Bounded Contexts & Aggregates (ADR-020)
 
 > Reference: [ADR-020](lib/event-sourcing-platform/docs/adrs/ADR-020-bounded-context-aggregate-convention.md), [VSA Quick Reference](lib/event-sourcing-platform/vsa/docs/QUICK-REFERENCE.md)

--- a/apps/syn-cli-node/package.json
+++ b/apps/syn-cli-node/package.json
@@ -22,6 +22,7 @@
     "generate:docs": "tsx scripts/generate-cli-docs.ts"
   },
   "dependencies": {
+    "openapi-fetch": "^0.17.0",
     "zod": "^3.24.0"
   },
   "devDependencies": {

--- a/apps/syn-cli-node/src/client/index.ts
+++ b/apps/syn-cli-node/src/client/index.ts
@@ -12,3 +12,4 @@ export {
 } from "./api.js";
 export { streamSSE, parseSseLine } from "./sse.js";
 export type { SSEEvent } from "./sse.js";
+export { api, createTypedClient } from "./typed.js";

--- a/apps/syn-cli-node/src/client/typed.ts
+++ b/apps/syn-cli-node/src/client/typed.ts
@@ -1,0 +1,27 @@
+/**
+ * Type-safe API client powered by openapi-fetch.
+ *
+ * Usage:
+ *   import { api } from "../client/typed.js";
+ *   const { data, error } = await api.GET("/triggers", { params: { query: { status: "active" } } });
+ *   // data is fully typed from the OpenAPI spec — no Record<string, unknown>
+ *
+ * Migrate commands incrementally: replace apiGet/apiGetPaginated calls with api.GET/api.POST.
+ */
+
+import createClient from "openapi-fetch";
+import type { paths } from "../generated/api-types.js";
+import { getApiUrl, getAuthHeaders } from "../config.js";
+
+const API_PREFIX = "/api/v1";
+
+export function createTypedClient() {
+  const baseUrl = getApiUrl();
+  return createClient<paths>({
+    baseUrl: `${baseUrl}${API_PREFIX}`,
+    headers: getAuthHeaders(),
+  });
+}
+
+/** Singleton typed client — use this in command handlers. */
+export const api = createTypedClient();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
 
   apps/syn-cli-node:
     dependencies:
+      openapi-fetch:
+        specifier: ^0.17.0
+        version: 0.17.0
       zod:
         specifier: ^3.24.0
         version: 3.25.76
@@ -4446,8 +4449,14 @@ packages:
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
+  openapi-fetch@0.17.0:
+    resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
+
   openapi-sampler@1.7.0:
     resolution: {integrity: sha512-fWq32F5vqGpgRJYIarC/9Y1wC9tKnRDcCOjsDJ7MIcSv2HsE7kNifcXIZ8FVtNStBUWxYrEk/MKqVF0SwZ5gog==}
+
+  openapi-typescript-helpers@0.1.0:
+    resolution: {integrity: sha512-OKTGPthhivLw/fHz6c3OPtg72vi86qaMlqbJuVJ23qOvQ+53uw1n7HdmkJFibloF7QEjDrDkzJiOJuockM/ljw==}
 
   openapi-typescript@7.13.0:
     resolution: {integrity: sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ==}
@@ -10076,11 +10085,17 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  openapi-fetch@0.17.0:
+    dependencies:
+      openapi-typescript-helpers: 0.1.0
+
   openapi-sampler@1.7.0:
     dependencies:
       '@types/json-schema': 7.0.15
       fast-xml-parser: 5.5.9
       json-pointer: 0.6.2
+
+  openapi-typescript-helpers@0.1.0: {}
 
   openapi-typescript@7.13.0(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
## Summary

Adds the `openapi-fetch` typed client and documents the full API→CLI type pipeline in AGENTS.md.

- **`openapi-fetch`** dependency added — provides compile-time path validation and auto-inferred response types from the OpenAPI spec
- **`src/client/typed.ts`** — singleton typed client wrapper; new commands use `api.GET("/triggers")` instead of `apiGet<Record<string, unknown>>("/triggers")`
- **AGENTS.md** — new "API → CLI Type Pipeline" section documenting the single source of truth flow: `Pydantic → OpenAPI → openapi-typescript → openapi-fetch → CLI`

Existing commands continue working with the untyped `apiGet`/`apiGetPaginated` helpers. Migration to the typed client is incremental.

## Test plan
- [x] Build succeeds (168KB bundle)
- [x] All 140 CLI tests pass
- [ ] Verify typed client works against running API