### PR TITLE
docs(#518,#519): ADR-055 projection coordinator + ADR index

### DIFF
--- a/docs/adrs/ADR-055-projection-checkpoint-coordinator-architecture.md
+++ b/docs/adrs/ADR-055-projection-checkpoint-coordinator-architecture.md
@@ -6,7 +6,9 @@ Accepted
 
 ## Date
 
-2026-04-03
+2026-04-04
+
+**Partially Supersedes:** ADR-010 (subscription mechanism section)
 
 ## Related
 
@@ -54,6 +56,18 @@ Each `CheckpointedProjection` tracks its own position in a `projection_checkpoin
 | `SystemProjection` (via adapter) | organization |
 | `RepoProjection` (via adapter) | organization |
 
+### `AutoDispatchProjection` base class
+
+Most projections extend `AutoDispatchProjection` from the ESP library, which uses `get_subscribed_event_types()` to auto-route events to `handle_<EventType>` methods. This eliminates the fragile two-places-to-update pattern where adding an event type to the subscription list and adding a handler method had to stay in sync manually.
+
+### `_NamespacedProjectionAdapter` for organization context
+
+Organization-context projections (`OrganizationProjection`, `SystemProjection`, `RepoProjection`) use namespace-qualified event type strings (e.g., `organization.OrganizationCreated`). The coordinator strips namespace prefixes when matching subscribed event types, so thin adapter wrappers (`OrganizationListAdapter`, `SystemListAdapter`, `RepoListAdapter`) handle the namespace translation.
+
+### `SessionToolsProjection` excluded
+
+`SessionToolsProjection` is not registered in the coordinator. It is a read-only SQL query against TimescaleDB observability tables, not an event consumer. It has no `handle_event` method and does not implement `CheckpointedProjection`.
+
 ### `RealTimeProjectionAdapter` wraps legacy `RealTimeProjection` for SSE
 
 `RealTimeProjection` (non-persisting, SSE broadcast) predates `CheckpointedProjection`. Rather than rewrite it, `RealTimeProjectionAdapter` wraps it as a `CheckpointedProjection` that always returns `ProjectionResult.SUCCESS` without saving a checkpoint. This keeps the SSE path unchanged (documented in ADR-010's RealTimeProjection section) while integrating it into the coordinator lifecycle.
@@ -91,6 +105,7 @@ Logic lives in `coordinator_helpers.run_coordinator()`.
 - **More complex wiring.** `create_coordinator_service()` must be kept in sync with all projections; forgetting to register a new projection silently omits it from the subscription.
 - **Checkpoint store dependency.** A running PostgreSQL instance is required before `start()` is called. Tests must inject a `MemoryCheckpointStore` (via the `checkpoint_store` parameter) to avoid the database dependency.
 - **Organization adapters.** Organization-context projections use namespace-qualified event types that require thin adapter wrappers (`OrganizationListAdapter`, `SystemListAdapter`, `RepoListAdapter`). New projections in similar contexts may need the same treatment.
+- **Two registries coexist.** The coordinator registry (`create_coordinator_service()`) and the legacy `ProjectionManager` with its `EVENT_HANDLERS` map coexist during migration. Delete the legacy `ProjectionManager` and `EVENT_HANDLERS` when migration is complete.
 
 ## Legacy Status of ADR-010
 

--- a/docs/adrs/AGENTS.md
+++ b/docs/adrs/AGENTS.md
@@ -2,25 +2,9 @@
 
 Check [README.md](README.md) for the categorized index of all Architecture Decision Records.
 
-## Creating a New ADR
-
 - Next available number: **ADR-056**
-- Follow the Nygard template: Status → Date → Context → Decision → Consequences
+- Follow the Nygard template: Status, Date, Context, Decision, Consequences
+- Filename format: `ADR-NNN-short-kebab-title.md`
 - After creating, add an entry to README.md in the appropriate category
-- Keep the filename format: `ADR-NNN-short-kebab-title.md`
-- All TODO/FIXME comments in the ADR body must reference a GitHub issue: `TODO(#NNN):`
-
-## Numbering Notes
-
-- **ADR-025** was never created (numbering gap — do not reuse)
-- **ADR-027** has two variants: `sdk-wrapper-architecture` (superseded) and `unified-workflow-executor` (accepted)
-- **ADR-035** has two variants: `conversation-storage-architecture` (proposed) and `qa-workflow-standard` (accepted)
-
-## Status Values
-
-Use one of: `Proposed`, `Accepted`, `Superseded`, `On Hold`, `Implemented`
-
-## Related ADR Directories
-
-- Event Sourcing Platform: `lib/event-sourcing-platform/docs/adrs/`
-- agentic-primitives: `lib/agentic-primitives/docs/adrs/`
+- ADR-025 was never created (numbering gap — do not reuse)
+- Event Sourcing Platform has separate ADRs: `lib/event-sourcing-platform/docs/adrs/`

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,133 +1,108 @@
 # Architecture Decision Records
 
-This directory contains all ADRs for the Syntropic137 project. ADRs capture significant architectural decisions with context, rationale, and consequences.
+## How to use
 
-## How to Use This Index
-
-- Browse by category to find relevant decisions
-- Each ADR links to the full document with detailed context
-- For event-sourcing-platform ADRs, see `lib/event-sourcing-platform/docs/adrs/`
-
-## Notes
-
-- **ADR-025** was never created (numbering gap)
-- **ADR-027** has two variant files: `ADR-027-sdk-wrapper-architecture.md` (superseded) and `ADR-027-unified-workflow-executor.md` (accepted)
-- **ADR-035** has two variant files: `ADR-035-conversation-storage-architecture.md` (proposed) and `ADR-035-qa-workflow-standard.md` (accepted)
 - Next available number: **ADR-056**
+- Template: Status, Date, Context, Decision, Consequences (Nygard format)
+- ADR-025 was never created (numbering gap)
+- ADR-027 has two files: `ADR-027-sdk-wrapper-architecture.md` (superseded) and `ADR-027-unified-workflow-executor.md` (accepted)
+- ADR-035 has two files: `ADR-035-conversation-storage-architecture.md` (proposed) and `ADR-035-qa-workflow-standard.md` (accepted)
+- Event Sourcing Platform has separate ADRs: `lib/event-sourcing-platform/docs/adrs/`
 
----
+## Index
 
-## Architecture & Standards
+### Event Sourcing & CQRS
 
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-001](ADR-001-monorepo-architecture.md) | Monorepo Architecture with VSA | `apps/` + `packages/` flat monorepo structure with git submodules and DDD |
-| [ADR-002](ADR-002-uv-monorepo-architecture.md) | uv Monorepo Architecture | Python workspace conventions using `uv` with `uv_build` backend |
-| [ADR-004](ADR-004-environment-configuration.md) | Environment Configuration with Pydantic Settings | All config via `pydantic-settings` with startup validation and secret protection |
-| [ADR-020](ADR-020-event-sourcing-projection-consistency.md) | Bounded Context and Aggregate Conventions | VSA folder conventions, aggregate naming rules, and projection placement |
-| [ADR-042](ADR-042-event-type-naming-standard.md) | Event Type Naming Standard | Python identifier names must match their string values exactly |
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-003](ADR-003-event-sourcing-decorators.md) | Event Sourcing Decorator Patterns | Accepted |
+| [ADR-007](ADR-007-event-store-integration.md) | Event Store Integration Architecture | Accepted |
+| [ADR-008](ADR-008-vsa-projection-architecture.md) | VSA Projection Architecture for CQRS Read Side | Accepted |
+| [ADR-010](ADR-010-event-subscription-architecture.md) | Event Subscription Architecture for Projections | Accepted (partially superseded by ADR-055) |
+| [ADR-018](ADR-018-commands-vs-observations-event-architecture.md) | Commands vs Observations in Event-Driven Architecture | Accepted |
+| [ADR-020](ADR-020-event-sourcing-projection-consistency.md) | Event Sourcing Projection Consistency | Accepted |
+| [ADR-032](ADR-032-domain-event-type-safety.md) | Domain Event Type Safety | Accepted |
+| [ADR-042](ADR-042-event-type-naming-standard.md) | Event Type Naming Standard | Accepted |
+| [ADR-051](ADR-051-soft-delete-archive-pattern.md) | Soft-Delete (Archive) Pattern for Domain Aggregates | Accepted |
+| [ADR-055](ADR-055-projection-checkpoint-coordinator-architecture.md) | Projection Checkpoint Coordinator Architecture | Accepted |
 
----
+### Orchestration & Execution
 
-## Event Sourcing & CQRS
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-009](ADR-009-agentic-execution-architecture.md) | Agentic Execution Architecture | Accepted |
+| [ADR-014](ADR-014-workflow-execution-model.md) | Workflow Execution Model | Accepted |
+| [ADR-019](ADR-019-websocket-control-plane.md) | WebSocket Control Plane Architecture | Accepted |
+| [ADR-023](ADR-023-workspace-first-execution-model.md) | Workspace-First Execution Model | Accepted |
+| [ADR-027](ADR-027-unified-workflow-executor.md) | Unified Workflow Executor Architecture | Accepted |
+| [ADR-036](ADR-036-workspace-structure-convention.md) | Workspace Structure Convention | Accepted |
+| [ADR-048](ADR-048-workflows-as-cc-commands.md) | Workflows as Claude Code Commands | Accepted |
+| [ADR-049](ADR-049-sse-over-websocket-for-execution-streams.md) | Server-Sent Events (SSE) for Real-Time Execution Streams | Accepted |
 
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-003](ADR-003-event-sourcing-decorators.md) | Event Sourcing Decorator Patterns | Standard use of `@aggregate`, `@command`, `@event` decorators from the ESP SDK |
-| [ADR-007](ADR-007-event-store-integration.md) | Event Store Integration Architecture | Use ESP's gRPC event store server rather than direct PostgreSQL queries |
-| [ADR-008](ADR-008-vsa-projection-architecture.md) | VSA Projection Architecture for CQRS Read Side | CQRS read-side using VSA-compliant query slices instead of a monolithic read model |
-| [ADR-010](ADR-010-event-subscription-architecture.md) | Event Subscription Architecture for Projections | Subscription mechanism connecting the event store to projections |
-| [ADR-018](ADR-018-commands-vs-observations-event-architecture.md) | Commands vs Observations in Event-Driven Architecture | Separates domain events (command outcomes) from observability events (external facts) |
-| [ADR-032](ADR-032-domain-event-type-safety.md) | Domain Event Type Safety | Pydantic models with `frozen=True` and `extra="forbid"` for all domain events |
-| [ADR-051](ADR-051-soft-delete-archive-pattern.md) | Soft-Delete (Archive) Pattern for Domain Aggregates | Archive aggregates via domain events instead of hard deletion |
-| [ADR-055](ADR-055-projection-checkpoint-coordinator-architecture.md) | Projection Checkpoint & Coordinator Architecture | Per-projection checkpoints replacing legacy global-checkpoint subscription service |
+### Infrastructure & Storage
 
----
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-001](ADR-001-monorepo-architecture.md) | Monorepo Architecture with VSA | Accepted (Revised) |
+| [ADR-002](ADR-002-uv-monorepo-architecture.md) | uv Monorepo Architecture | Accepted |
+| [ADR-004](ADR-004-environment-configuration.md) | Environment Configuration with Pydantic Settings | Accepted |
+| [ADR-005](ADR-005-development-environments.md) | Development Environment Strategy | Accepted |
+| [ADR-011](ADR-011-structured-logging.md) | Structured Logging with agentic-logging | Accepted |
+| [ADR-012](ADR-012-artifact-storage.md) | Artifact Storage Architecture | Accepted |
+| [ADR-026](ADR-026-timescaledb-observability-storage.md) | TimescaleDB for Observability Event Storage | Accepted |
+| [ADR-028](ADR-028-otel-integration.md) | OpenTelemetry Integration for Agent Observability | Superseded |
+| [ADR-030](ADR-030-database-consolidation.md) | Database Consolidation to Single TimescaleDB Instance | Accepted |
+| [ADR-031](ADR-031-sql-schema-validation.md) | SQL Schema Validation for Raw SQL Operations | Accepted |
+| [ADR-045](ADR-045-secrets-management-standard.md) | Secrets Management Standard | Accepted |
+| [ADR-052](ADR-052-docs-site-vercel-deployment.md) | Documentation Site Deployment via Vercel | Superseded |
+| [ADR-054](ADR-054-generated-docs-sync-pipeline.md) | Generated Documentation Sync Pipeline | Accepted |
 
-## Orchestration & Execution
+### Testing & Quality
 
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-009](ADR-009-agentic-execution-architecture.md) | Agentic Execution Architecture | Defines the agentic protocol and workspace concept (execution model superseded by ADR-023) |
-| [ADR-014](ADR-014-workflow-execution-model.md) | Workflow Execution Model | Separates Workflow Templates from Workflow Executions for correct metrics and history |
-| [ADR-019](ADR-019-websocket-control-plane.md) | WebSocket Control Plane Architecture | HTTP POST endpoints as canonical control plane for pause/resume/cancel/inject |
-| [ADR-023](ADR-023-workspace-first-execution-model.md) | Workspace-First Execution Model | Enforces that `WorkflowExecutionEngine` always runs via `WorkspaceRouter` |
-| [ADR-027](ADR-027-unified-workflow-executor.md) | Unified Workflow Executor Architecture | Single executor implementation for both CLI and Dashboard with consistent observability |
-| [ADR-036](ADR-036-workspace-structure-convention.md) | Workspace Structure Convention | Standardized directory layout inside agent containers for reliable artifact passing |
-| [ADR-048](ADR-048-workflows-as-cc-commands.md) | Workflows as Claude Code Commands | Workflow phases use Claude Code command Markdown files with `$ARGUMENTS` substitution |
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-013](ADR-013-integration-testing-strategy.md) | Integration Testing Strategy with Event Store | Accepted |
+| [ADR-029](ADR-029-ai-agent-testing-verification.md) | AI Agent Testing & Verification Philosophy | Accepted |
+| [ADR-033](ADR-033-recording-based-integration-testing.md) | Recording-Based Integration Testing | Accepted |
+| [ADR-034](ADR-034-test-infrastructure-architecture.md) | Test Infrastructure Architecture | Accepted |
+| [ADR-035](ADR-035-qa-workflow-standard.md) | QA Workflow Standard | Accepted |
+| [ADR-038](ADR-038-test-organization-standard.md) | Test Organization Standard | Accepted |
 
----
+### GitHub Integration
 
-## Infrastructure & Storage
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-040](ADR-040-github-trigger-architecture.md) | GitHub Trigger Architecture | Proposed |
+| [ADR-041](ADR-041-offline-dev-and-webhook-recording.md) | Offline Development Mode and Webhook Recording | Accepted |
+| [ADR-043](ADR-043-git-hook-event-pipeline.md) | Git Hook Event Pipeline | Accepted |
+| [ADR-050](ADR-050-hybrid-webhook-polling-event-pipeline.md) | Hybrid Webhook + Polling Event Pipeline | Accepted |
 
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-005](ADR-005-development-environments.md) | Development Environment Strategy | Three-tier strategy (unit / local Docker / CI) with no SQLite shortcuts |
-| [ADR-012](ADR-012-artifact-storage.md) | Artifact Storage Architecture | Artifact metadata in PostgreSQL projections, content in MinIO object storage |
-| [ADR-026](ADR-026-timescaledb-observability-storage.md) | TimescaleDB for Observability Event Storage | Observability events stored in TimescaleDB hypertables, separate from domain event store |
-| [ADR-030](ADR-030-database-consolidation.md) | Database Consolidation to Single TimescaleDB Instance | Merges two PostgreSQL instances into one TimescaleDB for both domain and observability data |
-| [ADR-031](ADR-031-sql-schema-validation.md) | SQL Schema Validation for Raw SQL Operations | Compile-time schema validation for raw `asyncpg` queries to prevent column drift |
-| [ADR-045](ADR-045-secrets-management-standard.md) | Secrets Management Standard | Canonical secret naming convention with 1Password `op://` resolver |
-| [ADR-049](ADR-049-sse-over-websocket-for-execution-streams.md) | SSE over WebSocket for Real-Time Execution Streams | Server-Sent Events replace WebSocket for unidirectional server→client event streaming |
-| [ADR-052](ADR-052-docs-site-vercel-deployment.md) | Documentation Site Deployment via Vercel | Public docs site (`apps/syn-docs/`) deployed via Vercel git integration |
+### UI & Communication
 
----
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-016](ADR-016-ui-feedback-module.md) | UI Feedback Module | Proposed |
+| [ADR-044](ADR-044-cli-first-agent-native-interface.md) | CLI-First, Agent-Native Interface Design | Accepted |
+| [ADR-053](ADR-053-plugin-schema-generation-strategy.md) | Plugin Schema Generation Strategy | Accepted |
 
-## Testing & Quality
+### Agent Architecture
 
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-013](ADR-013-integration-testing-strategy.md) | Integration Testing Strategy with Event Store | Integration tests run against a real event store to catch serialization bugs |
-| [ADR-029](ADR-029-ai-agent-testing-verification.md) | AI Agent Testing & Verification Philosophy | Tests must verify real observable behavior, not mock-passing stubs |
-| [ADR-033](ADR-033-recording-based-integration-testing.md) | Recording-Based Integration Testing | Record real agent JSONL streams and replay them in tests to avoid API token spend |
-| [ADR-034](ADR-034-test-infrastructure-architecture.md) | Test Infrastructure Architecture | Ephemeral test stack on ports +10000 enables parallel dev and integration test runs |
-| [ADR-035](ADR-035-qa-workflow-standard.md) | QA Workflow Standard | Two-tier parallel QA suite targeting sub-1-minute full validation |
-| [ADR-038](ADR-038-test-organization-standard.md) | Test Organization Standard | Co-locate unit tests with slices; keep integration tests in a top-level `tests/` directory |
-| [ADR-041](ADR-041-offline-dev-and-webhook-recording.md) | Offline Development Mode and Webhook Recording | Record and replay webhook payloads for GitHub trigger testing without a live tunnel |
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-006](ADR-006-hook-architecture-agent-swarms.md) | Hook Architecture for Agent Swarms | Accepted |
+| [ADR-015](ADR-015-agent-observability.md) | Agent Session Observability Architecture | Accepted |
+| [ADR-017](ADR-017-scalable-event-collection-architecture.md) | Scalable Event Collection Architecture | Accepted |
+| [ADR-021](ADR-021-isolated-workspace-architecture.md) | Isolated Workspace Architecture | Accepted |
+| [ADR-022](ADR-022-secure-token-architecture.md) | Secure Token Architecture for Agentic Scale | On Hold |
+| [ADR-024](ADR-024-setup-phase-secrets.md) | Setup Phase Secrets Pattern | Accepted |
+| [ADR-027](ADR-027-sdk-wrapper-architecture.md) | SDK Wrapper Architecture via agentic-primitives | Superseded |
+| [ADR-035](ADR-035-conversation-storage-architecture.md) | Agent Output Data Model and Storage | Proposed |
+| [ADR-037](ADR-037-subagent-observability.md) | Subagent Observability | Accepted |
+| [ADR-039](ADR-039-context-window-cost-tracking.md) | Context Window and Cost Tracking | Accepted |
 
----
+### Organization & Repos
 
-## GitHub Integration
-
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-040](ADR-040-github-trigger-architecture.md) | GitHub Trigger Architecture | First-class trigger resources for auto-firing workflows from GitHub CI and review events |
-| [ADR-043](ADR-043-git-hook-event-pipeline.md) | Git Hook Event Pipeline | Record real git operations via tool result scanning rather than command inference |
-| [ADR-050](ADR-050-hybrid-webhook-polling-event-pipeline.md) | Hybrid Webhook + Polling Event Pipeline | Unified pipeline accepts both webhook deliveries and Events API polling with dedup |
-
----
-
-## UI & Communication
-
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-011](ADR-011-structured-logging.md) | Structured Logging with agentic-logging | JSON structured logging across all components for agent-parseable debug output |
-| [ADR-016](ADR-016-ui-feedback-module.md) | UI Feedback Module | In-context feedback capture widget stored in PostgreSQL, queryable by agents |
-| [ADR-044](ADR-044-cli-first-agent-native-interface.md) | CLI-First, Agent-Native Interface Design | CLI is the canonical interface; API serves it, dashboard is a consumer like any other |
-| [ADR-053](ADR-053-plugin-schema-generation-strategy.md) | Plugin Schema Generation Strategy | Generate JSON Schema from Pydantic models for all plugin file formats |
-| [ADR-054](ADR-054-generated-docs-sync-pipeline.md) | Generated Documentation Sync Pipeline | Node.js CLI drives docs generation; CI drift detection prevents stale reference docs |
-
----
-
-## Agent Architecture
-
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-006](ADR-006-hook-architecture-agent-swarms.md) | Hook Architecture for Agent Swarms | Async hook client library replacing subprocess hooks for 1000+ concurrent agents |
-| [ADR-021](ADR-021-isolated-workspace-architecture.md) | Isolated Workspace Architecture | Docker/Firecracker/gVisor isolation for agent containers with hook event transport |
-| [ADR-022](ADR-022-secure-token-architecture.md) | Secure Token Architecture for Agentic Scale | Shared Envoy cluster for token vending (on hold pending auth/multi-tenant work) |
-| [ADR-024](ADR-024-setup-phase-secrets.md) | Setup Phase Secrets Pattern | Inject secrets during a pre-execution setup phase and clear them before agent starts |
-| [ADR-037](ADR-037-subagent-observability.md) | Subagent Observability | Track parent-child agent hierarchies with per-subagent tool attribution and cost |
-
----
-
-## Organization & Observability
-
-| ADR | Title | Summary |
-|-----|-------|---------|
-| [ADR-015](ADR-015-agent-observability.md) | Agent Session Observability Architecture | Tool call timeline and token tracking per session via JSONL hook parsing |
-| [ADR-017](ADR-017-scalable-event-collection-architecture.md) | Scalable Event Collection Architecture | `syn-collector` service ingests hook events and writes to TimescaleDB |
-| [ADR-028](ADR-028-otel-integration.md) | OpenTelemetry Integration *(superseded by ADR-029)* | OTel proposed as observability transport, replaced by direct JSONL parsing |
-| [ADR-039](ADR-039-context-window-cost-tracking.md) | Context Window and Cost Tracking | Use the final `result` event `total_cost_usd` as authoritative; per-turn usage for streaming |
-| [ADR-046](ADR-046-organization-query-insight-layer.md) | Organization Query & Insight Layer | Read-side analytics projection for per-repo health, cost rollup, and failure patterns |
-| [ADR-047](ADR-047-repo-execution-correlation-pattern.md) | Repo-Execution Correlation Pattern | Correlation projection links executions to repos without coupling event schemas |
+| ADR | Title | Status |
+|-----|-------|--------|
+| [ADR-046](ADR-046-organization-query-insight-layer.md) | Organization Query & Insight Layer | Accepted |
+| [ADR-047](ADR-047-repo-execution-correlation-pattern.md) | Repo-Execution Correlation Pattern | Accepted |


### PR DESCRIPTION
## Summary

- Write ADR-055: Projection Checkpoint & Coordinator Architecture — documents the migration from global-checkpoint EventSubscriptionService to per-projection CoordinatorSubscriptionService
- Create categorized ADR index at `docs/adrs/README.md` covering all 55 ADRs
- Add `docs/adrs/AGENTS.md` with next available number (ADR-056)

## Test plan
- [ ] ADR-055 accurately reflects the current 20-projection coordinator architecture
- [ ] README.md index covers all ADR files in docs/adrs/
- [ ] No broken links
- [ ] CI green (docs only — no code changes)

Closes #518, #519
Refs #520