### PR TITLE
fix(#532): normalize Events API action names + auto-resolve installation_id

### DIFF
--- a/apps/syn-api/src/syn_api/routes/triggers/commands.py
+++ b/apps/syn-api/src/syn_api/routes/triggers/commands.py
@@ -47,6 +47,20 @@ async def register_trigger(
 
     await ensure_connected()
 
+    # Auto-resolve installation_id from GitHub App if not provided
+    if not installation_id and repository:
+        try:
+            from syn_adapters.github.client import get_github_client
+
+            client = get_github_client()
+            installation_id = await client.get_installation_for_repo(repository)
+            logger.info("Auto-resolved installation_id=%s for %s", installation_id, repository)
+        except Exception:
+            logger.warning(
+                "Could not auto-resolve installation_id for %s — trigger will register without it",
+                repository,
+            )
+
     workflow_repo = get_workflow_repo()
     if not await workflow_repo.exists(workflow_id):
         return Err(
@@ -140,6 +154,20 @@ async def enable_preset(
     )
 
     await ensure_connected()
+
+    # Auto-resolve installation_id from GitHub App if not provided
+    if not installation_id and repository:
+        try:
+            from syn_adapters.github.client import get_github_client
+
+            client = get_github_client()
+            installation_id = await client.get_installation_for_repo(repository)
+            logger.info("Auto-resolved installation_id=%s for %s", installation_id, repository)
+        except Exception:
+            logger.warning(
+                "Could not auto-resolve installation_id for %s — preset will register without it",
+                repository,
+            )
 
     try:
         command = create_preset_command(

--- a/apps/syn-api/src/syn_api/routes/triggers/commands.py
+++ b/apps/syn-api/src/syn_api/routes/triggers/commands.py
@@ -25,6 +25,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/triggers", tags=["triggers"])
 
 
+async def _resolve_installation_id(installation_id: str, repository: str) -> str:
+    """Auto-resolve installation_id from the GitHub App if not provided."""
+    if installation_id or not repository:
+        return installation_id
+    try:
+        from syn_adapters.github.client import get_github_client
+
+        client = get_github_client()
+        resolved = await client.get_installation_for_repo(repository)
+        logger.info("Auto-resolved installation_id=%s for %s", resolved, repository)
+        return resolved
+    except Exception:
+        logger.warning(
+            "Could not auto-resolve installation_id for %s",
+            repository,
+        )
+        return installation_id
+
+
 async def register_trigger(
     name: str,
     event: str,
@@ -46,20 +65,7 @@ async def register_trigger(
     )
 
     await ensure_connected()
-
-    # Auto-resolve installation_id from GitHub App if not provided
-    if not installation_id and repository:
-        try:
-            from syn_adapters.github.client import get_github_client
-
-            client = get_github_client()
-            installation_id = await client.get_installation_for_repo(repository)
-            logger.info("Auto-resolved installation_id=%s for %s", installation_id, repository)
-        except Exception:
-            logger.warning(
-                "Could not auto-resolve installation_id for %s — trigger will register without it",
-                repository,
-            )
+    installation_id = await _resolve_installation_id(installation_id, repository)
 
     workflow_repo = get_workflow_repo()
     if not await workflow_repo.exists(workflow_id):
@@ -154,20 +160,7 @@ async def enable_preset(
     )
 
     await ensure_connected()
-
-    # Auto-resolve installation_id from GitHub App if not provided
-    if not installation_id and repository:
-        try:
-            from syn_adapters.github.client import get_github_client
-
-            client = get_github_client()
-            installation_id = await client.get_installation_for_repo(repository)
-            logger.info("Auto-resolved installation_id=%s for %s", installation_id, repository)
-        except Exception:
-            logger.warning(
-                "Could not auto-resolve installation_id for %s — preset will register without it",
-                repository,
-            )
+    installation_id = await _resolve_installation_id(installation_id, repository)
 
     try:
         command = create_preset_command(

--- a/packages/syn-domain/src/syn_domain/contexts/github/slices/event_pipeline/event_type_mapper.py
+++ b/packages/syn-domain/src/syn_domain/contexts/github/slices/event_pipeline/event_type_mapper.py
@@ -29,6 +29,14 @@ logger = logging.getLogger(__name__)
 # https://docs.github.com/en/rest/using-the-rest-api/github-event-types
 _EVENTS_API_TYPE_MAP: dict[str, str] = build_events_api_type_map()
 
+# Maps Events API action names to webhook action names for events where they differ.
+# GitHub's Events API uses different action values than webhooks for some event types.
+# Only PullRequestReviewEvent has known mismatches — all other events use matching actions.
+# See: https://docs.github.com/en/rest/using-the-rest-api/github-event-types
+_EVENTS_API_ACTION_MAP: dict[str, dict[str, str]] = {
+    "pull_request_review": {"created": "submitted", "updated": "edited"},
+}
+
 
 def map_events_api_to_normalized(
     raw_event: dict[str, Any],
@@ -50,7 +58,13 @@ def map_events_api_to_normalized(
         return None
 
     payload: dict[str, Any] = raw_event.get("payload", {})
-    action = payload.get("action", "")
+    action: str = str(payload.get("action", ""))
+
+    # Normalize action names that differ between Events API and webhooks
+    action_map = _EVENTS_API_ACTION_MAP.get(event_type)
+    if action_map:
+        action = action_map.get(action, action)
+
     # Events API uses "repo.name" which is "owner/repo" format
     repo_name = raw_event.get("repo", {}).get("name", "")
     event_id = str(raw_event.get("id", ""))

--- a/packages/syn-domain/src/syn_domain/contexts/github/slices/event_pipeline/test_event_type_mapper.py
+++ b/packages/syn-domain/src/syn_domain/contexts/github/slices/event_pipeline/test_event_type_mapper.py
@@ -88,6 +88,46 @@ class TestEventTypeMapper:
         assert result is not None
         assert result.payload["repository"]["full_name"] == "owner/repo"
 
+    def test_normalizes_pull_request_review_created_to_submitted(self) -> None:
+        """Events API uses 'created' but webhooks expect 'submitted'."""
+        raw = {
+            "id": "review-123",
+            "type": "PullRequestReviewEvent",
+            "repo": {"name": "owner/repo"},
+            "payload": {"action": "created", "review": {"id": 999, "state": "commented"}},
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        result = map_events_api_to_normalized(raw, "inst-1")
+        assert result is not None
+        assert result.event_type == "pull_request_review"
+        assert result.action == "submitted"
+
+    def test_normalizes_pull_request_review_updated_to_edited(self) -> None:
+        """Events API 'updated' maps to webhook 'edited'."""
+        raw = {
+            "id": "review-456",
+            "type": "PullRequestReviewEvent",
+            "repo": {"name": "owner/repo"},
+            "payload": {"action": "updated", "review": {"id": 999}},
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        result = map_events_api_to_normalized(raw, "inst-1")
+        assert result is not None
+        assert result.action == "edited"
+
+    def test_pull_request_review_dismissed_passes_through(self) -> None:
+        """Actions without mapping pass through unchanged."""
+        raw = {
+            "id": "review-789",
+            "type": "PullRequestReviewEvent",
+            "repo": {"name": "owner/repo"},
+            "payload": {"action": "dismissed", "review": {"id": 999}},
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        result = map_events_api_to_normalized(raw, "inst-1")
+        assert result is not None
+        assert result.action == "dismissed"
+
     def test_dedup_key_matches_webhook_for_push(self) -> None:
         """Push events from both sources should produce the same dedup key."""
         from syn_domain.contexts.github.slices.event_pipeline.dedup_keys import compute_dedup_key


### PR DESCRIPTION
## Summary

Fixes the P0 trigger pipeline bug: GitHub's Events API returns different action names than webhooks for `PullRequestReviewEvent` (`created` vs `submitted`, `updated` vs `edited`). Triggers expecting `pull_request_review.submitted` never fire via the poller path.

- Add `_EVENTS_API_ACTION_MAP` constant co-located with `_EVENTS_API_TYPE_MAP` in `event_type_mapper.py` — poka-yoke: if you add a new event type, the action map is right there
- Normalize actions during `map_events_api_to_normalized()` before dedup key computation
- Auto-resolve `installation_id` in trigger registration and preset enablement routes (prevents empty `installation_id` crashes in the poller)
- 3 new unit tests for action normalization (created→submitted, updated→edited, dismissed passthrough)

**Closes #532 (partial — trigger pipeline fix)**

## Test plan

- [ ] `uv run pytest packages/syn-domain/.../test_event_type_mapper.py -v` — 10/10 pass
- [ ] `uv run pyright` on changed files — 0 errors
- [ ] Register trigger without `installation_id`, verify auto-resolution
- [ ] Submit PR review on target repo → verify poller normalizes `created` → `submitted` → trigger fires