### PR TITLE
fix(#542): trigger partial ID on mutations, last_fired_at, created_at

### DIFF
--- a/apps/syn-api/src/syn_api/routes/triggers/commands.py
+++ b/apps/syn-api/src/syn_api/routes/triggers/commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, HTTPException
@@ -119,6 +120,7 @@ async def _index_and_sync_trigger(store: Any, aggregate: Any) -> None:
         installation_id=aggregate.installation_id,
         created_by=aggregate.created_by,
         status=aggregate.status.value,
+        created_at=datetime.now(UTC),
     )
     await sync_published_events_to_projections()
 
@@ -380,6 +382,9 @@ async def enable_preset_endpoint(preset_name: str, body: dict[str, Any]) -> Trig
 )
 async def update_trigger_endpoint(trigger_id: str, body: dict[str, Any]) -> TriggerActionResponse:
     """Update trigger (pause/resume)."""
+    from .queries import _resolve_trigger_id
+
+    trigger_id = await _resolve_trigger_id(trigger_id)
     action = body.get("action", "")
     if action == "pause":
         result = await pause_trigger(
@@ -408,6 +413,9 @@ async def update_trigger_endpoint(trigger_id: str, body: dict[str, Any]) -> Trig
 )
 async def delete_trigger_endpoint(trigger_id: str) -> TriggerActionResponse:
     """Delete a trigger rule."""
+    from .queries import _resolve_trigger_id
+
+    trigger_id = await _resolve_trigger_id(trigger_id)
     result = await delete_trigger(trigger_id=trigger_id, deleted_by="api")
     if isinstance(result, Err):
         raise HTTPException(

--- a/apps/syn-api/src/syn_api/services/seeding.py
+++ b/apps/syn-api/src/syn_api/services/seeding.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 
 from syn_api._wiring import (
     ensure_connected,
@@ -109,6 +110,7 @@ async def _seed_trigger_presets() -> int:
                 installation_id=aggregate.installation_id,
                 created_by=aggregate.created_by,
                 status=aggregate.status.value,
+                created_at=datetime.now(UTC),
             )
             count += 1
         except Exception:

--- a/packages/syn-adapters/src/syn_adapters/projections/trigger_query_projection.py
+++ b/packages/syn-adapters/src/syn_adapters/projections/trigger_query_projection.py
@@ -135,6 +135,7 @@ class TriggerQueryProjection(CheckpointedProjection):
                 "created_by": data.get("created_by", ""),
                 "status": "active",
                 "fire_count": 0,
+                "created_at": datetime.now(UTC).isoformat(),
             },
         )
 
@@ -191,8 +192,9 @@ class TriggerQueryProjection(CheckpointedProjection):
                 },
             )
 
-        # Increment fire count on trigger index
+        # Increment fire count and update last_fired_at on trigger index
         existing = await self._store.get(NS_TRIGGER_INDEX, trigger_id)
         if existing:
             existing["fire_count"] = existing.get("fire_count", 0) + 1
+            existing["last_fired_at"] = fired_at
             await self._store.save(NS_TRIGGER_INDEX, trigger_id, existing)

--- a/packages/syn-adapters/src/syn_adapters/storage/trigger_query_store.py
+++ b/packages/syn-adapters/src/syn_adapters/storage/trigger_query_store.py
@@ -73,6 +73,12 @@ class PersistentTriggerQueryStore(TriggerQueryStore):
             status=data.get("status", "active"),
         )
         trigger.fire_count = data.get("fire_count", 0)
+        raw_created_at = data.get("created_at")
+        if isinstance(raw_created_at, str):
+            trigger.created_at = datetime.fromisoformat(raw_created_at)
+        raw_last_fired = data.get("last_fired_at")
+        if isinstance(raw_last_fired, str):
+            trigger.last_fired_at = datetime.fromisoformat(raw_last_fired)
         return trigger
 
     # --- Read methods ---
@@ -156,6 +162,7 @@ class PersistentTriggerQueryStore(TriggerQueryStore):
         installation_id: str,
         created_by: str,
         status: str,
+        created_at: datetime | None = None,
     ) -> None:
         pass  # Writes come from TriggerQueryProjection
 

--- a/packages/syn-domain/src/syn_domain/contexts/github/_shared/trigger_query_store.py
+++ b/packages/syn-domain/src/syn_domain/contexts/github/_shared/trigger_query_store.py
@@ -41,6 +41,7 @@ class TriggerQueryStore(ABC):
         installation_id: str,
         created_by: str,
         status: str,
+        created_at: datetime | None = None,
     ) -> None:
         """Index a trigger for fast lookups."""
         ...
@@ -171,8 +172,9 @@ class InMemoryTriggerQueryStore(TriggerQueryStore):
         installation_id: str,
         created_by: str,
         status: str,
+        created_at: datetime | None = None,
     ) -> None:
-        self._triggers[trigger_id] = _IndexedTrigger(
+        trigger = _IndexedTrigger(
             trigger_id=trigger_id,
             name=name,
             event=event,
@@ -185,6 +187,8 @@ class InMemoryTriggerQueryStore(TriggerQueryStore):
             created_by=created_by,
             status=status,
         )
+        trigger.created_at = created_at or datetime.now(UTC)
+        self._triggers[trigger_id] = trigger
 
     async def update_status(self, trigger_id: str, status: str) -> None:
         trigger = self._triggers.get(trigger_id)


### PR DESCRIPTION
## Summary
Fixes 3 trigger-related gaps from e2e pressure testing (#542, cycle 3):

- **Partial ID on mutations**: `PATCH /triggers/{partial}` and `DELETE /triggers/{partial}` now call `_resolve_trigger_id()` before using the ID, matching GET behavior
- **`last_fired_at` null**: `TriggerQueryProjection._on_trigger_fired()` now updates `last_fired_at` in the trigger index alongside `fire_count`
- **`created_at` null on seeds**: Added `created_at` parameter to `TriggerQueryStore.index_trigger()` interface, implementations, seeding, and projection

## Test plan
- [x] All 24 trigger tests pass
- [x] pyright 0 errors
- [x] ruff clean
- [x] `PATCH /triggers/{partial}` resolves partial IDs
- [x] `DELETE /triggers/{partial}` resolves partial IDs
- [x] `last_fired_at` populated after trigger fire
- [x] Seeded triggers have `created_at` timestamp