### PR TITLE
fix(#542): normalize execution ID prefix to exec- format

### DIFF
--- a/apps/syn-api/src/syn_api/routes/executions/commands.py
+++ b/apps/syn-api/src/syn_api/routes/executions/commands.py
@@ -196,7 +196,7 @@ async def execute_workflow_endpoint(
     background_tasks: BackgroundTasks,
 ) -> ExecuteWorkflowResponse:
     """Start workflow execution in background."""
-    execution_id = str(uuid4())
+    execution_id = f"exec-{uuid4().hex[:12]}"
 
     async def _run() -> None:
         result = await execute(
@@ -238,8 +238,15 @@ async def get_execution_status_endpoint(
     execution_id: str,
 ) -> ExecutionStatusResponse:
     """Get the status of a workflow execution."""
+    from syn_api._wiring import get_projection_mgr
+    from syn_api.prefix_resolver import resolve_or_raise
+
     from .queries import get_detail
 
+    mgr = get_projection_mgr()
+    execution_id = await resolve_or_raise(
+        mgr.store, "workflow_execution_details", execution_id, "Execution"
+    )
     result = await get_detail(execution_id)
     if isinstance(result, Err):
         raise HTTPException(status_code=404, detail=f"Execution {execution_id} not found")

--- a/apps/syn-api/src/syn_api/routes/executions/control.py
+++ b/apps/syn-api/src/syn_api/routes/executions/control.py
@@ -204,6 +204,17 @@ async def get_state(
 # =============================================================================
 
 
+async def _resolve_execution_id(execution_id: str) -> str:
+    """Resolve a partial execution ID prefix to a full ID."""
+    from syn_api._wiring import get_projection_mgr
+    from syn_api.prefix_resolver import resolve_or_raise
+
+    mgr = get_projection_mgr()
+    return await resolve_or_raise(
+        mgr.store, "workflow_execution_details", execution_id, "Execution"
+    )
+
+
 async def _handle_control_result(result: Any, _action: str = "") -> ControlResponse:
     """Convert control result to HTTP response."""
     if isinstance(result, Err):
@@ -227,6 +238,7 @@ async def pause_execution_endpoint(
     request: PauseRequest | None = None,
 ) -> ControlResponse:
     """Pause a running execution."""
+    execution_id = await _resolve_execution_id(execution_id)
     result = await pause(execution_id, reason=request.reason if request else None)
     return await _handle_control_result(result, "pause")
 
@@ -234,6 +246,7 @@ async def pause_execution_endpoint(
 @router.post("/executions/{execution_id}/resume", response_model=ControlResponse)
 async def resume_execution_endpoint(execution_id: str) -> ControlResponse:
     """Resume a paused execution."""
+    execution_id = await _resolve_execution_id(execution_id)
     result = await resume(execution_id)
     return await _handle_control_result(result, "resume")
 
@@ -244,6 +257,7 @@ async def cancel_execution_endpoint(
     request: CancelRequest | None = None,
 ) -> ControlResponse:
     """Cancel a running or paused execution."""
+    execution_id = await _resolve_execution_id(execution_id)
     result = await cancel(execution_id, reason=request.reason if request else None)
     return await _handle_control_result(result, "cancel")
 
@@ -254,6 +268,7 @@ async def inject_context_endpoint(
     request: InjectRequest,
 ) -> ControlResponse:
     """Inject a message into the execution context."""
+    execution_id = await _resolve_execution_id(execution_id)
     result = await inject(execution_id, message=request.message, role=request.role)
     return await _handle_control_result(result, "inject")
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
@@ -82,7 +82,9 @@ class ExecuteWorkflowHandler:
             workflow_name=workflow.name or "",
             phases=phases,
             inputs=merged_inputs,
-            execution_id=command.execution_id or str(uuid4()),
+            execution_id=command.execution_id
+            if command.execution_id and command.execution_id.startswith("exec-")
+            else f"exec-{uuid4().hex[:12]}",
             repo_url=repo_url,
         )
 


### PR DESCRIPTION
## Summary
- **ExecuteWorkflowHandler**: Changed fallback ID generation from bare `str(uuid4())` to `exec-{uuid4().hex[:12]}`, with guard to reject caller-provided IDs missing the `exec-` prefix
- **commands.py execute endpoint**: Changed `str(uuid4())` to `exec-{uuid4().hex[:12]}` for the background execution ID
- **control.py**: Added `resolve_or_raise` prefix resolution to pause, resume, cancel, and inject endpoints (previously only `get_state` had it)
- **commands.py status endpoint**: Added `resolve_or_raise` prefix resolution for the `GET /{workflow_id}/executions/{execution_id}` endpoint

Closes #542

## Test plan
- [x] `pytest packages/syn-domain/tests/ -k execution` passes (40 tests)
- [x] `ruff check` and `ruff format` clean
- [ ] Verify partial ID `exec-abc` resolves correctly for pause/resume/cancel/inject
- [ ] Verify triggered executions and manual executions both get `exec-` prefix