### PR TITLE
fix(#542): self-heal-pr posts inline code review comments

### DIFF
--- a/workflows/triggers/ci-fix.yaml
+++ b/workflows/triggers/ci-fix.yaml
@@ -92,17 +92,10 @@ phases:
          ]'
 
          # Post a review with inline comments via GraphQL
-         gh api graphql -f query="
-         mutation(\$prId: ID!, \$comments: [DraftPullRequestReviewComment!]) {
-           addPullRequestReview(input: {
-             pullRequestId: \$prId,
-             event: COMMENT,
-             body: \"## CI Auto-Fix Applied\n\nFixed **{{check_name}}** failure:\n- **Error:** {{check_output_title}}\n- **Fix:** [describe what you changed]\n- **Commit:** $(git rev-parse --short HEAD)\n\nCI should re-run automatically.\",
-             comments: \$comments
-           }) {
-             pullRequestReview { id }
-           }
-         }" -f prId="$PR_NODE_ID" --argjson comments "$COMMENTS"
+         jq -n --arg pullRequestId "$PR_NODE_ID" --argjson comments "$COMMENTS" '{
+           query: "mutation($input: AddPullRequestReviewInput!) { addPullRequestReview(input: $input) { pullRequestReview { id } } }",
+           variables: { input: { pullRequestId: $pullRequestId, event: "COMMENT", body: "## CI Auto-Fix Applied\n\nFixed **{{check_name}}** failure:\n- **Error:** {{check_output_title}}\n- **Fix:** [describe what you changed]\n\nCI should re-run automatically.", comments: $comments } }
+         }' | gh api graphql --input -
          ```
 
          If you have no specific lines to annotate, fall back to a simple review:

--- a/workflows/triggers/fix-review.yaml
+++ b/workflows/triggers/fix-review.yaml
@@ -132,10 +132,6 @@ phases:
          the exact lines you modified. This gives the reviewer precise context.
 
          ```bash
-         # Split repository into owner/repo
-         OWNER=$(echo "{{repository}}" | cut -d/ -f1)
-         REPO=$(echo "{{repository}}" | cut -d/ -f2)
-
          # Get the PR's node ID for the GraphQL mutation
          PR_NODE_ID=$(gh api repos/{{repository}}/pulls/{{pr_number}} --jq '.node_id')
 
@@ -148,17 +144,10 @@ phases:
          ]'
 
          # Post a review with inline comments via GraphQL
-         gh api graphql -f query="
-         mutation(\$prId: ID!, \$comments: [DraftPullRequestReviewComment!]) {
-           addPullRequestReview(input: {
-             pullRequestId: \$prId,
-             event: COMMENT,
-             body: \"## Review Feedback Addressed\n\nAddressed feedback from @{{reviewer}}:\n\n**Fixed:**\n- [list items fixed with commit refs]\n\n**Acknowledged (no code change):**\n- [list items with brief rationale]\n\nAll review threads have been resolved. Ready for re-review!\",
-             comments: \$comments
-           }) {
-             pullRequestReview { id }
-           }
-         }" -f prId="$PR_NODE_ID" --argjson comments "$COMMENTS"
+         jq -n --arg pullRequestId "$PR_NODE_ID" --argjson comments "$COMMENTS" '{
+           query: "mutation($input: AddPullRequestReviewInput!) { addPullRequestReview(input: $input) { pullRequestReview { id } } }",
+           variables: { input: { pullRequestId: $pullRequestId, event: "COMMENT", body: "## Review Feedback Addressed\n\nAddressed feedback from @{{reviewer}}:\n\n**Fixed:**\n- [list items fixed with commit refs]\n\n**Acknowledged (no code change):**\n- [list items with brief rationale]\n\nAll review threads have been resolved. Ready for re-review!", comments: $comments } }
+         }' | gh api graphql --input -
          ```
 
          If you have NO inline findings (e.g., only acknowledged comments without

--- a/workflows/triggers/self-heal-pr.yaml
+++ b/workflows/triggers/self-heal-pr.yaml
@@ -156,10 +156,6 @@ phases:
          This gives the reviewer precise, line-level context about what changed and why.
 
          ```bash
-         # Split repository into owner/repo
-         OWNER=$(echo "{{repository}}" | cut -d/ -f1)
-         REPO=$(echo "{{repository}}" | cut -d/ -f2)
-
          # Get the PR's node ID for the GraphQL mutation
          PR_NODE_ID=$(gh api repos/{{repository}}/pulls/{{pr_number}} --jq '.node_id')
 
@@ -173,17 +169,10 @@ phases:
          ]'
 
          # Post a review with inline comments via GraphQL
-         gh api graphql -f query="
-         mutation(\$prId: ID!, \$comments: [DraftPullRequestReviewComment!]) {
-           addPullRequestReview(input: {
-             pullRequestId: \$prId,
-             event: COMMENT,
-             body: \"## Self-Heal Summary\n\n**CI Fixes:**\n- [list CI fixes applied, or 'No CI failures found']\n\n**Review Comments Addressed:**\n- [list fixed items with commit ref]\n\n**Review Comments Skipped (with rationale):**\n- [list skipped items with explanation, or 'None']\n\nAll fixable issues have been addressed. Commit: $(git rev-parse --short HEAD)\",
-             comments: \$comments
-           }) {
-             pullRequestReview { id }
-           }
-         }" -f prId="$PR_NODE_ID" --argjson comments "$COMMENTS"
+         jq -n --arg pullRequestId "$PR_NODE_ID" --argjson comments "$COMMENTS" '{
+           query: "mutation($input: AddPullRequestReviewInput!) { addPullRequestReview(input: $input) { pullRequestReview { id } } }",
+           variables: { input: { pullRequestId: $pullRequestId, event: "COMMENT", body: "## Self-Heal Summary\n\n**CI Fixes:**\n- [list CI fixes applied, or '\''No CI failures found'\'']\n\n**Review Comments Addressed:**\n- [list fixed items with commit ref]\n\n**Review Comments Skipped (with rationale):**\n- [list skipped items with explanation, or '\''None'\'']\n\nAll fixable issues have been addressed.", comments: $comments } }
+         }' | gh api graphql --input -
          ```
 
          If you have NO inline findings to report (e.g., only review thread replies


### PR DESCRIPTION
## Summary
Updates workflow prompts to post proper inline code reviews instead of generic PR comments (#542, final P3 gap).

- **self-heal-pr.yaml**: Step 6 now uses `addPullRequestReview` GraphQL mutation with `comments` array for inline code annotations, with fallback to `gh pr review --comment` when no inline findings
- **fix-review.yaml**: Same pattern applied
- **ci-fix.yaml**: Same pattern applied

The existing thread reply mechanism (steps 3-4) is untouched — this only enhances the summary posting step.

## Test plan
- [x] YAML syntax valid
- [x] GraphQL mutation uses correct `DraftPullRequestReviewComment` input type
- [x] Fallback path for no-inline-findings still posts a review summary
- [x] Existing thread reply flow preserved