### PR TITLE
fix(#542): add otlp_log to shared EventType — OTLP logs silently dropped

### DIFF
--- a/packages/syn-adapters/src/syn_adapters/events/models.py
+++ b/packages/syn-adapters/src/syn_adapters/events/models.py
@@ -31,6 +31,7 @@ from syn_shared.events import (
     GIT_COMMIT,
     GIT_OPERATION,
     GIT_PUSH,
+    OTLP_LOG,
     PERMISSION_REQUESTED,
     SECURITY_DECISION,
     SESSION_COMPLETED,
@@ -90,6 +91,8 @@ _EVENT_TYPE_MAPPING: dict[str, str] = {
     SYSTEM_NOTIFICATION: SYSTEM_NOTIFICATION,
     # User interaction events (from agentic_events.EventType)
     USER_PROMPT_SUBMITTED: USER_PROMPT_SUBMITTED,
+    # OTLP observability events (from workspace OTel push — ADR-056)
+    OTLP_LOG: OTLP_LOG,
 }
 
 # Fields excluded from the data dict (they go in top-level AgentEvent fields)

--- a/packages/syn-shared/src/syn_shared/events/__init__.py
+++ b/packages/syn-shared/src/syn_shared/events/__init__.py
@@ -72,6 +72,9 @@ SYSTEM_NOTIFICATION = "system_notification"
 # User interaction events (from agentic_events.EventType)
 USER_PROMPT_SUBMITTED = "user_prompt_submitted"
 
+# OTLP observability events (from workspace OTel push — ADR-056)
+OTLP_LOG = "otlp_log"
+
 # Type-safe literal union (like TypeScript)
 # MUST match the constants above and agentic_isolation.EventType
 EventType = Literal[
@@ -106,6 +109,7 @@ EventType = Literal[
     "context_compacted",
     "system_notification",
     "user_prompt_submitted",
+    "otlp_log",
 ]
 
 # Runtime validation set (auto-generated from Literal)
@@ -129,6 +133,7 @@ __all__ = [
     "GIT_OPERATION",
     "GIT_PUSH",
     "GIT_REWRITE",
+    "OTLP_LOG",
     "PERMISSION_REQUESTED",
     "PHASE_COMPLETED",
     "PHASE_STARTED",


### PR DESCRIPTION
## Summary

- OTLP log events from PR #555 (workspace tooling) were silently dropped by the TimescaleDB store
- The collector parsed them correctly (`accepted: 1`) but `AgentEvent` validation rejected `otlp_log` because it wasn't in the shared `EventType` Literal
- Found during local pressure testing of the OTLP `/v1/logs` endpoint

## Changes

- Add `OTLP_LOG = "otlp_log"` constant to `syn_shared/events/__init__.py`
- Add `otlp_log` to the `EventType` Literal and `__all__` exports
- Add `OTLP_LOG` mapping in `syn_adapters/events/models.py`

## Test plan

- [x] 16 OTLP tests pass (parser + routes)
- [x] 109 shared tests pass (including event type consistency)
- [x] 21 event model tests pass
- [x] Verified fix via local collector: `POST /v1/logs` → event accepted AND persisted (no more validation error in logs)