### PR TITLE
fix: pass explicit limit to insights cost aggregation

### DIFF
--- a/apps/syn-api/src/syn_api/routes/insights.py
+++ b/apps/syn-api/src/syn_api/routes/insights.py
@@ -125,7 +125,7 @@ async def get_global_cost(
     await ensure_connected()
 
     query_svc = get_execution_cost_query()
-    all_costs = await query_svc.list_all()
+    all_costs = await query_svc.list_all(limit=10_000)
 
     # Fix(#542): filter by system_id when provided
     if system_id:


### PR DESCRIPTION
## Summary

- Pass `limit=10_000` to `query_svc.list_all()` in `get_global_cost()` so global cost totals include all executions instead of silently capping at the default 500.

## Test plan

- [x] `uv run pytest apps/syn-api/tests/ -x -q` passes
- [ ] Verify insights cost endpoint returns correct totals for orgs with >500 executions