### PR TITLE
fix: CLI SYN_NO_PREFIX explicit boolean + workflow GraphQL side field

### DIFF
--- a/apps/syn-cli-node/src/client/http.ts
+++ b/apps/syn-cli-node/src/client/http.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_TIMEOUT_MS, SSE_CONNECT_TIMEOUT_MS, getApiUrl, getAuthHeaders } from "../config.js";
 
-const API_PREFIX = process.env["SYN_NO_PREFIX"] ? "" : "/api/v1";
+const API_PREFIX = (process.env["SYN_NO_PREFIX"] === "1" || process.env["SYN_NO_PREFIX"] === "true") ? "" : "/api/v1";
 
 export interface ApiResponse<T> {
   status: number;

--- a/apps/syn-cli-node/src/client/typed.ts
+++ b/apps/syn-cli-node/src/client/typed.ts
@@ -13,7 +13,7 @@ import createClient from "openapi-fetch";
 import type { paths } from "../generated/api-types.js";
 import { getApiUrl, getAuthHeaders } from "../config.js";
 
-const API_PREFIX = process.env["SYN_NO_PREFIX"] ? "" : "/api/v1";
+const API_PREFIX = (process.env["SYN_NO_PREFIX"] === "1" || process.env["SYN_NO_PREFIX"] === "true") ? "" : "/api/v1";
 
 export function createTypedClient() {
   const baseUrl = getApiUrl().replace(/\/+$/, "");

--- a/workflows/triggers/ci-fix.yaml
+++ b/workflows/triggers/ci-fix.yaml
@@ -88,7 +88,7 @@ phases:
          # current version of the file), body (description of the fix).
          # Example — adapt to your actual fixes:
          COMMENTS='[
-           {"path": "path/to/file.py", "line": 42, "body": "Fixed: description of change"}
+           {"path": "path/to/file.py", "line": 42, "side": "RIGHT", "body": "Fixed: description of change"}
          ]'
 
          # Post a review with inline comments via GraphQL

--- a/workflows/triggers/fix-review.yaml
+++ b/workflows/triggers/fix-review.yaml
@@ -140,7 +140,7 @@ phases:
          # current version of the file), body (description of the fix).
          # Example — adapt to your actual fixes:
          COMMENTS='[
-           {"path": "path/to/file.py", "line": 42, "body": "Fixed: description of change"}
+           {"path": "path/to/file.py", "line": 42, "side": "RIGHT", "body": "Fixed: description of change"}
          ]'
 
          # Post a review with inline comments via GraphQL

--- a/workflows/triggers/self-heal-pr.yaml
+++ b/workflows/triggers/self-heal-pr.yaml
@@ -164,8 +164,8 @@ phases:
          # current version of the file), body (description of the fix or finding).
          # Example with two inline comments — adapt to your actual findings:
          COMMENTS='[
-           {"path": "path/to/file.py", "line": 42, "body": "Fixed: description of what was changed here"},
-           {"path": "path/to/other.py", "line": 17, "body": "Fixed: description of second fix"}
+           {"path": "path/to/file.py", "line": 42, "side": "RIGHT", "body": "Fixed: description of what was changed here"},
+           {"path": "path/to/other.py", "line": 17, "side": "RIGHT", "body": "Fixed: description of second fix"}
          ]'
 
          # Post a review with inline comments via GraphQL


### PR DESCRIPTION
## Summary

- **SYN_NO_PREFIX truthy check:** Changed from JavaScript truthy check to explicit `=== "1" || === "true"` in both `typed.ts` and `http.ts`. Previously `SYN_NO_PREFIX=0` or `SYN_NO_PREFIX=false` would incorrectly disable the `/api/v1` prefix since any non-empty string is truthy in JS.
- **Workflow GraphQL `side` field:** Added missing `"side": "RIGHT"` to `AddPullRequestReviewInput.comments` objects in `self-heal-pr.yaml`, `fix-review.yaml`, and `ci-fix.yaml`. GitHub's GraphQL API may reject review comments without this field.

## Test plan

- [ ] Verify `pnpm build` passes in `syn-cli-node` (confirmed locally)
- [ ] Confirm `SYN_NO_PREFIX=1` still disables the prefix
- [ ] Confirm `SYN_NO_PREFIX=0` no longer disables the prefix
- [ ] Trigger workflow templates still valid YAML