### PR TITLE
fix: trigger projection uses event timestamp instead of clock time

### DIFF
--- a/packages/syn-adapters/src/syn_adapters/projections/trigger_query_projection.py
+++ b/packages/syn-adapters/src/syn_adapters/projections/trigger_query_projection.py
@@ -79,7 +79,7 @@ class TriggerQueryProjection(CheckpointedProjection):
         handler_name = self._EVENT_DISPATCH.get(event_type)
         if handler_name is not None:
             handler = getattr(self, handler_name)
-            await handler(event_data)
+            await handler(event_data, envelope)
 
     async def handle_event(
         self,
@@ -117,7 +117,9 @@ class TriggerQueryProjection(CheckpointedProjection):
             await self._store.delete_all(NS_FIRE_RECORDS)
             await self._store.delete_all(NS_DELIVERIES)
 
-    async def _on_trigger_registered(self, data: dict[str, Any]) -> None:
+    async def _on_trigger_registered(
+        self, data: dict[str, Any], envelope: EventEnvelope[Any]
+    ) -> None:
         trigger_id = data.get("trigger_id", "")
         await self._store.save(
             NS_TRIGGER_INDEX,
@@ -135,25 +137,29 @@ class TriggerQueryProjection(CheckpointedProjection):
                 "created_by": data.get("created_by", ""),
                 "status": "active",
                 "fire_count": 0,
-                "created_at": datetime.now(UTC).isoformat(),
+                "created_at": envelope.metadata.timestamp.isoformat(),
             },
         )
 
-    async def _on_trigger_paused(self, data: dict[str, Any]) -> None:
+    async def _on_trigger_paused(self, data: dict[str, Any], _envelope: EventEnvelope[Any]) -> None:
         trigger_id = data.get("trigger_id", "")
         existing = await self._store.get(NS_TRIGGER_INDEX, trigger_id)
         if existing:
             existing["status"] = "paused"
             await self._store.save(NS_TRIGGER_INDEX, trigger_id, existing)
 
-    async def _on_trigger_resumed(self, data: dict[str, Any]) -> None:
+    async def _on_trigger_resumed(
+        self, data: dict[str, Any], _envelope: EventEnvelope[Any]
+    ) -> None:
         trigger_id = data.get("trigger_id", "")
         existing = await self._store.get(NS_TRIGGER_INDEX, trigger_id)
         if existing:
             existing["status"] = "active"
             await self._store.save(NS_TRIGGER_INDEX, trigger_id, existing)
 
-    async def _on_trigger_deleted(self, data: dict[str, Any]) -> None:
+    async def _on_trigger_deleted(
+        self, data: dict[str, Any], _envelope: EventEnvelope[Any]
+    ) -> None:
         trigger_id = data.get("trigger_id", "")
         existing = await self._store.get(NS_TRIGGER_INDEX, trigger_id)
         if existing:


### PR DESCRIPTION
## Summary

- Fixed `_dispatch_event` to pass `EventEnvelope` to all handlers, not just `_on_trigger_fired`
- Changed `_on_trigger_registered` to use `envelope.metadata.timestamp` instead of `datetime.now(UTC)` for `created_at`, so projection rebuilds preserve the original event timestamp
- Updated `_on_trigger_paused`, `_on_trigger_resumed`, and `_on_trigger_deleted` signatures to accept the envelope parameter

## Test plan

- [x] All `packages/syn-adapters/tests/` pass (479 passed, 2 xfail)
- [x] Formatted with `ruff format`
- [ ] Verify trigger `created_at` survives projection rebuild with correct original timestamp