### PR TITLE
fix: smoke test network lookup + release gating

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -32,10 +32,9 @@ on:
       - main
       - release
       - 'release/**'
-    paths:
-      - 'docker/**'
-      - 'infra/docker/**'
-      - '.github/workflows/smoke-test.yml'
+    # No paths filter — every push to main/release gets a smoke test result.
+    # Required for release branch protection (smoke test must pass before
+    # main → release PR can merge).
   # Disabled: ~4 min Docker build is a CI/CD bottleneck for PR iteration.
   # Tier 1 fitness tests catch config drift on every push. This smoke test
   # runs post-merge as a safety net before release.
@@ -162,11 +161,14 @@ jobs:
           # The envoy image is minimal (no curl/wget). Use a lightweight
           # container on the agent-net network to verify DNS + HTTP connectivity.
           #
-          # Filter by compose project name to avoid grabbing a stale agent-net
-          # from a different project (e.g. dev stack).
-          PROJECT=$(docker compose $COMPOSE_FILES config --format json | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")
-          AGENT_NET=$(docker network ls --filter "name=${PROJECT}_agent-net" --format '{{.Name}}' | head -1)
-          echo "Compose project: $PROJECT"
+          # Extract the actual network name from compose config — the network
+          # has an explicit name (syntropic137_${APP_ENVIRONMENT}_agent-net)
+          # that differs from the compose project prefix.
+          AGENT_NET=$(docker compose $COMPOSE_FILES config --format json | python3 -c "
+          import sys, json
+          config = json.load(sys.stdin)
+          print(config.get('networks', {}).get('agent-net', {}).get('name', ''))
+          ")
           echo "Agent network: $AGENT_NET"
           if [ -z "$AGENT_NET" ]; then
             echo "ERROR: Could not find agent-net network for project '$PROJECT'"


### PR DESCRIPTION
## Summary

- **Fix network lookup** — extract actual network name from compose config instead of guessing from project prefix. The `agent-net` network has an explicit name (`syntropic137_${APP_ENVIRONMENT}_agent-net`) that uses a different default than the compose project name, causing the lookup to always fail.
- **Remove paths filter** — ensure every push to main/release gets a smoke test result. Required for release branch protection to gate main → release merges.

## Context

v0.21.3 released with a failing smoke test because:
1. The network lookup never found `agent-net` (name mismatch)
2. The release workflow ran independently of the smoke test result

## Follow-up (manual)

After merge, add "Compose Stack Smoke Test" as a required status check on the `release` branch protection rules. This gates main → release merges on smoke test status without adding latency to the release pipeline.

## Test plan

- [ ] CI passes
- [ ] Smoke test passes on main after merge (network lookup finds the correct network)
- [ ] Verify smoke test runs even when no Docker files changed (paths filter removed)