### PR TITLE
fix(#576): selfhost API degraded mode — MinIO startup race + recovery loop

### DIFF
--- a/apps/syn-api/src/syn_api/services/lifecycle.py
+++ b/apps/syn-api/src/syn_api/services/lifecycle.py
@@ -355,7 +355,6 @@ async def _attempt_recovery_pass(state: LifecycleState, delay: float) -> None:
             logger.debug("Recovery retry failed for %s, will retry in %.0fs", reason, delay)
 
 
-
 async def _recovery_loop(state: LifecycleState) -> None:
     """Background task: retry degraded subsystems with exponential backoff.
 


### PR DESCRIPTION
## Summary

Fixes the selfhost deployment entering permanent degraded mode due to a MinIO startup race condition.

- **Docker Compose**: Add `minio: condition: service_healthy` to the API's `depends_on` so the API container waits for MinIO to be healthy before starting. Remove the exposed MinIO port (`127.0.0.1:9000:9000`) since bucket init now happens inside the Docker network via `ensure_ready()`.
- **Lifecycle recovery loop**: Add a `DegradedReason` StrEnum replacing string literals. Introduce a background `_recovery_loop()` task with exponential backoff (10s-60s) that retries recoverable subsystems (artifact storage, subscription coordinator) after transient startup failures. Non-recoverable reasons (missing API keys, GitHub App config) are left alone.
- **Credentials**: Update `validate_credentials()` to use `DegradedReason` enum values instead of raw strings.

## Test plan

- [ ] Deploy selfhost stack from scratch — API should reach `full` mode (not `degraded`)
- [ ] Verify MinIO health check gate works: API container starts only after MinIO is healthy
- [ ] Simulate MinIO delay: API enters degraded, recovery loop brings it back to full
- [ ] Verify shutdown cancels recovery task cleanly

Closes #576