### PR TITLE
fix: codegen sync + Copilot review (#635)

### DIFF
--- a/apps/syn-api/src/syn_api/routes/sessions.py
+++ b/apps/syn-api/src/syn_api/routes/sessions.py
@@ -127,12 +127,18 @@ class SessionResponse(BaseModel):
 # =============================================================================
 
 
-async def _build_workflow_name_map() -> dict[str, str]:
-    """Build a {workflow_id: workflow_name} lookup from the workflow list projection."""
+async def _build_workflow_name_map(workflow_ids: set[str]) -> dict[str, str]:
+    """Build a {workflow_id: workflow_name} lookup for the given IDs via targeted store lookups."""
+    if not workflow_ids:
+        return {}
     try:
         manager = get_projection_mgr()
-        workflows = await manager.workflow_list.query()
-        return {w.id: w.name for w in workflows if w.name}
+        result: dict[str, str] = {}
+        for wf_id in workflow_ids:
+            wf_data = await manager.store.get("workflow_summaries", wf_id)
+            if isinstance(wf_data, dict) and wf_data.get("name"):
+                result[wf_id] = wf_data["name"]
+        return result
     except Exception:
         logger.debug("Could not load workflow names for session display", exc_info=True)
         return {}
@@ -404,7 +410,8 @@ async def list_sessions_endpoint(
         raise HTTPException(status_code=500, detail=result.message)
 
     summaries = result.value
-    wf_names = await _build_workflow_name_map()
+    wf_ids = {s.workflow_id for s in summaries if s.workflow_id}
+    wf_names = await _build_workflow_name_map(wf_ids)
     responses = [
         SessionSummaryResponse(
             id=s.id,

--- a/apps/syn-cli-node/src/generated/api-types.ts
+++ b/apps/syn-cli-node/src/generated/api-types.ts
@@ -3462,6 +3462,8 @@ export interface components {
             id: string;
             /** Workflow Id */
             workflow_id: string | null;
+            /** Workflow Name */
+            workflow_name?: string | null;
             /** Execution Id */
             execution_id?: string | null;
             /** Phase Id */

--- a/apps/syn-dashboard-ui/src/api/sessions.ts
+++ b/apps/syn-dashboard-ui/src/api/sessions.ts
@@ -20,6 +20,6 @@ export async function listSessions(params?: {
   return fetchJSON(`${API_BASE}/sessions${query ? `?${query}` : ''}`)
 }
 
-export async function getSession(sessionId: string): Promise<SessionResponse> {
-  return fetchJSON<SessionResponse>(`${API_BASE}/sessions/${sessionId}`)
+export async function getSession(sessionId: string, signal?: AbortSignal): Promise<SessionResponse> {
+  return fetchJSON<SessionResponse>(`${API_BASE}/sessions/${sessionId}`, { signal })
 }

--- a/apps/syn-dashboard-ui/src/hooks/useSessionData.ts
+++ b/apps/syn-dashboard-ui/src/hooks/useSessionData.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { getSession } from '../api/sessions'
 import type { SessionResponse } from '../types'
 import { useLiveTimer } from './useLiveTimer'
 import { usePolling } from './usePolling'
@@ -13,16 +14,6 @@ export interface UseSessionDataResult {
 }
 
 const FETCH_TIMEOUT_MS = 15_000
-const API_BASE = '/api/v1'
-
-async function fetchSessionWithTimeout(sessionId: string, signal?: AbortSignal): Promise<SessionResponse> {
-  const response = await fetch(`${API_BASE}/sessions/${sessionId}`, { signal })
-  if (!response.ok) {
-    const error = await response.json().catch(() => ({ detail: response.statusText }))
-    throw new Error(error.detail || `API Error: ${response.status}`)
-  }
-  return response.json()
-}
 
 export function useSessionData(sessionId: string | undefined): UseSessionDataResult {
   const [session, setSession] = useState<SessionResponse | null>(null)
@@ -49,7 +40,7 @@ export function useSessionData(sessionId: string | undefined): UseSessionDataRes
       controller.abort()
     }, FETCH_TIMEOUT_MS)
 
-    fetchSessionWithTimeout(sessionId, controller.signal)
+    getSession(sessionId, controller.signal)
       .then((data) => {
         setSession(data)
         setError(null)

--- a/apps/syn-docs/openapi.json
+++ b/apps/syn-docs/openapi.json
@@ -8421,6 +8421,17 @@
             ],
             "title": "Workflow Id"
           },
+          "workflow_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Workflow Name"
+          },
           "execution_id": {
             "anyOf": [
               {

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -437,13 +437,12 @@ class WorkflowExecutionProcessor:
 
         if result.command.exit_code != 0:
             reason = result.stream_result.error_reason
-            msg = (
+            base = (
                 f"Agent failed: {reason} (phase={todo.phase_id}, exit_code={result.command.exit_code})"
                 if reason
-                else f"Agent execution failed for phase {todo.phase_id} "
-                f"(exit_code={result.command.exit_code}, "
-                f"tokens={result.tokens.input_tokens}+{result.tokens.output_tokens})"
+                else f"Agent execution failed for phase {todo.phase_id} (exit_code={result.command.exit_code})"
             )
+            msg = f"{base} (tokens={result.tokens.input_tokens}+{result.tokens.output_tokens})"
             logger.error(msg)
             raise RuntimeError(msg)
 

--- a/uv.lock
+++ b/uv.lock
@@ -1322,7 +1322,7 @@ wheels = [
 
 [[package]]
 name = "syn-adapters"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "packages/syn-adapters" }
 dependencies = [
     { name = "agentic-events" },
@@ -1374,7 +1374,7 @@ provides-extras = ["postgres", "minio", "all"]
 
 [[package]]
 name = "syn-api"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "apps/syn-api" }
 dependencies = [
     { name = "agentic-logging" },
@@ -1405,7 +1405,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-collector"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "packages/syn-collector" }
 dependencies = [
     { name = "click" },
@@ -1445,7 +1445,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "syn-domain"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "packages/syn-domain" }
 dependencies = [
     { name = "agentic-events" },
@@ -1466,7 +1466,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-perf"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "packages/syn-perf" }
 dependencies = [
     { name = "rich" },
@@ -1494,7 +1494,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "syn-shared"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "packages/syn-shared" }
 dependencies = [
     { name = "pydantic" },
@@ -1513,7 +1513,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-tokens"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "packages/syn-tokens" }
 dependencies = [
     { name = "pydantic" },
@@ -1530,7 +1530,7 @@ requires-dist = [
 
 [[package]]
 name = "syntropic137"
-version = "0.22.3"
+version = "0.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "event-sourcing-python" },


### PR DESCRIPTION
Fixes the two release-gate failures on PR #635 (`main → release`):

- **CLI ↔ API Sync**: regenerate `api-types.ts` and `openapi.json` to include `workflow_name` and `error_message` fields added in #633
- **Docs Drift**: `apps/syn-docs/openapi.json` updated to match

Also addresses 3 Copilot review comments from #635:
1. `_build_workflow_name_map()` — replace bulk query (limit=100) with targeted store lookups per workflow ID so names are never missing for larger datasets
2. `useSessionData` — route through shared `getSession()` client instead of raw `fetch()` so existing tests keep working and `AbortSignal` passes consistently
3. `WorkflowExecutionProcessor` — include token counts in both branches of the agent failure log message

## Test plan
- [ ] CI green (CLI ↔ API Sync, Docs Drift both pass)
- [ ] PR #635 CI reruns and passes after this merges to main