### PR TITLE
fix: workflow name lookups — concurrent, per-ID error handling, no magic strings (#637 follow-up)

### DIFF
--- a/apps/syn-api/src/syn_api/routes/sessions.py
+++ b/apps/syn-api/src/syn_api/routes/sessions.py
@@ -33,7 +33,6 @@ from syn_api.types import (
     SessionSummary,
     ToolOperation,
 )
-
 from syn_domain.contexts.orchestration.slices.list_workflows.projection import (
     WorkflowListProjection,
 )
@@ -132,7 +131,9 @@ class SessionResponse(BaseModel):
 # =============================================================================
 
 
-async def _fetch_one_workflow_name(manager: ProjectionManager, wf_id: str) -> tuple[str, str] | None:
+async def _fetch_one_workflow_name(
+    manager: ProjectionManager, wf_id: str
+) -> tuple[str, str] | None:
     """Fetch a single workflow name; returns (id, name) or None on failure."""
     try:
         wf_data = await manager.store.get(WorkflowListProjection.PROJECTION_NAME, wf_id)
@@ -367,7 +368,9 @@ async def get_session(
     wf_name: str | None = None
     if session.workflow_id:
         try:
-            wf_data = await manager.store.get(WorkflowListProjection.PROJECTION_NAME, session.workflow_id)
+            wf_data = await manager.store.get(
+                WorkflowListProjection.PROJECTION_NAME, session.workflow_id
+            )
             if isinstance(wf_data, dict):
                 wf_name = wf_data.get("name")
         except Exception:


### PR DESCRIPTION
Addresses 3 Copilot comments from PR #637:

1. **Concurrent fetches** — `asyncio.gather()` replaces sequential `for` loop; 200 sessions → 200 concurrent store lookups instead of 200 serial round-trips
2. **Per-ID error handling** — exceptions caught at `_fetch_one_workflow_name()` level so a single transient failure doesn't blank all names for the response
3. **No magic strings** — use `WorkflowListProjection.PROJECTION_NAME` constant in both the list lookup and the existing `get_session()` targeted lookup

## Test plan
- [ ] CI green
- [ ] PR #635 release gate passes after this merges