### PR TITLE
chore: release v0.24.2

### DIFF
--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -43,6 +43,10 @@ on:
         type: string
   workflow_dispatch:
     inputs:
+      version:
+        description: "Version to publish (e.g. v0.24.2). Required when dry_run=false — must match package.json version on the release branch."
+        required: false
+        default: ""
       dry_run:
         description: "Dry run — build and test but don't publish"
         type: boolean
@@ -111,8 +115,9 @@ jobs:
           PKG_VERSION=$(node -p "require('./package.json').version")
           RELEASE_VERSION="${{ steps.version.outputs.semver }}"
 
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "Skipping version check for manual dispatch (dry run)"
+          # Skip version check only for dry-run dispatches with no version specified
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -z "${{ inputs.version }}" ]]; then
+            echo "Skipping version check for dry-run dispatch (no version specified)"
             exit 0
           fi
 

--- a/.github/workflows/release-cli.yaml
+++ b/.github/workflows/release-cli.yaml
@@ -2,7 +2,11 @@
 # Release CLI — Build, Test, Publish @syntropic137/cli to npm
 # =============================================================================
 #
-# Trigger: GitHub release published (same as release-containers).
+# Trigger: Called by release-create.yml (workflow_call) only.
+#          Manual dispatch (workflow_dispatch) is available for re-triggering
+#          a failed publish — must be run from the `release` branch only.
+#          DO NOT add a release.published trigger — it bypasses the approval gate.
+#          See docs/release-process.md before modifying this workflow.
 #
 # Pipeline:
 #   1. Verify package.json version matches release tag
@@ -12,7 +16,7 @@
 # Prerequisites:
 #   - Configure Trusted Publisher on npmjs.com for @syntropic137/cli:
 #     repo: syntropic137/syntropic137
-#     workflow: release-cli.yaml
+#     workflow: release-create.yml   <-- the CALLER, not this file
 #     environment: npm-publish-cli
 #   - Requires npm >= 11.5.1 and Node >= 22 for OIDC token exchange
 #
@@ -29,8 +33,8 @@
 name: Release CLI
 
 on:
-  release:
-    types: [published]
+  # release.published intentionally omitted — direct release events bypass the
+  # approval gate in release-create.yml. See docs/release-process.md.
   workflow_call:
     inputs:
       version:
@@ -65,6 +69,15 @@ jobs:
       id-token: write  # npm provenance + OIDC Trusted Publishing
 
     steps:
+      - name: Guard — dispatch only allowed from release branch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/release" ]]; then
+            echo "::error::Manual dispatch must be run from the release branch. Got: ${{ github.ref }}"
+            echo "See docs/release-process.md for the recovery procedure."
+            exit 1
+          fi
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:

--- a/.github/workflows/release-containers.yaml
+++ b/.github/workflows/release-containers.yaml
@@ -2,7 +2,11 @@
 # Release Containers — Build, Scan, Sign, Publish to GHCR
 # =============================================================================
 #
-# Trigger: GitHub release published (or manual dispatch for testing).
+# Trigger: Called by release-create.yml (workflow_call) only.
+#          Manual dispatch (workflow_dispatch) is available for re-triggering
+#          a failed build — must be run from the `release` branch only.
+#          DO NOT add a release.published trigger — it bypasses the approval gate.
+#          See docs/release-process.md before modifying this workflow.
 #
 # Pipeline:
 #   1. Build container images (multi-arch for servers, amd64-only for UI)
@@ -22,8 +26,8 @@
 name: Release Containers
 
 on:
-  release:
-    types: [published]
+  # release.published intentionally omitted — direct release events bypass the
+  # approval gate in release-create.yml. See docs/release-process.md.
   workflow_call:
     inputs:
       version:
@@ -39,7 +43,7 @@ on:
       dry_run:
         description: "Dry run — build and scan but don't push or sign"
         type: boolean
-        default: false
+        default: true  # Safe default: dispatch without explicit inputs never pushes
 
 concurrency:
   group: release-containers-${{ github.ref }}
@@ -111,6 +115,18 @@ jobs:
     # to the release-assets job via upload/download artifact instead.
 
     steps:
+      # -----------------------------------------------------------------------
+      # Poka-yoke guard — dispatch only from release branch
+      # -----------------------------------------------------------------------
+      - name: Guard — dispatch only allowed from release branch
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/release" ]]; then
+            echo "::error::Manual dispatch must be run from the release branch. Got: ${{ github.ref }}"
+            echo "See docs/release-process.md for the recovery procedure."
+            exit 1
+          fi
+
       # -----------------------------------------------------------------------
       # Checkout
       # -----------------------------------------------------------------------

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -17,7 +17,7 @@
 # relying on the release.published event.
 # =============================================================================
 
-name: Release
+name: Release (Create)
 
 on:
   push:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -334,6 +334,7 @@ The canonical release process lives in [docs/release-process.md](docs/release-pr
 - **Beta releases** bypass `release`: `gh release create v0.20.0-beta.1 --prerelease --target main`
 - **Version management:** `just bump-version 0.20.0` updates all 11 files. `just check-version` validates consistency.
 - **Docs:** `release` → Vercel production, `main` → preview only.
+- **Poka-yoke rules:** Before touching any release workflow or triggering a publish manually, read [docs/release-process.md](docs/release-process.md). The publish workflows have strict firing rules — wrong entry points are blocked by design.
 
 Submodules (agentic-primitives, event-sourcing-platform) have independent versioning — never bumped by the release script.
 

--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.24.1"
+version = "0.24.2"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli-node/README.md
+++ b/apps/syn-cli-node/README.md
@@ -1,6 +1,6 @@
 # @syntropic137/cli
 
-Command-line interface for [Syntropic137](https://github.com/syntropic137/syntropic137) — an event-sourced workflow engine for AI agents.
+Command-line interface for [Syntropic137](https://github.com/syntropic137/syntropic137). An event-sourced workflow engine for AI agents.
 
 ## Design
 
@@ -8,10 +8,10 @@ Command-line interface for [Syntropic137](https://github.com/syntropic137/syntro
 
 The CLI is built with a zero-dependency philosophy:
 
-- **No Commander.js** — custom two-level command framework on `node:parseArgs`
-- **No chalk** — direct ANSI escape codes with `NO_COLOR` support
-- **No axios** — built-in `fetch` with timeout and streaming (SSE)
-- **One runtime dep** — [Zod](https://zod.dev) for local file validation only
+- **No Commander.js**: custom two-level command framework on `node:parseArgs`
+- **No chalk**: direct ANSI escape codes with `NO_COLOR` support
+- **No axios**: built-in `fetch` with timeout and streaming (SSE)
+- **One runtime dep**: [Zod](https://zod.dev) for local file validation only
 
 The entire CLI ships as a single `dist/syn.mjs` file (168 KB). It targets Node.js 22+ with strict TypeScript (`noUncheckedIndexedAccess`, `exactOptionalPropertyTypes`).
 
@@ -212,10 +212,10 @@ syn insights heatmap                 # Activity heatmap
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `SYN_API_URL` | `http://localhost:8137` | API server URL |
-| `SYN_API_TOKEN` | — | Bearer token for authentication |
-| `SYN_API_USER` | — | Basic auth username |
-| `SYN_API_PASSWORD` | — | Basic auth password |
-| `NO_COLOR` | — | Disable colored output |
+| `SYN_API_TOKEN` | (none) | Bearer token for authentication |
+| `SYN_API_USER` | (none) | Basic auth username |
+| `SYN_API_PASSWORD` | (none) | Basic auth password |
+| `NO_COLOR` | (none) | Disable colored output |
 
 ## Development
 

--- a/apps/syn-cli-node/package.json
+++ b/apps/syn-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntropic137/cli",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "description": "Syntropic137 CLI - Event-sourced workflow engine for AI agents",
   "type": "module",
   "bin": {

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.24.1",
+  "version": "0.24.2",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-docs/package.json
+++ b/apps/syn-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-docs",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -285,17 +285,18 @@ The `create-release` job in `release-create.yml` uses `environment: release-publ
 If containers or CLI publish fails after the GitHub Release was already created:
 
 ```bash
-# Re-trigger CLI publish (dry_run must be explicitly set to false)
+# Re-trigger CLI publish (version must match package.json on the release branch)
 gh workflow run release-cli.yaml \
   --repo syntropic137/syntropic137 \
   --ref release \
+  -f version=vX.Y.Z \
   -f dry_run=false
 
 # Re-trigger containers publish
 gh workflow run release-containers.yaml \
   --repo syntropic137/syntropic137 \
   --ref release \
-  -f version=v0.24.1 \
+  -f version=vX.Y.Z \
   -f dry_run=false
 ```
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -36,7 +36,8 @@ Create `@syntropic137` at https://www.npmjs.com/org/create (if not already done)
    ```
 3. Configure Trusted Publisher on npmjs.com:
    - Go to https://www.npmjs.com/package/@syntropic137/cli/access
-   - Add Trusted Publisher: repo=`syntropic137/syntropic137`, workflow=`release-cli.yaml`, environment=`npm-publish-cli`
+   - Add Trusted Publisher: repo=`syntropic137/syntropic137`, workflow=`release-create.yml`, environment=`npm-publish-cli`
+   - **Important:** The workflow must be the **caller** (`release-create.yml`), not the callee (`release-cli.yaml`). GitHub mints the OIDC token with the caller's workflow name.
 4. Create the `npm-publish-cli` GitHub environment: repo Settings > Environments > New > `npm-publish-cli`
 5. After Trusted Publishing is configured, the `CLI_PUBLISH_NPM_TOKEN` secret is no longer needed and can be deleted.
 
@@ -107,7 +108,7 @@ Two environments are needed across the two repos:
 just bump-version 0.20.0
 ```
 
-This updates all 13 version files atomically (9 `pyproject.toml` + 4 `package.json`). Validate with `just check-version`.
+This updates all 11 version files atomically (8 `pyproject.toml` + 3 `package.json`). Validate with `just check-version`.
 
 ### 2. Commit and Push
 
@@ -119,7 +120,20 @@ git push origin main
 
 ### 3. Open Release PR
 
-Open a PR from `main` to `release`. The PR body becomes the GitHub Release notes — write meaningful release notes here.
+Open a PR from `main` to `release`. **The PR body becomes the GitHub Release notes** — write meaningful release notes here. The release-gate check enforces a minimum of 20 characters. Use this format as a guide:
+
+```markdown
+## What's Changed
+
+- Brief description of each notable change
+- Bug fixes, new features, breaking changes
+
+## Upgrade Notes
+
+Any migration steps or config changes required.
+```
+
+The `release-create.yml` workflow reads the merged PR body verbatim and sets it as the GitHub Release description. Write it for end users, not for internal tracking.
 
 ### 4. Release Gate Checks
 
@@ -217,17 +231,29 @@ PR: main → release
   └── release-gate.yml
         ├── version-check
         ├── changelog-check
-        ├── docker-dry-run (7 images)
+        ├── docker-dry-run (6 images)
         └── release-gate-success (aggregator)
 
 Merge to release
-  └── release-create.yml
-        ├── create-release (tag + GitHub Release)
-        ├── release-containers (reusable workflow call)
-        │     ├── build-scan-push (8 images, multi-arch)
+  └── release-create.yml  (triggered by push to release)
+        │
+        ├── create-release job
+        │     ⏸ environment: release-publish  ← MANUAL APPROVAL REQUIRED HERE
+        │     ├── read version from pyproject.toml
+        │     ├── create git tag
+        │     └── create GitHub Release (PR body = release notes)
+        │
+        ├── pre-publish-validation job  (needs: create-release)
+        │     ├── verify CLI types match OpenAPI spec
+        │     ├── verify CLI docs are current
+        │     └── verify API docs are current
+        │
+        ├── release-containers.yaml  (workflow_call, needs: pre-publish-validation)
+        │     ├── build-scan-push (6 images, multi-arch)
         │     └── release-assets (compose, SHA256SUMS, cosign sig, npx dispatch)
-        └── release-cli (reusable workflow call)
-              └── publish (npm, provenance)
+        │
+        └── release-cli.yaml  (workflow_call, needs: pre-publish-validation)
+              └── publish (npm OIDC, provenance)
 ```
 
 ## Branch Protection (release)
@@ -237,6 +263,47 @@ Merge to release
 - Squash merge only
 - No force pushes, no deletions
 - Admin bypass for emergencies
+
+## Poka-Yoke Rules
+
+These rules exist to prevent out-of-order publishing. Do not work around them.
+
+### The only valid release entry point is `release-create.yml`
+
+`release-containers.yaml` and `release-cli.yaml` are **internal callees** — they must only be triggered by `release-create.yml` via `workflow_call`. Direct triggers are poka-yoke protected:
+
+- **`release.published` is intentionally absent** from both publish workflows. A manually created GitHub Release (via UI, `gh release create`, or an AI agent) does not trigger publishing — it bypasses the approval gate.
+- **`workflow_dispatch` is branch-guarded** — both workflows reject dispatch from any branch other than `release`.
+- **`workflow_dispatch` dry_run defaults to `true`** on both workflows — dispatch with default inputs never pushes anything.
+
+### The approval gate
+
+The `create-release` job in `release-create.yml` uses `environment: release-publish`. GitHub pauses here and waits for a human to approve before creating the tag, the GitHub Release, or calling any publish workflow. **You must approve this manually every time.**
+
+### How to safely re-trigger a failed publish step
+
+If containers or CLI publish fails after the GitHub Release was already created:
+
+```bash
+# Re-trigger CLI publish (dry_run must be explicitly set to false)
+gh workflow run release-cli.yaml \
+  --repo syntropic137/syntropic137 \
+  --ref release \
+  -f dry_run=false
+
+# Re-trigger containers publish
+gh workflow run release-containers.yaml \
+  --repo syntropic137/syntropic137 \
+  --ref release \
+  -f version=v0.24.1 \
+  -f dry_run=false
+```
+
+Both commands must be run against `--ref release`. Any other ref will be rejected by the branch guard.
+
+### Do not create GitHub Releases manually
+
+Creating a release via the GitHub UI, `gh release create`, or any automated tool does NOT trigger publishing (by design). It will create the tag and GitHub Release but nothing will be built or published. The only way to publish is through the `release-create.yml` orchestrator.
 
 ## Known Gotchas
 

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.24.1"
+version = "0.24.2"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.24.1"
+version = "0.24.2"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.24.1"
+version = "0.24.2"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.24.1"
+version = "0.24.2"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.24.1"
+version = "0.24.2"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.24.1"
+version = "0.24.2"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.24.1"
+version = "0.24.2"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## What's Changed

- Hardened release workflow poka-yoke: publish workflows now only fire via the `release-create.yml` orchestrator — no more accidental publishing from manual releases or direct dispatches
- Fixed Trusted Publisher configuration docs (was referencing wrong workflow filename — root cause of v0.24.1 CLI publish failure)
- Added branch guard to both publish workflows: dispatch rejected unless run from `release` branch
- Flipped `release-containers` dry_run default to `true` — safe by default on manual dispatch
- Updated workflow architecture diagram and added Poka-Yoke Rules section to `docs/release-process.md`
- Added release process pointer to `AGENTS.md` so agents read the rules before touching release workflows
- CLI README: removed em dashes, use colons in design bullets

## Upgrade Notes

No breaking changes. Internal CI/release workflow changes only.