### PR TITLE
refactor(ci): composable release gate checks + codegen drift script

### DIFF
--- a/.github/workflows/checks/changelog-check.yml
+++ b/.github/workflows/checks/changelog-check.yml
@@ -7,7 +7,7 @@
 # Called by: release-gate.yml
 # =============================================================================
 
-name: Check — Release Notes
+name: Check - Release Notes
 
 on:
   workflow_call:

--- a/.github/workflows/checks/changelog-check.yml
+++ b/.github/workflows/checks/changelog-check.yml
@@ -1,0 +1,42 @@
+# =============================================================================
+# Check: Release Notes Present
+# =============================================================================
+# Validates the PR body contains meaningful release notes (min 20 chars).
+# The PR body is used verbatim as the GitHub Release description.
+#
+# Called by: release-gate.yml
+# =============================================================================
+
+name: Check — Release Notes
+
+on:
+  workflow_call:
+    inputs:
+      pr_body:
+        description: Pull request body text
+        type: string
+        required: true
+
+permissions: {}
+
+jobs:
+  changelog-check:
+    name: Release Notes Present
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR body has release notes
+        env:
+          PR_BODY: ${{ inputs.pr_body }}
+        run: |
+          if [ -z "$PR_BODY" ]; then
+            echo "::error::PR body is empty. Add release notes describing what changed."
+            exit 1
+          fi
+
+          BODY_LENGTH=${#PR_BODY}
+          if [ "$BODY_LENGTH" -lt 20 ]; then
+            echo "::error::PR body is too short ($BODY_LENGTH chars). Add meaningful release notes."
+            exit 1
+          fi
+
+          echo "OK: Release notes present ($BODY_LENGTH chars)"

--- a/.github/workflows/checks/codegen-sync.yml
+++ b/.github/workflows/checks/codegen-sync.yml
@@ -42,6 +42,8 @@ jobs:
 
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
 
+      - uses: extractions/setup-just@v2
+
       - name: Install dependencies
         run: |
           pnpm --filter @syntropic137/cli install --frozen-lockfile

--- a/.github/workflows/checks/codegen-sync.yml
+++ b/.github/workflows/checks/codegen-sync.yml
@@ -14,7 +14,7 @@
 # Called by: release-gate.yml, release-create.yml (pre-publish validation)
 # =============================================================================
 
-name: Check — Codegen Sync
+name: Check - Codegen Sync
 
 on:
   workflow_call:

--- a/.github/workflows/checks/codegen-sync.yml
+++ b/.github/workflows/checks/codegen-sync.yml
@@ -1,0 +1,59 @@
+# =============================================================================
+# Check: Codegen Sync
+# =============================================================================
+# Runs `just codegen` and verifies no generated artifacts have drifted.
+#
+# Generated paths checked:
+#   - apps/syn-cli-node/src/generated/  (CLI TypeScript types from OpenAPI)
+#   - apps/syn-docs/content/docs/cli/   (CLI command reference docs)
+#   - apps/syn-docs/content/docs/api/   (API reference docs)
+#   - apps/syn-docs/openapi.json        (OpenAPI spec)
+#
+# To fix a failure locally: just codegen && git add -A && git commit
+#
+# Called by: release-gate.yml, release-create.yml (pre-publish validation)
+# =============================================================================
+
+name: Check — Codegen Sync
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  codegen-sync:
+    name: Codegen Sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
+
+      - name: Install dependencies
+        run: |
+          pnpm --filter @syntropic137/cli install --frozen-lockfile
+          pnpm --filter syn-docs install --frozen-lockfile
+
+      - name: Regenerate all artifacts
+        run: just codegen
+
+      - name: Check for drift
+        run: |
+          python3 scripts/workflows/check_drift.py \
+            apps/syn-cli-node/src/generated/ \
+            apps/syn-docs/content/docs/cli/ \
+            apps/syn-docs/content/docs/api/ \
+            apps/syn-docs/openapi.json

--- a/.github/workflows/checks/docker-dry-run.yml
+++ b/.github/workflows/checks/docker-dry-run.yml
@@ -4,13 +4,13 @@
 # Builds all container images (single-arch, no push) to verify Dockerfiles
 # are valid and all build contexts resolve correctly.
 #
-# Always runs — no path-filter skip logic. Docker layer caching (GHA cache,
+# Always runs - no path-filter skip logic. Docker layer caching (GHA cache,
 # per-image scope) makes unchanged images near-instant on subsequent runs.
 #
 # Called by: release-gate.yml
 # =============================================================================
 
-name: Check — Docker Dry-Run
+name: Check - Docker Dry-Run
 
 on:
   workflow_call:
@@ -46,7 +46,7 @@ jobs:
           - image: token-injector
             dockerfile: docker/token-injector/Dockerfile
             context: docker/token-injector
-          # agentic-workspace uses build-provider.py staging — validated
+          # agentic-workspace uses build-provider.py staging - validated
           # separately in e2e-container.yml, skip in gate to save CI time.
 
     steps:

--- a/.github/workflows/checks/docker-dry-run.yml
+++ b/.github/workflows/checks/docker-dry-run.yml
@@ -1,0 +1,69 @@
+# =============================================================================
+# Check: Docker Dry-Run
+# =============================================================================
+# Builds all container images (single-arch, no push) to verify Dockerfiles
+# are valid and all build contexts resolve correctly.
+#
+# Always runs — no path-filter skip logic. Docker layer caching (GHA cache,
+# per-image scope) makes unchanged images near-instant on subsequent runs.
+#
+# Called by: release-gate.yml
+# =============================================================================
+
+name: Check — Docker Dry-Run
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  docker-dry-run:
+    name: "Docker Build: ${{ matrix.image }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image: syn-api
+            dockerfile: infra/docker/images/syn-api/Dockerfile
+            context: "."
+            build-args: "INCLUDE_DOCKER_CLI=1"
+          - image: syn-gateway
+            dockerfile: infra/docker/images/gateway/Dockerfile
+            context: "."
+          - image: syn-collector
+            dockerfile: packages/syn-collector/Dockerfile
+            context: "."
+          - image: syn-dashboard-ui
+            dockerfile: apps/syn-dashboard-ui/Dockerfile
+            context: "."
+          - image: sidecar-proxy
+            dockerfile: docker/sidecar-proxy/Dockerfile
+            context: docker/sidecar-proxy
+          - image: token-injector
+            dockerfile: docker/token-injector/Dockerfile
+            context: docker/token-injector
+          # agentic-workspace uses build-provider.py staging — validated
+          # separately in e2e-container.yml, skip in gate to save CI time.
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+
+      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+
+      - name: Build (no push)
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: false
+          load: true
+          tags: test/${{ matrix.image }}:gate
+          build-args: ${{ matrix.build-args }}
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,scope=${{ matrix.image }},mode=max

--- a/.github/workflows/checks/version-check.yml
+++ b/.github/workflows/checks/version-check.yml
@@ -1,0 +1,31 @@
+# =============================================================================
+# Check: Version Consistency
+# =============================================================================
+# Validates that all 11 version files match and the version is greater than
+# what's currently on the release branch.
+#
+# Called by: release-gate.yml
+# =============================================================================
+
+name: Check — Version Consistency
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  version-check:
+    name: Version Consistency
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0  # Need release branch history for comparison
+
+      - name: Validate all 11 version files match
+        run: python3 scripts/workflows/bump_version.py --check
+
+      - name: Validate version is bumped vs release branch
+        run: python3 scripts/workflows/bump_version.py --check-release

--- a/.github/workflows/checks/version-check.yml
+++ b/.github/workflows/checks/version-check.yml
@@ -7,7 +7,7 @@
 # Called by: release-gate.yml
 # =============================================================================
 
-name: Check — Version Consistency
+name: Check - Version Consistency
 
 on:
   workflow_call:

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -120,79 +120,13 @@ jobs:
           echo "Created release: ${{ steps.version.outputs.version }}"
 
   # ---------------------------------------------------------------------------
-  # Step 2: Pre-publish validation — verify API/CLI/docs pipeline is in sync
+  # Step 2: Pre-publish validation — codegen sync (reuses checks/codegen-sync.yml)
   # ---------------------------------------------------------------------------
   pre-publish-validation:
     name: Pre-Publish Validation
     needs: [create-release]
     if: needs.create-release.outputs.created == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          submodules: true
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-        with:
-          version: 10
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-
-      - name: Install dependencies
-        run: |
-          pnpm --filter @syntropic137/cli install --frozen-lockfile
-          pnpm --filter syn-docs install --frozen-lockfile
-
-      - name: Regenerate OpenAPI spec
-        run: uv run python scripts/extract_openapi.py
-
-      - name: Verify CLI types match OpenAPI spec
-        run: pnpm --filter @syntropic137/cli run check:api-drift
-
-      - name: Verify generated CLI types are current
-        run: |
-          pnpm --filter @syntropic137/cli generate:types
-          CHANGED=$(git diff --name-only apps/syn-cli-node/src/generated/)
-          UNTRACKED=$(git ls-files --others --exclude-standard apps/syn-cli-node/src/generated/)
-          if [[ -n "$CHANGED" || -n "$UNTRACKED" ]]; then
-            echo "::error::CLI types are stale — aborting release."
-            [[ -n "$CHANGED" ]] && echo "Modified:" && echo "$CHANGED"
-            [[ -n "$UNTRACKED" ]] && echo "Untracked:" && echo "$UNTRACKED"
-            exit 1
-          fi
-          echo "CLI types are in sync."
-
-      - name: Verify CLI docs are current
-        run: |
-          pnpm --filter @syntropic137/cli generate:docs
-          CHANGED=$(git diff --name-only apps/syn-docs/content/docs/cli/)
-          UNTRACKED=$(git ls-files --others --exclude-standard apps/syn-docs/content/docs/cli/)
-          if [[ -n "$CHANGED" || -n "$UNTRACKED" ]]; then
-            echo "::error::CLI docs are stale — aborting release."
-            [[ -n "$CHANGED" ]] && echo "Modified:" && echo "$CHANGED"
-            [[ -n "$UNTRACKED" ]] && echo "Untracked:" && echo "$UNTRACKED"
-            exit 1
-          fi
-          echo "CLI docs are in sync."
-
-      - name: Verify API docs are current
-        run: |
-          cd apps/syn-docs && pnpm run generate:openapi
-          cd ../..
-          CHANGED=$(git diff --name-only apps/syn-docs/openapi.json apps/syn-docs/content/docs/api/)
-          UNTRACKED=$(git ls-files --others --exclude-standard apps/syn-docs/content/docs/api/)
-          if [[ -n "$CHANGED" || -n "$UNTRACKED" ]]; then
-            echo "::error::API docs are stale — aborting release."
-            [[ -n "$CHANGED" ]] && echo "Modified:" && echo "$CHANGED"
-            [[ -n "$UNTRACKED" ]] && echo "Untracked:" && echo "$UNTRACKED"
-            exit 1
-          fi
-          echo "API docs are in sync."
+    uses: ./.github/workflows/checks/codegen-sync.yml
 
   # ---------------------------------------------------------------------------
   # Step 3: Build, sign, push Docker images + attach release assets

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -117,22 +117,20 @@ jobs:
           echo "dependency-review:${{ needs.dependency-review.result }}"
 
           FAILED=0
-          for JOB in version-check changelog-check codegen-sync docker-dry-run osv-scan pip-audit dependency-review; do
-            RESULT=$(eval echo "\${{ needs.${JOB}.result }}" 2>/dev/null || echo "unknown")
-            case "$JOB" in
-              version-check)    RESULT="${{ needs.version-check.result }}" ;;
-              changelog-check)  RESULT="${{ needs.changelog-check.result }}" ;;
-              codegen-sync)     RESULT="${{ needs.codegen-sync.result }}" ;;
-              docker-dry-run)   RESULT="${{ needs.docker-dry-run.result }}" ;;
-              osv-scan)         RESULT="${{ needs.osv-scan.result }}" ;;
-              pip-audit)        RESULT="${{ needs.pip-audit.result }}" ;;
-              dependency-review) RESULT="${{ needs.dependency-review.result }}" ;;
-            esac
-            if [[ "$RESULT" != "success" ]]; then
-              echo "::error::$JOB did not pass (result: $RESULT)"
+          check() {
+            local job="$1" result="$2"
+            if [[ "$result" != "success" ]]; then
+              echo "::error::${job} did not pass (result: ${result})"
               FAILED=1
             fi
-          done
+          }
+          check "version-check"    "${{ needs.version-check.result }}"
+          check "changelog-check"  "${{ needs.changelog-check.result }}"
+          check "codegen-sync"     "${{ needs.codegen-sync.result }}"
+          check "docker-dry-run"   "${{ needs.docker-dry-run.result }}"
+          check "osv-scan"         "${{ needs.osv-scan.result }}"
+          check "pip-audit"        "${{ needs.pip-audit.result }}"
+          check "dependency-review" "${{ needs.dependency-review.result }}"
 
           if [[ "$FAILED" == "1" ]]; then
             exit 1

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -7,12 +7,13 @@
 # Checks:
 #   1. Version consistency — all 11 package files match and are bumped
 #   2. Release notes — PR body must contain meaningful release notes
-#   3. Docs drift — generated CLI + API docs match source
-#   4. CLI ↔ API sync — generated CLI types match OpenAPI spec (single source of truth)
-#   5. Docker dry-run — all container images build successfully (single-arch)
-#   6. Security scans — OSV, pip-audit, dependency review (no known vulnerabilities)
+#   3. Codegen sync — CLI types, CLI docs, API docs all match source
+#   4. Docker dry-run — all container images build successfully (single-arch, cached)
+#   5. Security scans — OSV, pip-audit, dependency review
 #
 # Full CI (tests, lint, typecheck) also runs on these PRs via ci.yml.
+#
+# Each check lives in .github/workflows/checks/ as a reusable workflow.
 # =============================================================================
 
 name: Release Gate
@@ -27,308 +28,24 @@ permissions:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Version Consistency
+  # Reusable checks
   # ---------------------------------------------------------------------------
   version-check:
-    name: Version Consistency
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0  # Need release branch HEAD for comparison
+    uses: ./.github/workflows/checks/version-check.yml
 
-      - name: Validate version files match
-        run: python3 scripts/bump_version.py --check
-
-      - name: Validate version is bumped
-        run: |
-          PR_VERSION=$(python3 scripts/bump_version.py --current)
-          RELEASE_VERSION=$(git show origin/release:pyproject.toml | grep '^version = ' | head -1 | sed 's/version = "\(.*\)"/\1/')
-
-          echo "PR version:      $PR_VERSION"
-          echo "Release version: $RELEASE_VERSION"
-
-          if [ "$PR_VERSION" = "$RELEASE_VERSION" ]; then
-            echo "::error::Version $PR_VERSION has not been bumped from the current release."
-            echo "Run: just bump-version <new-version>"
-            exit 1
-          fi
-
-          # Compare versions using semantic version precedence rules.
-          # Pre-releases sort lower than their stable counterpart (e.g.,
-          # 0.19.1-beta.1 < 0.19.1) per the semver spec.
-          python3 -c "
-          import re
-          import sys
-
-          SEMVER_RE = re.compile(
-              r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)'
-              r'(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$'
-          )
-
-          def parse_version(v):
-              match = SEMVER_RE.fullmatch(v)
-              if not match:
-                  raise ValueError(f'Invalid semantic version: {v}')
-              major, minor, patch, prerelease = match.groups()
-              prerelease_parts = prerelease.split('.') if prerelease else None
-              return (int(major), int(minor), int(patch), prerelease_parts)
-
-          def compare_prerelease(pr1, pr2):
-              if pr1 is None and pr2 is None:
-                  return 0
-              if pr1 is None:
-                  return 1   # stable > prerelease
-              if pr2 is None:
-                  return -1  # prerelease < stable
-              for a, b in zip(pr1, pr2):
-                  a_num, b_num = a.isdigit(), b.isdigit()
-                  if a_num and b_num:
-                      if int(a) != int(b):
-                          return -1 if int(a) < int(b) else 1
-                  elif a_num != b_num:
-                      return -1 if a_num else 1
-                  else:
-                      if a != b:
-                          return -1 if a < b else 1
-              if len(pr1) == len(pr2):
-                  return 0
-              return -1 if len(pr1) < len(pr2) else 1
-
-          def compare_versions(v1, v2):
-              maj1, min1, pat1, pre1 = parse_version(v1)
-              maj2, min2, pat2, pre2 = parse_version(v2)
-              core1, core2 = (maj1, min1, pat1), (maj2, min2, pat2)
-              if core1 != core2:
-                  return -1 if core1 < core2 else 1
-              return compare_prerelease(pre1, pre2)
-
-          try:
-              cmp = compare_versions('$PR_VERSION', '$RELEASE_VERSION')
-          except ValueError as exc:
-              print(f'::error::{exc}')
-              sys.exit(1)
-
-          if cmp <= 0:
-              print(f'::error::PR version $PR_VERSION is not greater than release version $RELEASE_VERSION')
-              sys.exit(1)
-          print(f'OK: $PR_VERSION > $RELEASE_VERSION')
-          "
-
-  # ---------------------------------------------------------------------------
-  # Release Notes
-  # ---------------------------------------------------------------------------
   changelog-check:
-    name: Release Notes Present
-    runs-on: ubuntu-latest
-    steps:
-      - name: Validate PR body has release notes
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          if [ -z "$PR_BODY" ]; then
-            echo "::error::PR body is empty. Add release notes describing what changed."
-            exit 1
-          fi
+    uses: ./.github/workflows/checks/changelog-check.yml
+    with:
+      pr_body: ${{ github.event.pull_request.body }}
 
-          BODY_LENGTH=${#PR_BODY}
-          if [ "$BODY_LENGTH" -lt 20 ]; then
-            echo "::error::PR body is too short ($BODY_LENGTH chars). Add meaningful release notes."
-            exit 1
-          fi
+  codegen-sync:
+    uses: ./.github/workflows/checks/codegen-sync.yml
 
-          echo "OK: Release notes present ($BODY_LENGTH chars)"
-
-  # ---------------------------------------------------------------------------
-  # Docs Drift — generated CLI + API docs must match source
-  # ---------------------------------------------------------------------------
-  docs-drift:
-    name: Docs Drift
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          submodules: true
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-        with:
-          version: 10
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-
-      - name: Install dependencies
-        run: |
-          pnpm --filter @syntropic137/cli install --frozen-lockfile
-          pnpm --filter syn-docs install --frozen-lockfile
-
-      - name: Generate CLI docs
-        run: pnpm --filter @syntropic137/cli generate:docs
-
-      - name: Check CLI docs drift
-        run: |
-          CHANGED=$(git diff --name-only apps/syn-docs/content/docs/cli/)
-          UNTRACKED=$(git ls-files --others --exclude-standard apps/syn-docs/content/docs/cli/)
-          if [[ -n "$CHANGED" || -n "$UNTRACKED" ]]; then
-            echo "::error::CLI docs are out of sync. Run 'just codegen' and commit."
-            [[ -n "$CHANGED" ]] && echo "Modified:" && echo "$CHANGED"
-            [[ -n "$UNTRACKED" ]] && echo "Untracked:" && echo "$UNTRACKED"
-            exit 1
-          fi
-          echo "CLI docs are up to date."
-
-      - name: Generate API docs
-        run: |
-          uv run python scripts/extract_openapi.py
-          cd apps/syn-docs && pnpm run generate:openapi
-
-      - name: Check API docs drift
-        run: |
-          CHANGED=$(git diff --name-only apps/syn-docs/openapi.json apps/syn-docs/content/docs/api/)
-          UNTRACKED=$(git ls-files --others --exclude-standard apps/syn-docs/content/docs/api/)
-          if [[ -n "$CHANGED" || -n "$UNTRACKED" ]]; then
-            echo "::error::API docs are out of sync. Run 'just codegen' and commit."
-            [[ -n "$CHANGED" ]] && echo "Modified:" && echo "$CHANGED"
-            [[ -n "$UNTRACKED" ]] && echo "Untracked:" && echo "$UNTRACKED"
-            exit 1
-          fi
-          echo "API docs are up to date."
-
-  # ---------------------------------------------------------------------------
-  # CLI ↔ API Sync — generated CLI types must match OpenAPI spec
-  # ---------------------------------------------------------------------------
-  cli-api-sync:
-    name: CLI ↔ API Sync
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          submodules: true
-
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
-        with:
-          version: 10
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: 22
-          cache: 'pnpm'
-
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a # v4
-
-      - name: Install CLI dependencies
-        run: pnpm --filter @syntropic137/cli install --frozen-lockfile
-
-      - name: Regenerate OpenAPI spec
-        run: uv run python scripts/extract_openapi.py
-
-      - name: Check CLI types vs OpenAPI spec
-        run: pnpm --filter @syntropic137/cli run check:api-drift
-
-      - name: Regenerate CLI types and check for drift
-        run: |
-          pnpm --filter @syntropic137/cli generate:types
-          CHANGED=$(git diff --name-only apps/syn-cli-node/src/generated/)
-          UNTRACKED=$(git ls-files --others --exclude-standard apps/syn-cli-node/src/generated/)
-          if [[ -n "$CHANGED" || -n "$UNTRACKED" ]]; then
-            echo "::error::CLI generated types are out of sync with OpenAPI spec."
-            echo "Run 'just codegen' and commit."
-            [[ -n "$CHANGED" ]] && echo "Changed files:" && echo "$CHANGED"
-            [[ -n "$UNTRACKED" ]] && echo "Untracked files:" && echo "$UNTRACKED"
-            exit 1
-          fi
-          echo "CLI types are in sync with OpenAPI spec."
-
-  # ---------------------------------------------------------------------------
-  # Docker Change Detection — skip Docker builds when only non-Docker files changed
-  # ---------------------------------------------------------------------------
-  check-docker-changes:
-    name: Check Docker Changes
-    runs-on: ubuntu-latest
-    outputs:
-      docker_changed: ${{ steps.filter.outputs.docker }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            docker:
-              - 'infra/docker/**'
-              - 'docker/**'
-              - '**/Dockerfile*'
-              - 'apps/syn-api/**'
-              - 'apps/syn-dashboard-ui/**'
-              - 'packages/syn-collector/**'
-              - 'packages/syn-domain/**'
-              - 'packages/syn-adapters/**'
-              - 'packages/syn-shared/**'
-              - 'lib/**'
-              - 'pyproject.toml'
-              - 'uv.lock'
-              - 'pnpm-lock.yaml'
-              - 'pnpm-workspace.yaml'
-
-  # ---------------------------------------------------------------------------
-  # Docker Dry-Run — verify all images build (single-arch, no push)
-  # ---------------------------------------------------------------------------
   docker-dry-run:
-    name: "Docker Build: ${{ matrix.image }}"
-    needs: check-docker-changes
-    if: needs.check-docker-changes.outputs.docker_changed == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - image: syn-api
-            dockerfile: infra/docker/images/syn-api/Dockerfile
-            context: "."
-            build-args: "INCLUDE_DOCKER_CLI=1"
-          - image: syn-gateway
-            dockerfile: infra/docker/images/gateway/Dockerfile
-            context: "."
-          - image: syn-collector
-            dockerfile: packages/syn-collector/Dockerfile
-            context: "."
-          - image: syn-dashboard-ui
-            dockerfile: apps/syn-dashboard-ui/Dockerfile
-            context: "."
-          - image: sidecar-proxy
-            dockerfile: docker/sidecar-proxy/Dockerfile
-            context: docker/sidecar-proxy
-          - image: token-injector
-            dockerfile: docker/token-injector/Dockerfile
-            context: docker/token-injector
-          # agentic-workspace uses build-provider.py staging — validated
-          # separately in e2e-container.yml, skip in gate to save CI time.
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          submodules: true
-
-      - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
-
-      - name: Build (no push)
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          push: false
-          load: true
-          tags: test/${{ matrix.image }}:gate
-          build-args: ${{ matrix.build-args }}
-          cache-from: type=gha
+    uses: ./.github/workflows/checks/docker-dry-run.yml
 
   # ---------------------------------------------------------------------------
-  # Security Scans — no known vulnerabilities in dependencies
+  # Security Scans — inline (not duplicated elsewhere, no extraction needed)
   # ---------------------------------------------------------------------------
   osv-scan:
     name: OSV Vulnerability Scan
@@ -379,47 +96,45 @@ jobs:
   release-gate-success:
     name: Release Gate
     if: always()
-    needs: [version-check, changelog-check, docs-drift, cli-api-sync, check-docker-changes, docker-dry-run, osv-scan, pip-audit, dependency-review]
+    needs:
+      - version-check
+      - changelog-check
+      - codegen-sync
+      - docker-dry-run
+      - osv-scan
+      - pip-audit
+      - dependency-review
     runs-on: ubuntu-latest
     steps:
       - name: Check all gates passed
         run: |
-          echo "version-check: ${{ needs.version-check.result }}"
-          echo "changelog-check: ${{ needs.changelog-check.result }}"
-          echo "docs-drift: ${{ needs.docs-drift.result }}"
-          echo "cli-api-sync: ${{ needs.cli-api-sync.result }}"
-          echo "check-docker-changes: ${{ needs.check-docker-changes.result }}"
-          echo "docker-dry-run: ${{ needs.docker-dry-run.result }}"
-          echo "osv-scan: ${{ needs.osv-scan.result }}"
-          echo "pip-audit: ${{ needs.pip-audit.result }}"
-          echo "dependency-review: ${{ needs.dependency-review.result }}"
+          echo "version-check:    ${{ needs.version-check.result }}"
+          echo "changelog-check:  ${{ needs.changelog-check.result }}"
+          echo "codegen-sync:     ${{ needs.codegen-sync.result }}"
+          echo "docker-dry-run:   ${{ needs.docker-dry-run.result }}"
+          echo "osv-scan:         ${{ needs.osv-scan.result }}"
+          echo "pip-audit:        ${{ needs.pip-audit.result }}"
+          echo "dependency-review:${{ needs.dependency-review.result }}"
 
-          # Core gates must all succeed
-          if [[ "${{ needs.version-check.result }}" != "success" ]] || \
-             [[ "${{ needs.changelog-check.result }}" != "success" ]] || \
-             [[ "${{ needs.docs-drift.result }}" != "success" ]] || \
-             [[ "${{ needs.cli-api-sync.result }}" != "success" ]] || \
-             [[ "${{ needs.check-docker-changes.result }}" != "success" ]]; then
-            echo "::error::One or more release gate checks failed."
-            exit 1
-          fi
+          FAILED=0
+          for JOB in version-check changelog-check codegen-sync docker-dry-run osv-scan pip-audit dependency-review; do
+            RESULT=$(eval echo "\${{ needs.${JOB}.result }}" 2>/dev/null || echo "unknown")
+            case "$JOB" in
+              version-check)    RESULT="${{ needs.version-check.result }}" ;;
+              changelog-check)  RESULT="${{ needs.changelog-check.result }}" ;;
+              codegen-sync)     RESULT="${{ needs.codegen-sync.result }}" ;;
+              docker-dry-run)   RESULT="${{ needs.docker-dry-run.result }}" ;;
+              osv-scan)         RESULT="${{ needs.osv-scan.result }}" ;;
+              pip-audit)        RESULT="${{ needs.pip-audit.result }}" ;;
+              dependency-review) RESULT="${{ needs.dependency-review.result }}" ;;
+            esac
+            if [[ "$RESULT" != "success" ]]; then
+              echo "::error::$JOB did not pass (result: $RESULT)"
+              FAILED=1
+            fi
+          done
 
-          # Docker dry-run must succeed when it ran, or be skipped (no docker changes)
-          DOCKER_RESULT="${{ needs.docker-dry-run.result }}"
-          if [[ "$DOCKER_RESULT" != "success" && "$DOCKER_RESULT" != "skipped" ]]; then
-            echo "::error::Docker dry-run failed."
-            exit 1
-          fi
-
-          if [[ "$DOCKER_RESULT" == "skipped" ]]; then
-            echo "Docker dry-run skipped (no Docker-related changes detected)."
-          fi
-
-          # Security scans must all succeed
-          if [[ "${{ needs.osv-scan.result }}" != "success" ]] || \
-             [[ "${{ needs.pip-audit.result }}" != "success" ]] || \
-             [[ "${{ needs.dependency-review.result }}" != "success" ]]; then
-            echo "::error::Security scan(s) failed — release blocked until vulnerabilities are resolved."
+          if [[ "$FAILED" == "1" ]]; then
             exit 1
           fi
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -201,7 +201,7 @@ just bump-version 0.19.1
 
 ## Version Files Reference
 
-The `scripts/bump_version.py` script updates exactly these 11 files:
+The `scripts/workflows/bump_version.py` script updates exactly these 11 files:
 
 **Python (pyproject.toml):**
 1. `pyproject.toml` (root)
@@ -228,10 +228,14 @@ The `scripts/bump_version.py` script updates exactly these 11 files:
 ```
 PR: main → release
   ├── ci.yml (full CI suite)
-  └── release-gate.yml
-        ├── version-check
-        ├── changelog-check
-        ├── docker-dry-run (6 images)
+  └── release-gate.yml  (thin orchestrator — 4 reusable checks + 3 inline security scans)
+        ├── checks/version-check.yml       — all 11 files consistent, version > release
+        ├── checks/changelog-check.yml     — PR body >= 20 chars
+        ├── checks/codegen-sync.yml        — CLI types, CLI docs, API docs all current
+        ├── checks/docker-dry-run.yml      — all container images build (single-arch, cached)
+        ├── osv-scan (inline)
+        ├── pip-audit (inline)
+        ├── dependency-review (inline)
         └── release-gate-success (aggregator)
 
 Merge to release
@@ -244,17 +248,29 @@ Merge to release
         │     └── create GitHub Release (PR body = release notes)
         │
         ├── pre-publish-validation job  (needs: create-release)
-        │     ├── verify CLI types match OpenAPI spec
-        │     ├── verify CLI docs are current
-        │     └── verify API docs are current
+        │     └── checks/codegen-sync.yml  (workflow_call — reused from gate)
         │
         ├── release-containers.yaml  (workflow_call, needs: pre-publish-validation)
-        │     ├── build-scan-push (6 images, multi-arch)
+        │     ├── build-scan-push (multi-arch)
         │     └── release-assets (compose, SHA256SUMS, cosign sig, npx dispatch)
         │
         └── release-cli.yaml  (workflow_call, needs: pre-publish-validation)
               └── publish (npm OIDC, provenance)
 ```
+
+### Workflow Files
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/release-gate.yml` | Thin orchestrator — calls checks + inline security scans |
+| `.github/workflows/release-create.yml` | Release pipeline — create tag/release, publish containers + CLI |
+| `.github/workflows/checks/version-check.yml` | Version consistency: all 11 files match, bumped vs release |
+| `.github/workflows/checks/changelog-check.yml` | PR body length validation (takes `pr_body` input) |
+| `.github/workflows/checks/codegen-sync.yml` | Runs `just codegen`, checks for drift (CLI types, API docs, CLI docs) |
+| `.github/workflows/checks/docker-dry-run.yml` | All container images build successfully (single-arch, GHA cache) |
+| `.github/workflows/release-containers.yaml` | Multi-arch build, cosign sign, push to GHCR, release assets |
+| `.github/workflows/release-cli.yaml` | Build + publish `@syntropic137/cli` to npm (OIDC, provenance) |
+| `scripts/workflows/bump_version.py` | Version bump script; `--check` (consistency) and `--check-release` (semver vs release branch) |
 
 ## Branch Protection (release)
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -22,7 +22,7 @@ These are the manual, one-time steps required before the automated release pipel
 
 Create `@syntropic137` at https://www.npmjs.com/org/create (if not already done).
 
-#### 2. @syntropic137/cli (main repo — `apps/syn-cli-node`)
+#### 2. @syntropic137/cli (main repo - `apps/syn-cli-node`)
 
 1. Login to npm with org scope:
    ```bash
@@ -41,7 +41,7 @@ Create `@syntropic137` at https://www.npmjs.com/org/create (if not already done)
 4. Create the `npm-publish-cli` GitHub environment: repo Settings > Environments > New > `npm-publish-cli`
 5. After Trusted Publishing is configured, the `CLI_PUBLISH_NPM_TOKEN` secret is no longer needed and can be deleted.
 
-#### 3. @syntropic137/setup (npx repo — `syntropic137-npx`)
+#### 3. @syntropic137/setup (npx repo - `syntropic137-npx`)
 
 1. Login (same org scope as above):
    ```bash
@@ -61,10 +61,10 @@ Create `@syntropic137` at https://www.npmjs.com/org/create (if not already done)
 ### NPM Trusted Publishing Requirements
 
 - npm >= 11.5.1 and Node >= 22.14.0 (for OIDC token exchange)
-- Do NOT set `NODE_AUTH_TOKEN` — it overrides OIDC
-- Do NOT set `registry-url` in `setup-node` — it creates `.npmrc` that interferes with OIDC
+- Do NOT set `NODE_AUTH_TOKEN` - it overrides OIDC
+- Do NOT set `registry-url` in `setup-node` - it creates `.npmrc` that interferes with OIDC
 - The `--provenance` flag is still recommended even though docs say it is automatic
-- npm returns E404 (not 401/403) for auth failures on scoped packages — this is misleading but means "not authenticated"
+- npm returns E404 (not 401/403) for auth failures on scoped packages - this is misleading but means "not authenticated"
 
 ### GitHub Environments
 
@@ -96,8 +96,8 @@ Two environments are needed across the two repos:
 
 ### Docker / Container Setup
 
-- **GHCR authentication** uses the built-in `GITHUB_TOKEN` — no additional setup needed.
-- **Cosign keyless signing** uses Sigstore OIDC — no additional setup needed.
+- **GHCR authentication** uses the built-in `GITHUB_TOKEN` - no additional setup needed.
+- **Cosign keyless signing** uses Sigstore OIDC - no additional setup needed.
 - **Multi-arch builds** (amd64 + arm64) use QEMU emulation via `docker/setup-qemu-action`.
 
 ## Production Release
@@ -120,7 +120,7 @@ git push origin main
 
 ### 3. Open Release PR
 
-Open a PR from `main` to `release`. **The PR body becomes the GitHub Release notes** — write meaningful release notes here. The release-gate check enforces a minimum of 20 characters. Use this format as a guide:
+Open a PR from `main` to `release`. **The PR body becomes the GitHub Release notes** - write meaningful release notes here. The release-gate check enforces a minimum of 20 characters. Use this format as a guide:
 
 ```markdown
 ## What's Changed
@@ -139,10 +139,10 @@ The `release-create.yml` workflow reads the merged PR body verbatim and sets it 
 
 The following checks run automatically on the PR:
 
-- **Version consistency** — all 11 files match, version > current release
-- **Release notes** — PR body has content (minimum 20 characters)
-- **Docker dry-run** — all 7 container images build successfully (single-arch, no push)
-- **Full CI** — tests, lint, typecheck, security scans (same as any PR)
+- **Version consistency** - all 11 files match, version > current release
+- **Release notes** - PR body has content (minimum 20 characters)
+- **Docker dry-run** - all 7 container images build successfully (single-arch, no push)
+- **Full CI** - tests, lint, typecheck, security scans (same as any PR)
 
 ### 5. Merge
 
@@ -219,20 +219,20 @@ The `scripts/workflows/bump_version.py` script updates exactly these 11 files:
 11. `apps/syn-docs/package.json`
 
 **Not included** (independent versioning):
-- `lib/agentic-primitives/` — separate project
-- `lib/event-sourcing-platform/` — separate project
-- `packages/openclaw-plugin/` — independent plugin
+- `lib/agentic-primitives/` - separate project
+- `lib/event-sourcing-platform/` - separate project
+- `packages/openclaw-plugin/` - independent plugin
 
 ## Workflow Architecture
 
 ```
 PR: main → release
   ├── ci.yml (full CI suite)
-  └── release-gate.yml  (thin orchestrator — 4 reusable checks + 3 inline security scans)
-        ├── checks/version-check.yml       — all 11 files consistent, version > release
-        ├── checks/changelog-check.yml     — PR body >= 20 chars
-        ├── checks/codegen-sync.yml        — CLI types, CLI docs, API docs all current
-        ├── checks/docker-dry-run.yml      — all container images build (single-arch, cached)
+  └── release-gate.yml  (thin orchestrator - 4 reusable checks + 3 inline security scans)
+        ├── checks/version-check.yml       - all 11 files consistent, version > release
+        ├── checks/changelog-check.yml     - PR body >= 20 chars
+        ├── checks/codegen-sync.yml        - CLI types, CLI docs, API docs all current
+        ├── checks/docker-dry-run.yml      - all container images build (single-arch, cached)
         ├── osv-scan (inline)
         ├── pip-audit (inline)
         ├── dependency-review (inline)
@@ -248,7 +248,7 @@ Merge to release
         │     └── create GitHub Release (PR body = release notes)
         │
         ├── pre-publish-validation job  (needs: create-release)
-        │     └── checks/codegen-sync.yml  (workflow_call — reused from gate)
+        │     └── checks/codegen-sync.yml  (workflow_call - reused from gate)
         │
         ├── release-containers.yaml  (workflow_call, needs: pre-publish-validation)
         │     ├── build-scan-push (multi-arch)
@@ -262,8 +262,8 @@ Merge to release
 
 | File | Purpose |
 |------|---------|
-| `.github/workflows/release-gate.yml` | Thin orchestrator — calls checks + inline security scans |
-| `.github/workflows/release-create.yml` | Release pipeline — create tag/release, publish containers + CLI |
+| `.github/workflows/release-gate.yml` | Thin orchestrator - calls checks + inline security scans |
+| `.github/workflows/release-create.yml` | Release pipeline - create tag/release, publish containers + CLI |
 | `.github/workflows/checks/version-check.yml` | Version consistency: all 11 files match, bumped vs release |
 | `.github/workflows/checks/changelog-check.yml` | PR body length validation (takes `pr_body` input) |
 | `.github/workflows/checks/codegen-sync.yml` | Runs `just codegen`, checks for drift (CLI types, API docs, CLI docs) |
@@ -286,11 +286,11 @@ These rules exist to prevent out-of-order publishing. Do not work around them.
 
 ### The only valid release entry point is `release-create.yml`
 
-`release-containers.yaml` and `release-cli.yaml` are **internal callees** — they must only be triggered by `release-create.yml` via `workflow_call`. Direct triggers are poka-yoke protected:
+`release-containers.yaml` and `release-cli.yaml` are **internal callees** - they must only be triggered by `release-create.yml` via `workflow_call`. Direct triggers are poka-yoke protected:
 
-- **`release.published` is intentionally absent** from both publish workflows. A manually created GitHub Release (via UI, `gh release create`, or an AI agent) does not trigger publishing — it bypasses the approval gate.
-- **`workflow_dispatch` is branch-guarded** — both workflows reject dispatch from any branch other than `release`.
-- **`workflow_dispatch` dry_run defaults to `true`** on both workflows — dispatch with default inputs never pushes anything.
+- **`release.published` is intentionally absent** from both publish workflows. A manually created GitHub Release (via UI, `gh release create`, or an AI agent) does not trigger publishing - it bypasses the approval gate.
+- **`workflow_dispatch` is branch-guarded** - both workflows reject dispatch from any branch other than `release`.
+- **`workflow_dispatch` dry_run defaults to `true`** on both workflows - dispatch with default inputs never pushes anything.
 
 ### The approval gate
 
@@ -324,7 +324,7 @@ Creating a release via the GitHub UI, `gh release create`, or any automated tool
 
 ## Known Gotchas
 
-- **npm E404 on scoped packages:** npm returns E404 on PUT for scoped packages when auth fails. This is misleading — it means "not authenticated", not "package not found".
+- **npm E404 on scoped packages:** npm returns E404 on PUT for scoped packages when auth fails. This is misleading - it means "not authenticated", not "package not found".
 - **npm Trusted Publishing version requirement:** OIDC-based registry auth requires npm >= 11.5.1. Older npm versions only use OIDC for Sigstore provenance signing, NOT for registry authentication.
 - **Missing README on npmjs.com:** The `files` array in `package.json` must explicitly include `README.md` or it will not appear on the npm package page.
 - **GITHUB_TOKEN loop prevention:** Releases and events created by `GITHUB_TOKEN` do NOT trigger other workflows (GitHub's anti-loop mechanism). That is why `release-create.yml` uses reusable workflow calls (`workflow_call`) instead of relying on `release.published` events.

--- a/justfile
+++ b/justfile
@@ -1771,11 +1771,11 @@ _workspace-check:
 
 # Bump version across all 11 package files
 bump-version version:
-    python3 scripts/bump_version.py {{version}}
+    python3 scripts/workflows/bump_version.py {{version}}
 
 # Validate all 11 package files have the same version
 check-version:
-    python3 scripts/bump_version.py --check
+    python3 scripts/workflows/bump_version.py --check
 
 registry := "ghcr.io/syntropic137"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,6 +133,7 @@ testpaths = [
     "packages/syn-domain/src",  # VSA co-located tests
     "packages/syn-adapters/tests",
     "packages/syn-shared/tests",
+    "scripts/workflows",
 ]
 pythonpath = [
     "apps/syn-api/src",
@@ -140,6 +141,7 @@ pythonpath = [
     "packages/syn-domain/src",
     "packages/syn-adapters/src",
     "packages/syn-shared/src",
+    "scripts/workflows",
 ]
 python_files = ["test_*.py", "*_test.py"]
 python_functions = ["test_*"]

--- a/scripts/workflows/README.md
+++ b/scripts/workflows/README.md
@@ -1,0 +1,3 @@
+# GitHub Workflow File Support
+
+Supporting scripts for GitHub Workflows ./.github/workflows.

--- a/scripts/workflows/bump_version.py
+++ b/scripts/workflows/bump_version.py
@@ -9,13 +9,13 @@ Usage:
 
 This script updates the 11 tracked version files. Submodule versions
 (event-sourcing-platform, agentic-primitives, openclaw-plugin) are
-intentionally excluded — they have independent versioning.
+intentionally excluded - they have independent versioning.
 
 All files are pre-validated before any writes occur. If any file is
 missing a version field, the script fails without modifying anything.
 
 ─────────────────────────────────────────────────────────────────────────────
-CI DEPENDENCY — this script is called directly by the release gate workflow:
+CI DEPENDENCY - this script is called directly by the release gate workflow:
   .github/workflows/checks/version-check.yml
     → python3 scripts/workflows/bump_version.py --check          (all 11 files match)
     → python3 scripts/workflows/bump_version.py --check-release  (version > release branch)
@@ -35,7 +35,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
-# Hardcoded list — matches the 11 files in every "chore: bump version" commit.
+# Hardcoded list - matches the 11 files in every "chore: bump version" commit.
 # DO NOT discover dynamically. Submodules must be excluded.
 PYPROJECT_FILES = [
     ROOT / "pyproject.toml",
@@ -230,7 +230,7 @@ def bump(target: str) -> None:
 
     current = get_current_version()
     if current == target:
-        print(f"Version is already {target} — nothing to do.")
+        print(f"Version is already {target} - nothing to do.")
         return
 
     print(f"Bumping: {current} → {target}\n")

--- a/scripts/workflows/bump_version.py
+++ b/scripts/workflows/bump_version.py
@@ -5,6 +5,7 @@ Usage:
     python scripts/bump_version.py 0.20.0          # Update all 11 files
     python scripts/bump_version.py --check          # Validate all files match
     python scripts/bump_version.py --current        # Print current version
+    python scripts/bump_version.py --check-release  # Validate version is bumped vs release branch
 
 This script updates the 11 tracked version files. Submodule versions
 (event-sourcing-platform, agentic-primitives, openclaw-plugin) are
@@ -12,12 +13,23 @@ intentionally excluded — they have independent versioning.
 
 All files are pre-validated before any writes occur. If any file is
 missing a version field, the script fails without modifying anything.
+
+─────────────────────────────────────────────────────────────────────────────
+CI DEPENDENCY — this script is called directly by the release gate workflow:
+  .github/workflows/checks/version-check.yml
+    → python3 scripts/workflows/bump_version.py --check          (all 11 files match)
+    → python3 scripts/workflows/bump_version.py --check-release  (version > release branch)
+
+Also called by the just recipes `check-version` and `bump-version`.
+Do not rename flags or change exit codes without updating the workflow.
+─────────────────────────────────────────────────────────────────────────────
 """
 
 from __future__ import annotations
 
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -48,6 +60,11 @@ VERSION_RE = re.compile(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$")
 PYPROJECT_VERSION_RE = re.compile(r'^(version\s*=\s*")[^"]*(")', re.MULTILINE)
 PACKAGE_JSON_VERSION_RE = re.compile(r'^(\s*"version"\s*:\s*")[^"]*(")', re.MULTILINE)
 
+SEMVER_RE = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
 
 def read_pyproject_version(path: Path) -> str | None:
     text = path.read_text()
@@ -76,6 +93,105 @@ def get_current_version() -> str:
         print("ERROR: Could not read version from root pyproject.toml", file=sys.stderr)
         sys.exit(1)
     return v
+
+
+def _parse_semver(v: str) -> tuple[int, int, int, list[str] | None]:
+    m = SEMVER_RE.fullmatch(v)
+    if not m:
+        raise ValueError(f"Invalid semantic version: {v!r}")
+    major, minor, patch, prerelease = m.groups()
+    pre_parts: list[str] | None = prerelease.split(".") if prerelease else None
+    return int(major), int(minor), int(patch), pre_parts
+
+
+def _compare_prerelease(pr1: list[str] | None, pr2: list[str] | None) -> int:
+    if pr1 is None and pr2 is None:
+        return 0
+    if pr1 is None:
+        return 1  # stable > prerelease
+    if pr2 is None:
+        return -1  # prerelease < stable
+    for a, b in zip(pr1, pr2):
+        a_num, b_num = a.isdigit(), b.isdigit()
+        if a_num and b_num:
+            if int(a) != int(b):
+                return -1 if int(a) < int(b) else 1
+        elif a_num != b_num:
+            return -1 if a_num else 1
+        else:
+            if a != b:
+                return -1 if a < b else 1
+    if len(pr1) == len(pr2):
+        return 0
+    return -1 if len(pr1) < len(pr2) else 1
+
+
+def compare_versions(v1: str, v2: str) -> int:
+    """Compare two semver strings. Returns -1, 0, or 1."""
+    maj1, min1, pat1, pre1 = _parse_semver(v1)
+    maj2, min2, pat2, pre2 = _parse_semver(v2)
+    core1, core2 = (maj1, min1, pat1), (maj2, min2, pat2)
+    if core1 != core2:
+        return -1 if core1 < core2 else 1
+    return _compare_prerelease(pre1, pre2)
+
+
+def check_release_bump(release_ref: str = "origin/release") -> bool:
+    """Validate current version is greater than what's on the release branch.
+
+    Used by CI to ensure the PR has actually bumped the version before merging.
+    Reads the release branch version via git show to avoid a full checkout.
+    """
+    pr_version = get_current_version()
+
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{release_ref}:pyproject.toml"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError:
+        print(f"ERROR: Could not read {release_ref}:pyproject.toml", file=sys.stderr)
+        print("Ensure 'git fetch origin' has been run.", file=sys.stderr)
+        return False
+
+    release_version: str | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("version = "):
+            release_version = line.split('"')[1]
+            break
+
+    if release_version is None:
+        print(f"ERROR: No version field found in {release_ref}:pyproject.toml", file=sys.stderr)
+        return False
+
+    print(f"PR version:      {pr_version}")
+    print(f"Release version: {release_version}")
+
+    if pr_version == release_version:
+        print(
+            f"ERROR: Version {pr_version} has not been bumped from the current release.",
+            file=sys.stderr,
+        )
+        print("Run: just bump-version <new-version>", file=sys.stderr)
+        return False
+
+    try:
+        cmp = compare_versions(pr_version, release_version)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return False
+
+    if cmp <= 0:
+        print(
+            f"ERROR: PR version {pr_version} is not greater than release version {release_version}",
+            file=sys.stderr,
+        )
+        return False
+
+    print(f"OK: {pr_version} > {release_version}")
+    return True
 
 
 def check_consistency() -> bool:
@@ -164,6 +280,9 @@ def main() -> None:
         sys.exit(0 if check_consistency() else 1)
     elif arg == "--current":
         print(get_current_version())
+    elif arg == "--check-release":
+        release_ref = sys.argv[2] if len(sys.argv) > 2 else "origin/release"
+        sys.exit(0 if check_release_bump(release_ref) else 1)
     elif arg.startswith("-"):
         print(f"Unknown flag: {arg}", file=sys.stderr)
         print(__doc__)

--- a/scripts/workflows/bump_version.py
+++ b/scripts/workflows/bump_version.py
@@ -111,7 +111,7 @@ def _compare_prerelease(pr1: list[str] | None, pr2: list[str] | None) -> int:
         return 1  # stable > prerelease
     if pr2 is None:
         return -1  # prerelease < stable
-    for a, b in zip(pr1, pr2):
+    for a, b in zip(pr1, pr2, strict=False):
         a_num, b_num = a.isdigit(), b.isdigit()
         if a_num and b_num:
             if int(a) != int(b):

--- a/scripts/workflows/bump_version.py
+++ b/scripts/workflows/bump_version.py
@@ -2,10 +2,10 @@
 """Bump version across all Syntropic137 packages.
 
 Usage:
-    python scripts/bump_version.py 0.20.0          # Update all 11 files
-    python scripts/bump_version.py --check          # Validate all files match
-    python scripts/bump_version.py --current        # Print current version
-    python scripts/bump_version.py --check-release  # Validate version is bumped vs release branch
+    python scripts/workflows/bump_version.py 0.20.0          # Update all 11 files
+    python scripts/workflows/bump_version.py --check          # Validate all files match
+    python scripts/workflows/bump_version.py --current        # Print current version
+    python scripts/workflows/bump_version.py --check-release  # Validate version is bumped vs release branch
 
 This script updates the 11 tracked version files. Submodule versions
 (event-sourcing-platform, agentic-primitives, openclaw-plugin) are
@@ -33,7 +33,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-ROOT = Path(__file__).resolve().parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent  # scripts/workflows/ -> scripts/ -> repo root
 
 # Hardcoded list - matches the 11 files in every "chore: bump version" commit.
 # DO NOT discover dynamically. Submodules must be excluded.

--- a/scripts/workflows/check_drift.py
+++ b/scripts/workflows/check_drift.py
@@ -53,7 +53,9 @@ def check_drift(paths: list[str]) -> bool:
 def _git_diff(paths: list[str]) -> list[str]:
     result = subprocess.run(
         ["git", "diff", "--name-only", "--", *paths],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     )
     return [line for line in result.stdout.splitlines() if line]
 
@@ -61,7 +63,9 @@ def _git_diff(paths: list[str]) -> list[str]:
 def _git_untracked(paths: list[str]) -> list[str]:
     result = subprocess.run(
         ["git", "ls-files", "--others", "--exclude-standard", "--", *paths],
-        capture_output=True, text=True, check=True,
+        capture_output=True,
+        text=True,
+        check=True,
     )
     return [line for line in result.stdout.splitlines() if line]
 

--- a/scripts/workflows/check_drift.py
+++ b/scripts/workflows/check_drift.py
@@ -8,7 +8,7 @@ Exits 0 if all paths are clean (no modified or untracked files).
 Exits 1 if any drift is detected, with a summary of what changed.
 
 ─────────────────────────────────────────────────────────────────────────────
-CI DEPENDENCY — called by the codegen sync check:
+CI DEPENDENCY - called by the codegen sync check:
   .github/workflows/checks/codegen-sync.yml
     → python3 scripts/workflows/check_drift.py \\
         apps/syn-cli-node/src/generated/ \\
@@ -84,7 +84,7 @@ def main() -> None:
 
     paths = sys.argv[1:]
 
-    # Validate paths exist (warn only — they may not exist on first run)
+    # Validate paths exist (warn only - they may not exist on first run)
     for p in paths:
         if not Path(p).exists():
             print(f"::warning::Path does not exist: {p}", file=sys.stderr)

--- a/scripts/workflows/check_drift.py
+++ b/scripts/workflows/check_drift.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Check generated artifact drift.
+
+Usage:
+    python3 scripts/workflows/check_drift.py <path> [<path> ...]
+
+Exits 0 if all paths are clean (no modified or untracked files).
+Exits 1 if any drift is detected, with a summary of what changed.
+
+─────────────────────────────────────────────────────────────────────────────
+CI DEPENDENCY — called by the codegen sync check:
+  .github/workflows/checks/codegen-sync.yml
+    → python3 scripts/workflows/check_drift.py \\
+        apps/syn-cli-node/src/generated/ \\
+        apps/syn-docs/content/docs/cli/ \\
+        apps/syn-docs/content/docs/api/ \\
+        apps/syn-docs/openapi.json
+
+To fix a failure locally: just codegen && git add -A && git commit
+─────────────────────────────────────────────────────────────────────────────
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def check_drift(paths: list[str]) -> bool:
+    """Return True if all paths are clean, False if any drift detected."""
+    changed = _git_diff(paths)
+    untracked = _git_untracked(paths)
+
+    if not changed and not untracked:
+        print("✓ All generated artifacts are in sync.")
+        return True
+
+    print("::error::Generated artifacts are stale. Run 'just codegen' and commit.")
+    print()
+
+    if changed:
+        _git_diff_stat(paths)
+
+    if untracked:
+        print("Untracked files:")
+        for f in untracked:
+            print(f"  {f}")
+
+    return False
+
+
+def _git_diff(paths: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", "--", *paths],
+        capture_output=True, text=True, check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _git_untracked(paths: list[str]) -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "--others", "--exclude-standard", "--", *paths],
+        capture_output=True, text=True, check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def _git_diff_stat(paths: list[str]) -> None:
+    subprocess.run(
+        ["git", "diff", "--stat", "--", *paths],
+        check=False,
+    )
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(1)
+
+    paths = sys.argv[1:]
+
+    # Validate paths exist (warn only — they may not exist on first run)
+    for p in paths:
+        if not Path(p).exists():
+            print(f"::warning::Path does not exist: {p}", file=sys.stderr)
+
+    sys.exit(0 if check_drift(paths) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/workflows/test_bump_version.py
+++ b/scripts/workflows/test_bump_version.py
@@ -24,6 +24,8 @@ from bump_version import (
     get_current_version,
 )
 
+pytestmark = pytest.mark.unit
+
 
 # =============================================================================
 # Semver parsing

--- a/scripts/workflows/test_bump_version.py
+++ b/scripts/workflows/test_bump_version.py
@@ -1,0 +1,319 @@
+"""Tests for scripts/workflows/bump_version.py.
+
+Covers version comparison, consistency checking, release bump validation,
+and the bump logic itself. All tests are pure unit tests — no git or
+filesystem side effects beyond temporary directories.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from bump_version import (
+    _compare_prerelease,
+    _parse_semver,
+    bump,
+    check_consistency,
+    check_release_bump,
+    compare_versions,
+    get_current_version,
+)
+
+
+# =============================================================================
+# Semver parsing
+# =============================================================================
+
+
+class TestParseSemver:
+    def test_stable(self) -> None:
+        assert _parse_semver("1.2.3") == (1, 2, 3, None)
+
+    def test_prerelease(self) -> None:
+        assert _parse_semver("0.24.2-beta.1") == (0, 24, 2, ["beta", "1"])
+
+    def test_multi_part_prerelease(self) -> None:
+        assert _parse_semver("1.0.0-rc.2.3") == (1, 0, 0, ["rc", "2", "3"])
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(ValueError, match="Invalid semantic version"):
+            _parse_semver("not-a-version")
+
+    def test_invalid_missing_patch_raises(self) -> None:
+        with pytest.raises(ValueError):
+            _parse_semver("1.2")
+
+
+# =============================================================================
+# Version comparison
+# =============================================================================
+
+
+class TestCompareVersions:
+    # Stable ordering
+    def test_patch_increment(self) -> None:
+        assert compare_versions("0.24.3", "0.24.2") == 1
+
+    def test_minor_increment(self) -> None:
+        assert compare_versions("0.25.0", "0.24.9") == 1
+
+    def test_major_increment(self) -> None:
+        assert compare_versions("1.0.0", "0.99.99") == 1
+
+    def test_equal(self) -> None:
+        assert compare_versions("0.24.2", "0.24.2") == 0
+
+    def test_less_than(self) -> None:
+        assert compare_versions("0.24.1", "0.24.2") == -1
+
+    # Prerelease ordering (semver spec: stable > prerelease of same core)
+    def test_stable_greater_than_prerelease(self) -> None:
+        assert compare_versions("0.24.2", "0.24.2-beta.1") == 1
+
+    def test_prerelease_less_than_stable(self) -> None:
+        assert compare_versions("0.24.2-beta.1", "0.24.2") == -1
+
+    def test_prerelease_numeric_ordering(self) -> None:
+        assert compare_versions("0.24.2-beta.2", "0.24.2-beta.1") == 1
+        assert compare_versions("0.24.2-beta.10", "0.24.2-beta.9") == 1
+
+    def test_prerelease_alpha_before_beta(self) -> None:
+        assert compare_versions("0.24.2-alpha.1", "0.24.2-beta.1") == -1
+
+    def test_rc_after_beta(self) -> None:
+        assert compare_versions("0.24.2-rc.1", "0.24.2-beta.1") == 1
+
+    def test_two_prereleases_equal(self) -> None:
+        assert compare_versions("0.24.2-beta.1", "0.24.2-beta.1") == 0
+
+
+# =============================================================================
+# check_consistency
+# =============================================================================
+
+
+def _make_version_files(tmp_path: Path, version: str) -> None:
+    """Write all 11 version files at the given version into tmp_path."""
+    pyprojects = [
+        "pyproject.toml",
+        "apps/syn-api/pyproject.toml",
+        "packages/syn-adapters/pyproject.toml",
+        "packages/syn-collector/pyproject.toml",
+        "packages/syn-domain/pyproject.toml",
+        "packages/syn-perf/pyproject.toml",
+        "packages/syn-shared/pyproject.toml",
+        "packages/syn-tokens/pyproject.toml",
+    ]
+    package_jsons = [
+        "apps/syn-cli-node/package.json",
+        "apps/syn-dashboard-ui/package.json",
+        "apps/syn-docs/package.json",
+    ]
+    for rel in pyprojects:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(textwrap.dedent(f"""\
+            [project]
+            name = "placeholder"
+            version = "{version}"
+        """))
+    for rel in package_jsons:
+        p = tmp_path / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(json.dumps({"name": "placeholder", "version": version}, indent=2) + "\n")
+
+
+class TestCheckConsistency:
+    def test_all_match(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _make_version_files(tmp_path, "0.24.2")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+        monkeypatch.setattr(
+            bv,
+            "PYPROJECT_FILES",
+            [tmp_path / p for p in [
+                "pyproject.toml",
+                "apps/syn-api/pyproject.toml",
+                "packages/syn-adapters/pyproject.toml",
+                "packages/syn-collector/pyproject.toml",
+                "packages/syn-domain/pyproject.toml",
+                "packages/syn-perf/pyproject.toml",
+                "packages/syn-shared/pyproject.toml",
+                "packages/syn-tokens/pyproject.toml",
+            ]],
+        )
+        monkeypatch.setattr(
+            bv,
+            "PACKAGE_JSON_FILES",
+            [tmp_path / p for p in [
+                "apps/syn-cli-node/package.json",
+                "apps/syn-dashboard-ui/package.json",
+                "apps/syn-docs/package.json",
+            ]],
+        )
+        assert check_consistency() is True
+
+    def test_mismatch_detected(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _make_version_files(tmp_path, "0.24.2")
+        # Introduce a mismatch in one package.json
+        bad = tmp_path / "apps/syn-cli-node/package.json"
+        bad.write_text(json.dumps({"name": "placeholder", "version": "0.24.1"}))
+
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+        monkeypatch.setattr(
+            bv,
+            "PYPROJECT_FILES",
+            [tmp_path / "pyproject.toml"],
+        )
+        monkeypatch.setattr(
+            bv,
+            "PACKAGE_JSON_FILES",
+            [tmp_path / "apps/syn-cli-node/package.json"],
+        )
+        assert check_consistency() is False
+
+
+# =============================================================================
+# check_release_bump — uses subprocess.run, so mock it
+# =============================================================================
+
+
+class TestCheckReleaseBump:
+    def _mock_git_show(self, monkeypatch: pytest.MonkeyPatch, release_version: str) -> None:
+        """Patch subprocess.run to return a fake pyproject.toml from the release branch."""
+        import bump_version as bv
+
+        pyproject_content = textwrap.dedent(f"""\
+            [project]
+            version = "{release_version}"
+        """)
+
+        def fake_run(
+            cmd: list[str],
+            *,
+            capture_output: bool = False,
+            text: bool = False,
+            check: bool = False,
+        ) -> subprocess.CompletedProcess[str]:
+            return subprocess.CompletedProcess(cmd, returncode=0, stdout=pyproject_content)
+
+        monkeypatch.setattr(bv.subprocess, "run", fake_run)
+
+    def test_bumped_version_passes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _make_version_files(tmp_path, "0.24.3")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+        self._mock_git_show(monkeypatch, "0.24.2")
+        assert check_release_bump() is True
+
+    def test_same_version_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _make_version_files(tmp_path, "0.24.2")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+        self._mock_git_show(monkeypatch, "0.24.2")
+        assert check_release_bump() is False
+
+    def test_lower_version_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _make_version_files(tmp_path, "0.24.1")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+        self._mock_git_show(monkeypatch, "0.24.2")
+        assert check_release_bump() is False
+
+    def test_prerelease_before_stable_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # 0.24.2-beta.1 < 0.24.2 — should fail
+        _make_version_files(tmp_path, "0.24.2-beta.1")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+        self._mock_git_show(monkeypatch, "0.24.2")
+        assert check_release_bump() is False
+
+    def test_git_failure_returns_false(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _make_version_files(tmp_path, "0.24.3")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+
+        def fail_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+            raise subprocess.CalledProcessError(1, "git")
+
+        monkeypatch.setattr(bv.subprocess, "run", fail_run)
+        assert check_release_bump() is False
+
+
+# =============================================================================
+# bump — filesystem round-trip
+# =============================================================================
+
+
+class TestBump:
+    def test_updates_all_files(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _make_version_files(tmp_path, "0.24.2")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+        monkeypatch.setattr(
+            bv,
+            "PYPROJECT_FILES",
+            [tmp_path / "pyproject.toml"],
+        )
+        monkeypatch.setattr(
+            bv,
+            "PACKAGE_JSON_FILES",
+            [tmp_path / "apps/syn-cli-node/package.json"],
+        )
+
+        bump("0.25.0")
+
+        pyproject = (tmp_path / "pyproject.toml").read_text()
+        assert 'version = "0.25.0"' in pyproject
+
+        pkg = json.loads((tmp_path / "apps/syn-cli-node/package.json").read_text())
+        assert pkg["version"] == "0.25.0"
+
+    def test_noop_if_already_at_version(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _make_version_files(tmp_path, "0.24.2")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+        monkeypatch.setattr(bv, "PYPROJECT_FILES", [tmp_path / "pyproject.toml"])
+        monkeypatch.setattr(bv, "PACKAGE_JSON_FILES", [])
+
+        bump("0.24.2")
+        out = capsys.readouterr().out
+        assert "nothing to do" in out
+
+    def test_invalid_version_exits(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _make_version_files(tmp_path, "0.24.2")
+        import bump_version as bv
+
+        monkeypatch.setattr(bv, "ROOT", tmp_path)
+
+        with pytest.raises(SystemExit):
+            bump("not-a-version")

--- a/scripts/workflows/test_bump_version.py
+++ b/scripts/workflows/test_bump_version.py
@@ -10,18 +10,18 @@ from __future__ import annotations
 import json
 import subprocess
 import textwrap
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 
+if TYPE_CHECKING:
+    from pathlib import Path
 from bump_version import (
-    _compare_prerelease,
     _parse_semver,
     bump,
     check_consistency,
     check_release_bump,
     compare_versions,
-    get_current_version,
 )
 
 pytestmark = pytest.mark.unit
@@ -119,11 +119,13 @@ def _make_version_files(tmp_path: Path, version: str) -> None:
     for rel in pyprojects:
         p = tmp_path / rel
         p.parent.mkdir(parents=True, exist_ok=True)
-        p.write_text(textwrap.dedent(f"""\
+        p.write_text(
+            textwrap.dedent(f"""\
             [project]
             name = "placeholder"
             version = "{version}"
-        """))
+        """)
+        )
     for rel in package_jsons:
         p = tmp_path / rel
         p.parent.mkdir(parents=True, exist_ok=True)
@@ -139,25 +141,31 @@ class TestCheckConsistency:
         monkeypatch.setattr(
             bv,
             "PYPROJECT_FILES",
-            [tmp_path / p for p in [
-                "pyproject.toml",
-                "apps/syn-api/pyproject.toml",
-                "packages/syn-adapters/pyproject.toml",
-                "packages/syn-collector/pyproject.toml",
-                "packages/syn-domain/pyproject.toml",
-                "packages/syn-perf/pyproject.toml",
-                "packages/syn-shared/pyproject.toml",
-                "packages/syn-tokens/pyproject.toml",
-            ]],
+            [
+                tmp_path / p
+                for p in [
+                    "pyproject.toml",
+                    "apps/syn-api/pyproject.toml",
+                    "packages/syn-adapters/pyproject.toml",
+                    "packages/syn-collector/pyproject.toml",
+                    "packages/syn-domain/pyproject.toml",
+                    "packages/syn-perf/pyproject.toml",
+                    "packages/syn-shared/pyproject.toml",
+                    "packages/syn-tokens/pyproject.toml",
+                ]
+            ],
         )
         monkeypatch.setattr(
             bv,
             "PACKAGE_JSON_FILES",
-            [tmp_path / p for p in [
-                "apps/syn-cli-node/package.json",
-                "apps/syn-dashboard-ui/package.json",
-                "apps/syn-docs/package.json",
-            ]],
+            [
+                tmp_path / p
+                for p in [
+                    "apps/syn-cli-node/package.json",
+                    "apps/syn-dashboard-ui/package.json",
+                    "apps/syn-docs/package.json",
+                ]
+            ],
         )
         assert check_consistency() is True
 
@@ -209,9 +217,7 @@ class TestCheckReleaseBump:
 
         monkeypatch.setattr(bv.subprocess, "run", fake_run)
 
-    def test_bumped_version_passes(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_bumped_version_passes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _make_version_files(tmp_path, "0.24.3")
         import bump_version as bv
 
@@ -219,9 +225,7 @@ class TestCheckReleaseBump:
         self._mock_git_show(monkeypatch, "0.24.2")
         assert check_release_bump() is True
 
-    def test_same_version_fails(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_same_version_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _make_version_files(tmp_path, "0.24.2")
         import bump_version as bv
 
@@ -229,9 +233,7 @@ class TestCheckReleaseBump:
         self._mock_git_show(monkeypatch, "0.24.2")
         assert check_release_bump() is False
 
-    def test_lower_version_fails(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_lower_version_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _make_version_files(tmp_path, "0.24.1")
         import bump_version as bv
 
@@ -309,9 +311,7 @@ class TestBump:
         out = capsys.readouterr().out
         assert "nothing to do" in out
 
-    def test_invalid_version_exits(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_invalid_version_exits(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         _make_version_files(tmp_path, "0.24.2")
         import bump_version as bv
 

--- a/scripts/workflows/test_bump_version.py
+++ b/scripts/workflows/test_bump_version.py
@@ -1,7 +1,7 @@
 """Tests for scripts/workflows/bump_version.py.
 
 Covers version comparison, consistency checking, release bump validation,
-and the bump logic itself. All tests are pure unit tests — no git or
+and the bump logic itself. All tests are pure unit tests - no git or
 filesystem side effects beyond temporary directories.
 """
 
@@ -192,7 +192,7 @@ class TestCheckConsistency:
 
 
 # =============================================================================
-# check_release_bump — uses subprocess.run, so mock it
+# check_release_bump - uses subprocess.run, so mock it
 # =============================================================================
 
 
@@ -244,7 +244,7 @@ class TestCheckReleaseBump:
     def test_prerelease_before_stable_fails(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # 0.24.2-beta.1 < 0.24.2 — should fail
+        # 0.24.2-beta.1 < 0.24.2 - should fail
         _make_version_files(tmp_path, "0.24.2-beta.1")
         import bump_version as bv
 
@@ -268,7 +268,7 @@ class TestCheckReleaseBump:
 
 
 # =============================================================================
-# bump — filesystem round-trip
+# bump - filesystem round-trip
 # =============================================================================
 
 

--- a/scripts/workflows/test_check_drift.py
+++ b/scripts/workflows/test_check_drift.py
@@ -1,0 +1,63 @@
+"""Tests for scripts/workflows/check_drift.py."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from check_drift import check_drift, _git_diff, _git_untracked
+
+
+class TestCheckDrift:
+    def _mock_git(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        changed: list[str],
+        untracked: list[str],
+    ) -> None:
+        def fake_run(
+            cmd: list[str],
+            *,
+            capture_output: bool = False,
+            text: bool = False,
+            check: bool = False,
+            **kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            if "diff" in cmd and "--name-only" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "\n".join(changed) + "\n")
+            if "ls-files" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, "\n".join(untracked) + "\n")
+            return subprocess.CompletedProcess(cmd, 0, "")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+    def test_clean_returns_true(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mock_git(monkeypatch, changed=[], untracked=[])
+        assert check_drift(["apps/syn-cli-node/src/generated/"]) is True
+
+    def test_changed_files_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mock_git(monkeypatch, changed=["apps/syn-cli-node/src/generated/api-types.ts"], untracked=[])
+        assert check_drift(["apps/syn-cli-node/src/generated/"]) is False
+
+    def test_untracked_files_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mock_git(monkeypatch, changed=[], untracked=["apps/syn-docs/content/docs/cli/new-cmd.md"])
+        assert check_drift(["apps/syn-docs/content/docs/cli/"]) is False
+
+    def test_both_changed_and_untracked_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mock_git(
+            monkeypatch,
+            changed=["apps/syn-cli-node/src/generated/api-types.ts"],
+            untracked=["apps/syn-docs/content/docs/cli/new.md"],
+        )
+        assert check_drift(["apps/syn-cli-node/src/generated/", "apps/syn-docs/content/docs/cli/"]) is False
+
+    def test_multiple_paths_all_clean(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._mock_git(monkeypatch, changed=[], untracked=[])
+        assert check_drift([
+            "apps/syn-cli-node/src/generated/",
+            "apps/syn-docs/content/docs/cli/",
+            "apps/syn-docs/openapi.json",
+        ]) is True

--- a/scripts/workflows/test_check_drift.py
+++ b/scripts/workflows/test_check_drift.py
@@ -3,11 +3,9 @@
 from __future__ import annotations
 
 import subprocess
-from unittest.mock import patch
 
 import pytest
-
-from check_drift import check_drift, _git_diff, _git_untracked
+from check_drift import check_drift
 
 pytestmark = pytest.mark.unit
 
@@ -40,25 +38,39 @@ class TestCheckDrift:
         assert check_drift(["apps/syn-cli-node/src/generated/"]) is True
 
     def test_changed_files_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        self._mock_git(monkeypatch, changed=["apps/syn-cli-node/src/generated/api-types.ts"], untracked=[])
+        self._mock_git(
+            monkeypatch, changed=["apps/syn-cli-node/src/generated/api-types.ts"], untracked=[]
+        )
         assert check_drift(["apps/syn-cli-node/src/generated/"]) is False
 
     def test_untracked_files_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        self._mock_git(monkeypatch, changed=[], untracked=["apps/syn-docs/content/docs/cli/new-cmd.md"])
+        self._mock_git(
+            monkeypatch, changed=[], untracked=["apps/syn-docs/content/docs/cli/new-cmd.md"]
+        )
         assert check_drift(["apps/syn-docs/content/docs/cli/"]) is False
 
-    def test_both_changed_and_untracked_returns_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_both_changed_and_untracked_returns_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         self._mock_git(
             monkeypatch,
             changed=["apps/syn-cli-node/src/generated/api-types.ts"],
             untracked=["apps/syn-docs/content/docs/cli/new.md"],
         )
-        assert check_drift(["apps/syn-cli-node/src/generated/", "apps/syn-docs/content/docs/cli/"]) is False
+        assert (
+            check_drift(["apps/syn-cli-node/src/generated/", "apps/syn-docs/content/docs/cli/"])
+            is False
+        )
 
     def test_multiple_paths_all_clean(self, monkeypatch: pytest.MonkeyPatch) -> None:
         self._mock_git(monkeypatch, changed=[], untracked=[])
-        assert check_drift([
-            "apps/syn-cli-node/src/generated/",
-            "apps/syn-docs/content/docs/cli/",
-            "apps/syn-docs/openapi.json",
-        ]) is True
+        assert (
+            check_drift(
+                [
+                    "apps/syn-cli-node/src/generated/",
+                    "apps/syn-docs/content/docs/cli/",
+                    "apps/syn-docs/openapi.json",
+                ]
+            )
+            is True
+        )

--- a/scripts/workflows/test_check_drift.py
+++ b/scripts/workflows/test_check_drift.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import subprocess
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
 from check_drift import check_drift, _git_diff, _git_untracked
+
+pytestmark = pytest.mark.unit
 
 
 class TestCheckDrift:


### PR DESCRIPTION
## Summary

- Extracts the monolithic `release-gate.yml` (383 lines) into four focused reusable workflows under `.github/workflows/checks/`, each independently callable via `workflow_call`
- Rewrites `release-gate.yml` as a thin ~50-line orchestrator
- Moves `scripts/bump_version.py` → `scripts/workflows/` with a new `--check-release` flag (semver comparison against `origin/release`)
- Adds `scripts/workflows/check_drift.py` to replace brittle inline shell in codegen-sync; consolidates the old duplicate `docs-drift` + `cli-api-sync` jobs into one
- Fixes Docker GHA cache: `cache-to` was missing so the layer cache was never warmed; drops the now-redundant `check-docker-changes` path filter
- 31 co-located tests (all passing)

## Changes

| File | Change |
|------|--------|
| `.github/workflows/checks/version-check.yml` | New — thin wrapper around `bump_version.py --check` + `--check-release` |
| `.github/workflows/checks/changelog-check.yml` | New — validates PR body ≥ 20 chars |
| `.github/workflows/checks/codegen-sync.yml` | New — `just codegen` + drift check via Python script |
| `.github/workflows/checks/docker-dry-run.yml` | New — always-on dry-run with proper `cache-to` |
| `.github/workflows/release-gate.yml` | Rewritten as thin orchestrator |
| `.github/workflows/release-create.yml` | Pre-publish validation now composes `codegen-sync.yml` |
| `scripts/workflows/bump_version.py` | Moved from `scripts/`; added `--check-release` + semver comparison |
| `scripts/workflows/check_drift.py` | New — replaces inline shell, checks git diff + untracked for paths |
| `scripts/workflows/test_bump_version.py` | New — 26 tests |
| `scripts/workflows/test_check_drift.py` | New — 5 tests |
| `pyproject.toml` | Added `scripts/workflows` to testpaths + pythonpath |
| `justfile` | Updated bump-version/check-version recipes to new path |
| `docs/release-process.md` | Trust architecture, token map, branch protection rules, workflow links |

## Test plan

- [ ] All 31 unit tests pass: `uv run pytest scripts/workflows/ -q`
- [ ] `just check-version` still works (updated recipe path)
- [ ] `just bump-version <ver>` still works
- [ ] CI gate fires on this PR — version-check, changelog-check, codegen-sync, docker-dry-run all run as composable checks
- [ ] Verify Docker build uses cache on second run (check GHA cache hit rate in logs)