### PR TITLE
fix: onboarding-discovered platform bugs — v0.24.4 patch (#661)

### DIFF
--- a/apps/syn-api/src/syn_api/routes/executions/commands.py
+++ b/apps/syn-api/src/syn_api/routes/executions/commands.py
@@ -99,13 +99,23 @@ def _build_auth_error_detail(repo_full_name: str, exc: Exception) -> str:
 
 
 def _apply_repo_substitution(repos: list[str], merged: dict[str, str]) -> list[str]:
-    """Substitute {{key}} patterns in each repo URL; skip entries with remaining placeholders."""
+    """Substitute {{key}} patterns in each repo URL; raise ValueError if any placeholders remain."""
     resolved = []
     for repo_url in repos:
         for key, value in merged.items():
             repo_url = repo_url.replace(f"{{{{{key}}}}}", value)
-        if "{{" not in repo_url:
-            resolved.append(repo_url)
+        if "{{" in repo_url:
+            unresolved = re.findall(r"\{\{(\w+)\}\}", repo_url)
+            if not unresolved:
+                raise ValueError(
+                    "Malformed placeholder in repos field. "
+                    "Expected {{name}} with alphanumeric/underscore characters."
+                )
+            raise ValueError(
+                f"Unresolved placeholders in repos field: {unresolved}. "
+                f"Provide them via --input {', '.join(f'{k}=<value>' for k in unresolved)}."
+            )
+        resolved.append(repo_url)
     return resolved
 
 
@@ -141,7 +151,10 @@ def _get_preflight_repos(
     # repository_url (which defaults to example/repo), producing a misleading auth error.
     if workflow.repos:
         merged = _build_merged_inputs(workflow, effective_inputs, task)
-        resolved = _apply_repo_substitution(workflow.repos, merged)
+        try:
+            resolved = _apply_repo_substitution(workflow.repos, merged)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc)) from exc
         if resolved:
             return resolved
 

--- a/apps/syn-api/src/syn_api/routes/executions/commands.py
+++ b/apps/syn-api/src/syn_api/routes/executions/commands.py
@@ -98,6 +98,34 @@ def _build_auth_error_detail(repo_full_name: str, exc: Exception) -> str:
     return f"GitHub App authentication failed for {repo_full_name}: {exc_message}"
 
 
+def _apply_repo_substitution(repos: list[str], merged: dict[str, str]) -> list[str]:
+    """Substitute {{key}} patterns in each repo URL; skip entries with remaining placeholders."""
+    resolved = []
+    for repo_url in repos:
+        for key, value in merged.items():
+            repo_url = repo_url.replace(f"{{{{{key}}}}}", value)
+        if "{{" not in repo_url:
+            resolved.append(repo_url)
+    return resolved
+
+
+def _build_merged_inputs(
+    workflow: WorkflowTemplateAggregate,
+    effective_inputs: dict[str, str],
+    task: str | None,
+) -> dict[str, str]:
+    """Merge input declaration defaults, effective inputs, and task into one dict."""
+    merged: dict[str, str] = {
+        decl.name: str(decl.default)
+        for decl in workflow.input_declarations
+        if decl.default is not None
+    }
+    merged.update(effective_inputs)
+    if task is not None:
+        merged["task"] = task
+    return merged
+
+
 def _get_preflight_repos(
     effective_inputs: dict[str, str],
     workflow: WorkflowTemplateAggregate,
@@ -112,20 +140,8 @@ def _get_preflight_repos(
     # Without this, unresolved {{variable}} patterns in repos silently fall through to
     # repository_url (which defaults to example/repo), producing a misleading auth error.
     if workflow.repos:
-        merged: dict[str, str] = {
-            decl.name: str(decl.default)
-            for decl in workflow.input_declarations
-            if decl.default is not None
-        }
-        merged.update(effective_inputs)
-        if task is not None:
-            merged["task"] = task
-        resolved = []
-        for repo_url in workflow.repos:
-            for key, value in merged.items():
-                repo_url = repo_url.replace(f"{{{{{key}}}}}", value)
-            if "{{" not in repo_url:
-                resolved.append(repo_url)
+        merged = _build_merged_inputs(workflow, effective_inputs, task)
+        resolved = _apply_repo_substitution(workflow.repos, merged)
         if resolved:
             return resolved
 

--- a/apps/syn-api/src/syn_api/routes/executions/commands.py
+++ b/apps/syn-api/src/syn_api/routes/executions/commands.py
@@ -152,11 +152,9 @@ def _get_preflight_repos(
     if workflow.repos:
         merged = _build_merged_inputs(workflow, effective_inputs, task)
         try:
-            resolved = _apply_repo_substitution(workflow.repos, merged)
+            return _apply_repo_substitution(workflow.repos, merged)
         except ValueError as exc:
             raise HTTPException(status_code=422, detail=str(exc)) from exc
-        if resolved:
-            return resolved
 
     fallback = _resolve_target_repo(workflow, effective_inputs, task)
     if fallback:

--- a/apps/syn-api/src/syn_api/routes/executions/commands.py
+++ b/apps/syn-api/src/syn_api/routes/executions/commands.py
@@ -107,6 +107,28 @@ def _get_preflight_repos(
     repos_csv = effective_inputs.get("repos", "")
     if repos_csv:
         return [u.strip() for u in repos_csv.split(",") if u.strip()]
+
+    # Check workflow.repos with variable substitution (mirrors ExecuteWorkflowHandler._resolve_repos).
+    # Without this, unresolved {{variable}} patterns in repos silently fall through to
+    # repository_url (which defaults to example/repo), producing a misleading auth error.
+    if workflow.repos:
+        merged: dict[str, str] = {
+            decl.name: str(decl.default)
+            for decl in workflow.input_declarations
+            if decl.default is not None
+        }
+        merged.update(effective_inputs)
+        if task is not None:
+            merged["task"] = task
+        resolved = []
+        for repo_url in workflow.repos:
+            for key, value in merged.items():
+                repo_url = repo_url.replace(f"{{{{{key}}}}}", value)
+            if "{{" not in repo_url:
+                resolved.append(repo_url)
+        if resolved:
+            return resolved
+
     fallback = _resolve_target_repo(workflow, effective_inputs, task)
     if fallback:
         return [f"https://github.com/{fallback}"]

--- a/apps/syn-cli-node/src/commands/workflow/crud.ts
+++ b/apps/syn-cli-node/src/commands/workflow/crud.ts
@@ -12,6 +12,7 @@ import { style, BOLD, CYAN, DIM, GREEN, YELLOW } from "../../output/ansi.js";
 import { Table } from "../../output/table.js";
 import { resolveWorkflow } from "./resolver.js";
 import { detectFormat, resolvePackage } from "../../packages/resolver.js";
+import fs from "node:fs";
 import path from "node:path";
 
 type WorkflowResponse = components["schemas"]["WorkflowResponse"];
@@ -30,6 +31,7 @@ export const createCommand: CommandDef = {
     ref: { type: "string", description: "Repository ref/branch", default: "main" },
     description: { type: "string", short: "d", description: "Workflow description" },
     repos: { type: "string", short: "R", description: "Default GitHub URLs for workspace hydration (repeatable). ADR-058.", multiple: true },
+    from: { type: "string", short: "f", description: "Path to workflow.yaml or directory containing it — registers phases from YAML" },
   },
   handler: async (parsed: ParsedArgs) => {
     const name = parsed.positionals[0];
@@ -44,6 +46,34 @@ export const createCommand: CommandDef = {
     const description = parsed.values["description"] as string | undefined;
     const reposValues = parsed.values["repos"];
     const templateRepos: string[] = Array.isArray(reposValues) ? reposValues as string[] : reposValues ? [reposValues as string] : [];
+    const fromPath = parsed.values["from"] as string | undefined;
+
+    let phases: Record<string, unknown>[] | undefined;
+    let inputDeclarations: unknown[] | undefined;
+
+    if (fromPath) {
+      const resolved = path.resolve(fromPath);
+      if (!fs.existsSync(resolved)) {
+        printError(`Path not found: ${fromPath}`);
+        throw new CLIError("Path not found", 1);
+      }
+      const stat = fs.statSync(resolved);
+      const workflowDir = stat.isDirectory() ? resolved : path.dirname(resolved);
+      try {
+        const { workflows } = resolvePackage(workflowDir);
+        if (workflows.length === 0) {
+          printError(`No workflows found in: ${workflowDir}`);
+          throw new CLIError("No workflows found", 1);
+        }
+        const wf = workflows[0]!;
+        phases = wf.phases as Record<string, unknown>[];
+        inputDeclarations = wf.input_declarations;
+      } catch (err) {
+        if (err instanceof CLIError) throw err;
+        printError(`Failed to parse workflow YAML: ${err instanceof Error ? err.message : String(err)}`);
+        throw new CLIError("YAML parse error", 1);
+      }
+    }
 
     const data = unwrap(
       await api.POST("/workflows", {
@@ -55,6 +85,8 @@ export const createCommand: CommandDef = {
           repository_ref: repoRef,
           description: description ?? null,
           ...(templateRepos.length > 0 ? { repos: templateRepos } : {}),
+          ...(phases !== undefined ? { phases } : {}),
+          ...(inputDeclarations !== undefined ? { input_declarations: inputDeclarations } : {}),
         },
       }),
       "Failed to create workflow",
@@ -64,6 +96,9 @@ export const createCommand: CommandDef = {
     printSuccess(`Created workflow: ${style(name, CYAN)}`);
     print(`  ID: ${style(workflowId, DIM)}`);
     print(`  Type: ${style(workflowType, DIM)}`);
+    if (!fromPath) {
+      printDim(`  Tip: Use --from ./workflow.yaml to register phases from a YAML file`);
+    }
   },
 };
 

--- a/apps/syn-cli-node/src/commands/workflow/crud.ts
+++ b/apps/syn-cli-node/src/commands/workflow/crud.ts
@@ -49,7 +49,7 @@ export const createCommand: CommandDef = {
     const fromPath = parsed.values["from"] as string | undefined;
 
     let phases: Record<string, unknown>[] | undefined;
-    let inputDeclarations: unknown[] | undefined;
+    let inputDeclarations: Record<string, unknown>[] | undefined;
 
     if (fromPath) {
       const resolved = path.resolve(fromPath);

--- a/apps/syn-dashboard-ui/src/pages/SessionDetail/CliDisclaimerBanner.tsx
+++ b/apps/syn-dashboard-ui/src/pages/SessionDetail/CliDisclaimerBanner.tsx
@@ -1,0 +1,13 @@
+import { Terminal } from 'lucide-react'
+
+export function CliDisclaimerBanner() {
+  return (
+    <div className="flex items-start gap-3 rounded-lg border border-blue-500/20 bg-blue-500/10 px-4 py-3">
+      <Terminal className="h-4 w-4 shrink-0 text-blue-400 mt-0.5" />
+      <p className="text-sm text-blue-300">
+        This page is intended to be operated by an agent through the CLI, either locally or remotely.
+        Manual kickoff is available as a convenience if desired.
+      </p>
+    </div>
+  )
+}

--- a/apps/syn-dashboard-ui/src/pages/SessionDetail/SessionDetail.tsx
+++ b/apps/syn-dashboard-ui/src/pages/SessionDetail/SessionDetail.tsx
@@ -8,6 +8,7 @@ import type { SessionResponse } from '../../types'
 import { useSessionData } from '../../hooks'
 import { ConversationLogViewer } from './ConversationLogViewer'
 import { OperationTimeline } from './OperationTimeline'
+import { CliDisclaimerBanner } from './CliDisclaimerBanner'
 import { SessionHeader } from './SessionHeader'
 import { SessionMetrics } from './SessionMetrics'
 
@@ -104,6 +105,7 @@ export function SessionDetail() {
 
       <Breadcrumbs items={buildSessionBreadcrumbs(session)} />
       <SessionHeader session={session} onViewConversationLog={() => setShowConversationLog(true)} />
+      <CliDisclaimerBanner />
       <SessionMetrics session={session} now={now} />
 
       {session.error_message && <SessionErrorCard message={session.error_message} />}

--- a/ci/fitness/fitness_exceptions.toml
+++ b/ci/fitness/fitness_exceptions.toml
@@ -34,7 +34,7 @@
 "packages/syn-domain/src/syn_domain/contexts/orchestration/cleanup/stale_execution_cleaner.py" = { max_calls = 1, issue = "#197" }
 "packages/syn-domain/src/syn_domain/contexts/orchestration/slices/create_workflow_template/CreateWorkflowTemplateHandler.py" = { max_calls = 1, issue = "#197" }
 "packages/syn-domain/src/syn_domain/contexts/orchestration/slices/update_workflow_phase/UpdateWorkflowPhaseHandler.py" = { max_calls = 1, issue = "#402" }
-"packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py" = { max_calls = 8, issue = "#196" }
+"packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py" = { max_calls = 9, issue = "#196" }
 "apps/syn-api/src/syn_api/routes/artifacts.py" = { max_calls = 1, issue = "#277" }
 
 [event_construction_outside_aggregate]

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
@@ -65,9 +65,14 @@ def _substitute_repo_vars(repo_url: str, merged_inputs: dict[str, str]) -> str:
         repo_url = repo_url.replace(f"{{{{{key}}}}}", str(value))
     if "{{" in repo_url:
         unresolved = re.findall(r"\{\{(\w+)\}\}", repo_url)
+        if not unresolved:
+            raise ValueError(
+                "Malformed placeholders in repos field. "
+                "Expected placeholders in the form {{name}} with alphanumeric/underscore characters."
+            )
         raise ValueError(
             f"Unresolved placeholders in repos field: {unresolved}. "
-            f"Provide them via --input {unresolved[0]}=<value>."
+            f"Provide them via --input {', '.join(f'{k}=<value>' for k in unresolved)}."
         )
     return repo_url
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
@@ -153,7 +153,18 @@ class ExecuteWorkflowHandler:
         if repos_raw:
             return [_normalise_repo_url(u.strip()) for u in repos_raw.split(",") if u.strip()]
         if workflow.repos:
-            return list(workflow.repos)
+            resolved_repos: list[str] = []
+            for repo_url in workflow.repos:
+                for key, value in merged_inputs.items():
+                    repo_url = repo_url.replace(f"{{{{{key}}}}}", str(value))
+                if "{{" in repo_url:
+                    unresolved = re.findall(r"\{\{(\w+)\}\}", repo_url)
+                    raise ValueError(
+                        f"Unresolved placeholders in repos field: {unresolved}. "
+                        f"Provide them via --input {unresolved[0]}=<value>."
+                    )
+                resolved_repos.append(_normalise_repo_url(repo_url))
+            return resolved_repos
         repo_url = _resolve_repo_url(workflow, merged_inputs)
         if repo_url:
             return [repo_url]

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
@@ -59,6 +59,19 @@ def _resolve_repo_url(
     return repo_url
 
 
+def _substitute_repo_vars(repo_url: str, merged_inputs: dict[str, str]) -> str:
+    """Apply {{key}} substitution to a repo URL; raise ValueError if placeholders remain."""
+    for key, value in merged_inputs.items():
+        repo_url = repo_url.replace(f"{{{{{key}}}}}", str(value))
+    if "{{" in repo_url:
+        unresolved = re.findall(r"\{\{(\w+)\}\}", repo_url)
+        raise ValueError(
+            f"Unresolved placeholders in repos field: {unresolved}. "
+            f"Provide them via --input {unresolved[0]}=<value>."
+        )
+    return repo_url
+
+
 def _normalise_repo_url(url: str) -> str:
     """Expand 'owner/repo' slugs to full GitHub HTTPS URLs (trigger preset compat).
 
@@ -153,18 +166,9 @@ class ExecuteWorkflowHandler:
         if repos_raw:
             return [_normalise_repo_url(u.strip()) for u in repos_raw.split(",") if u.strip()]
         if workflow.repos:
-            resolved_repos: list[str] = []
-            for repo_url in workflow.repos:
-                for key, value in merged_inputs.items():
-                    repo_url = repo_url.replace(f"{{{{{key}}}}}", str(value))
-                if "{{" in repo_url:
-                    unresolved = re.findall(r"\{\{(\w+)\}\}", repo_url)
-                    raise ValueError(
-                        f"Unresolved placeholders in repos field: {unresolved}. "
-                        f"Provide them via --input {unresolved[0]}=<value>."
-                    )
-                resolved_repos.append(_normalise_repo_url(repo_url))
-            return resolved_repos
+            return [
+                _normalise_repo_url(_substitute_repo_vars(r, merged_inputs)) for r in workflow.repos
+            ]
         repo_url = _resolve_repo_url(workflow, merged_inputs)
         if repo_url:
             return [repo_url]

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -168,20 +168,16 @@ class WorkflowExecutionProcessor:
         phase_outputs: dict[str, str] = {}
 
         try:
-            while True:
-                todos = await self._todo_projection.get_pending(execution_id)
-                if not todos:
-                    break
-                await self._dispatch(
-                    todo=todos[0],
-                    aggregate=aggregate,
-                    phase_map=phase_map,
-                    phase_results=phase_results,
-                    all_artifact_ids=all_artifact_ids,
-                    completed_phase_ids=completed_phase_ids,
-                    phase_outputs=phase_outputs,
-                    repos=repos,
-                )
+            await self._drain_todo_list(
+                execution_id=execution_id,
+                aggregate=aggregate,
+                phase_map=phase_map,
+                phase_results=phase_results,
+                all_artifact_ids=all_artifact_ids,
+                completed_phase_ids=completed_phase_ids,
+                phase_outputs=phase_outputs,
+                repos=repos,
+            )
             if aggregate.status == ExecutionStatus.CANCELLED:
                 return await self._cancel_execution(
                     execution_id,
@@ -210,6 +206,33 @@ class WorkflowExecutionProcessor:
                 all_artifact_ids,
                 completed_phase_ids,
                 started_at,
+            )
+
+    async def _drain_todo_list(
+        self,
+        execution_id: str,
+        aggregate: WorkflowExecutionAggregate,
+        phase_map: dict[str, ExecutablePhase],
+        phase_results: list[PhaseResult],
+        all_artifact_ids: list[str],
+        completed_phase_ids: list[str],
+        phase_outputs: dict[str, str],
+        repos: list[str] | None,
+    ) -> None:
+        """Process to-do items until the list is empty (all phases done or cancelled)."""
+        while True:
+            todos = await self._todo_projection.get_pending(execution_id)
+            if not todos:
+                break
+            await self._dispatch(
+                todo=todos[0],
+                aggregate=aggregate,
+                phase_map=phase_map,
+                phase_results=phase_results,
+                all_artifact_ids=all_artifact_ids,
+                completed_phase_ids=completed_phase_ids,
+                phase_outputs=phase_outputs,
+                repos=repos,
             )
 
     async def _dispatch(

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -31,6 +31,7 @@ from syn_domain.contexts.orchestration.slices.execute_workflow.ConversationRecor
 )
 from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
     AgentExecutionHandler,
+    AgentExecutionResult,
 )
 from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.ArtifactCollectionHandler import (
     ArtifactCollectionHandler,
@@ -437,13 +438,7 @@ class WorkflowExecutionProcessor:
         )
 
         if result.stream_result.interrupt_requested:
-            cancel_cmd = CancelExecutionCommand(
-                execution_id=todo.execution_id,
-                phase_id=todo.phase_id,
-                reason=result.stream_result.interrupt_reason or "Cancelled by user",
-            )
-            aggregate._handle_command(cancel_cmd)
-            await self._save_and_sync(aggregate)
+            await self._handle_cancel_signal(todo, result, aggregate)
             return
 
         if result.command.exit_code != 0:
@@ -458,6 +453,21 @@ class WorkflowExecutionProcessor:
             raise RuntimeError(msg)
 
         aggregate._handle_command(result.command)
+        await self._save_and_sync(aggregate)
+
+    async def _handle_cancel_signal(
+        self,
+        todo: TodoItem,
+        result: AgentExecutionResult,
+        aggregate: WorkflowExecutionAggregate,
+    ) -> None:
+        """Dispatch CancelExecutionCommand when the agent stream was interrupted by a cancel signal."""
+        cancel_cmd = CancelExecutionCommand(
+            execution_id=todo.execution_id,
+            phase_id=todo.phase_id,
+            reason=result.stream_result.interrupt_reason or "Cancelled by user",
+        )
+        aggregate._handle_command(cancel_cmd)
         await self._save_and_sync(aggregate)
 
     async def _handle_collect_artifacts(

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -15,6 +15,7 @@ from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects 
     PhaseResult,
 )
 from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    CancelExecutionCommand,
     CompleteExecutionCommand,
     CompletePhaseCommand,
     FailExecutionCommand,
@@ -434,6 +435,16 @@ class WorkflowExecutionProcessor:
             result.command.input_tokens,
             result.command.output_tokens,
         )
+
+        if result.stream_result.interrupt_requested:
+            cancel_cmd = CancelExecutionCommand(
+                execution_id=todo.execution_id,
+                phase_id=todo.phase_id,
+                reason=result.stream_result.interrupt_reason or "Cancelled by user",
+            )
+            aggregate._handle_command(cancel_cmd)
+            await self._save_and_sync(aggregate)
+            return
 
         if result.command.exit_code != 0:
             reason = result.stream_result.error_reason

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -11,6 +11,7 @@ from syn_domain.contexts.orchestration._shared.TodoValueObjects import TodoActio
 from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
     ExecutablePhase,
     ExecutionMetrics,
+    ExecutionStatus,
     PhaseDefinition,
     PhaseResult,
 )
@@ -181,6 +182,14 @@ class WorkflowExecutionProcessor:
                     phase_outputs=phase_outputs,
                     repos=repos,
                 )
+            if aggregate.status == ExecutionStatus.CANCELLED:
+                return await self._cancel_execution(
+                    execution_id,
+                    workflow_id,
+                    phase_results,
+                    all_artifact_ids,
+                    started_at,
+                )
             return await self._complete_execution(
                 aggregate,
                 execution_id,
@@ -244,6 +253,33 @@ class WorkflowExecutionProcessor:
                 phase_results,
                 completed_phase_ids,
             )
+
+    async def _cancel_execution(
+        self,
+        execution_id: str,
+        workflow_id: str,
+        phase_results: list[PhaseResult],
+        all_artifact_ids: list[str],
+        started_at: datetime,
+    ) -> WorkflowExecutionResult:
+        """Close open sessions as cancelled and return cancelled result.
+
+        Called when the to-do list empties due to ExecutionCancelledEvent.
+        The aggregate is already in CANCELLED status — no new command needed.
+        """
+        for _pid, mgr in list(self._session_managers.items()):
+            await mgr.complete_cancelled(reason="Cancelled by user")
+        self._session_managers.clear()
+        return WorkflowExecutionResult(
+            workflow_id=workflow_id,
+            execution_id=execution_id,
+            status="cancelled",
+            started_at=started_at,
+            completed_at=datetime.now(UTC),
+            phase_results=phase_results,
+            artifact_ids=all_artifact_ids,
+            metrics=ExecutionMetrics.from_results(phase_results),
+        )
 
     async def _complete_execution(
         self,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -462,6 +462,7 @@ class WorkflowExecutionProcessor:
         aggregate: WorkflowExecutionAggregate,
     ) -> None:
         """Dispatch CancelExecutionCommand when the agent stream was interrupted by a cancel signal."""
+        assert todo.phase_id is not None, "phase_id must be set for a running agent todo"
         cancel_cmd = CancelExecutionCommand(
             execution_id=todo.execution_id,
             phase_id=todo.phase_id,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
@@ -44,9 +44,12 @@ def _detect_exit_code(
     phase_id: str,
     tokens: TokenAccumulator,
 ) -> int:
-    """Determine agent exit code from stream result and workspace state."""
-    if stream_result.interrupt_requested:
-        return 1
+    """Determine agent exit code from stream result and workspace state.
+
+    Note: If interrupt_requested=True, the caller is responsible for routing
+    to the cancellation path. This function returns only the actual process
+    exit code.
+    """
     stream_exit_code = workspace.last_stream_exit_code
     if stream_exit_code is not None and stream_exit_code != 0:
         logger.error(

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_handlers.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_handlers.py
@@ -89,8 +89,13 @@ class TestAgentExecutionHandler:
         assert result.command.exit_code == 0
 
     @pytest.mark.anyio
-    async def test_interrupt_sets_exit_code_1(self) -> None:
-        """Interrupted execution sets exit_code to 1."""
+    async def test_interrupt_does_not_synthesise_exit_code_1(self) -> None:
+        """Interrupted execution must NOT synthesise exit_code=1.
+
+        The processor (_handle_run_agent) is responsible for routing interrupt_requested
+        to CancelExecutionCommand. _detect_exit_code must only return the actual process
+        exit code so the processor can make the cancellation vs failure decision cleanly.
+        """
         handler = AgentExecutionHandler(controller=None)
         workspace = MagicMock()
         workspace.last_stream_exit_code = 0
@@ -125,7 +130,9 @@ class TestAgentExecutionHandler:
                 timeout_seconds=300,
             )
 
-        assert result.command.exit_code == 1
+        assert result.command.exit_code == 0, (
+            "exit_code must reflect workspace state (0), not synthesise 1 for interrupt_requested"
+        )
         assert result.stream_result.interrupt_requested is True
 
     @pytest.mark.anyio
@@ -351,7 +358,12 @@ class TestHandlerRegistry:
 class TestDetectExitCode:
     """Tests for _detect_exit_code helper."""
 
-    def test_interrupt_returns_1(self) -> None:
+    def test_interrupt_does_not_return_1(self) -> None:
+        """interrupt_requested must NOT synthesise exit code 1.
+
+        The processor (_handle_cancel_signal) owns the cancellation routing.
+        _detect_exit_code must only return the actual process exit code.
+        """
         from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
             _detect_exit_code,
         )
@@ -366,7 +378,8 @@ class TestDetectExitCode:
             agent_task_result=None,
         )
         workspace = MagicMock()
-        assert _detect_exit_code(stream_result, workspace, "p-1", TokenAccumulator()) == 1
+        workspace.last_stream_exit_code = None
+        assert _detect_exit_code(stream_result, workspace, "p-1", TokenAccumulator()) == 0
 
     def test_nonzero_stream_exit_code(self) -> None:
         from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (

--- a/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_661_regression.py
+++ b/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_661_regression.py
@@ -1,0 +1,278 @@
+"""Regression tests for #661 platform bug fixes.
+
+Covers:
+- Item 1: syn control cancel sets status to 'cancelled' not 'failed'
+- Item 3: repos field applies {{variable}} substitution
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+    ExecutionStatus,
+    PhaseDefinition,
+)
+from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    CancelExecutionCommand,
+    StartExecutionCommand,
+    StartPhaseCommand,
+    WorkflowExecutionAggregate,
+)
+from syn_domain.contexts.orchestration.domain.events.ExecutionCancelledEvent import (
+    ExecutionCancelledEvent,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.ExecuteWorkflowHandler import (
+    ExecuteWorkflowHandler,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
+    _detect_exit_code,
+)
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _make_running_aggregate(execution_id: str = "exec-1") -> WorkflowExecutionAggregate:
+    """Create an aggregate in RUNNING state."""
+    agg = WorkflowExecutionAggregate()
+    agg._handle_command(
+        StartExecutionCommand(
+            execution_id=execution_id,
+            workflow_id="wf-1",
+            workflow_name="Test Workflow",
+            total_phases=1,
+            inputs={},
+            phase_definitions=[PhaseDefinition(phase_id="p-1", name="Phase 1", order=1)],
+        )
+    )
+    agg._handle_command(
+        StartPhaseCommand(
+            execution_id=execution_id,
+            workflow_id="wf-1",
+            phase_id="p-1",
+            phase_name="Phase 1",
+            phase_order=1,
+        )
+    )
+    return agg
+
+
+def _make_stream_result(interrupt_requested: bool = False, interrupt_reason: str | None = None):
+    """Create a minimal StreamResult mock."""
+    sr = MagicMock()
+    sr.interrupt_requested = interrupt_requested
+    sr.interrupt_reason = interrupt_reason
+    sr.line_count = 10
+    return sr
+
+
+def _make_workspace(last_stream_exit_code: int | None = None):
+    """Create a minimal ManagedWorkspace mock."""
+    ws = MagicMock()
+    ws.last_stream_exit_code = last_stream_exit_code
+    return ws
+
+
+def _make_tokens(input_tokens: int = 100, output_tokens: int = 200):
+    from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+        TokenAccumulator,
+    )
+
+    acc = TokenAccumulator()
+    acc.record(input_tokens=input_tokens, output_tokens=output_tokens)
+    return acc
+
+
+# ===========================================================================
+# Item 1: Cancel sets 'cancelled' not 'failed'
+# ===========================================================================
+
+
+class TestCancelExitCodeDetection:
+    """_detect_exit_code must NOT return 1 when interrupt_requested=True.
+
+    Previously it synthesised exit code 1, conflating cancellation with failure.
+    The processor now owns the decision; this function returns the actual process code.
+    """
+
+    def test_interrupt_requested_does_not_synthesise_exit_code_1(self):
+        """Exit code must reflect workspace state, not the interrupt flag."""
+        stream = _make_stream_result(interrupt_requested=True)
+        workspace = _make_workspace(last_stream_exit_code=None)
+        tokens = _make_tokens()
+
+        exit_code = _detect_exit_code(stream, workspace, "p-1", tokens)
+
+        # Must NOT be 1 (the old synthetic value)
+        assert exit_code == 0, (
+            "_detect_exit_code must not return 1 for interrupt_requested=True; "
+            "the caller handles cancellation routing"
+        )
+
+    def test_interrupt_with_nonzero_workspace_exit_returns_workspace_code(self):
+        """If process actually exited non-zero (e.g. 130 from SIGINT), return that."""
+        stream = _make_stream_result(interrupt_requested=True)
+        workspace = _make_workspace(last_stream_exit_code=130)
+        tokens = _make_tokens()
+
+        exit_code = _detect_exit_code(stream, workspace, "p-1", tokens)
+
+        assert exit_code == 130
+
+    def test_genuine_failure_returns_nonzero(self):
+        """Non-cancel failures with non-zero exit still return that code."""
+        stream = _make_stream_result(interrupt_requested=False)
+        workspace = _make_workspace(last_stream_exit_code=1)
+        tokens = _make_tokens()
+
+        exit_code = _detect_exit_code(stream, workspace, "p-1", tokens)
+
+        assert exit_code == 1
+
+    def test_clean_exit_returns_zero(self):
+        """Normal completion returns 0."""
+        stream = _make_stream_result(interrupt_requested=False)
+        workspace = _make_workspace(last_stream_exit_code=0)
+        tokens = _make_tokens()
+
+        exit_code = _detect_exit_code(stream, workspace, "p-1", tokens)
+
+        assert exit_code == 0
+
+
+class TestCancelExecutionAggregatePath:
+    """CancelExecutionCommand must emit ExecutionCancelledEvent and set status CANCELLED."""
+
+    def test_cancel_running_execution_sets_cancelled_status(self):
+        """Aggregate sets status to CANCELLED when CancelExecutionCommand is handled."""
+        agg = _make_running_aggregate()
+        assert agg._status == ExecutionStatus.RUNNING
+
+        agg._handle_command(
+            CancelExecutionCommand(
+                execution_id="exec-1",
+                phase_id="p-1",
+                reason="Cancelled by user",
+            )
+        )
+
+        assert agg._status == ExecutionStatus.CANCELLED
+
+    def test_cancel_emits_execution_cancelled_event(self):
+        """CancelExecutionCommand emits ExecutionCancelledEvent, not WorkflowFailedEvent."""
+        agg = _make_running_aggregate()
+        agg._handle_command(
+            CancelExecutionCommand(
+                execution_id="exec-1",
+                phase_id="p-1",
+                reason="Cancelled by user",
+            )
+        )
+
+        event_types = [type(e.event).__name__ for e in agg._uncommitted_events]
+        assert "ExecutionCancelledEvent" in event_types
+        assert "WorkflowFailedEvent" not in event_types
+
+    def test_cancel_event_carries_reason(self):
+        """Cancellation reason is preserved in the emitted event."""
+        agg = _make_running_aggregate()
+        agg._handle_command(
+            CancelExecutionCommand(
+                execution_id="exec-1",
+                phase_id="p-1",
+                reason="Cancelled by user",
+            )
+        )
+
+        cancelled_events = [
+            e.event for e in agg._uncommitted_events if isinstance(e.event, ExecutionCancelledEvent)
+        ]
+        assert len(cancelled_events) == 1
+        assert cancelled_events[0].reason == "Cancelled by user"
+
+
+# ===========================================================================
+# Item 3: repos field variable substitution
+# ===========================================================================
+
+
+def _make_workflow_with_repos(repos: list[str]) -> MagicMock:
+    """Mock WorkflowTemplateAggregate with a repos list."""
+    wf = MagicMock()
+    wf.repos = repos
+    wf._repository_url = None
+    wf.input_declarations = []
+    return wf
+
+
+class TestReposVariableSubstitution:
+    """ExecuteWorkflowHandler._resolve_repos must apply {{variable}} substitution."""
+
+    def test_variable_in_repos_resolves_with_input(self):
+        """{{owner}}/app + merged_inputs["owner"] = acme → full GitHub URL."""
+        wf = _make_workflow_with_repos(["{{owner}}/app"])
+        result = ExecuteWorkflowHandler._resolve_repos({"owner": "acme"}, wf)
+
+        assert result == ["https://github.com/acme/app"]
+
+    def test_variable_in_full_url_resolves(self):
+        """Full URL template resolves correctly."""
+        wf = _make_workflow_with_repos(["https://github.com/{{org}}/{{repo}}"])
+        result = ExecuteWorkflowHandler._resolve_repos({"org": "myorg", "repo": "myapp"}, wf)
+
+        assert result == ["https://github.com/myorg/myapp"]
+
+    def test_unresolved_placeholder_raises_value_error(self):
+        """Missing input for {{variable}} must raise ValueError, not silently fall back."""
+        wf = _make_workflow_with_repos(["{{owner}}/app"])
+
+        with pytest.raises(ValueError, match="Unresolved placeholders"):
+            ExecuteWorkflowHandler._resolve_repos({}, wf)
+
+    def test_unresolved_placeholder_error_names_the_variable(self):
+        """Error message must name the unresolved variable to aid debugging."""
+        wf = _make_workflow_with_repos(["{{repository}}/app"])
+
+        with pytest.raises(ValueError, match="repository"):
+            ExecuteWorkflowHandler._resolve_repos({}, wf)
+
+    def test_static_url_passes_through_unchanged(self):
+        """Static repos without {{}} are returned as-is (no normalisation change)."""
+        wf = _make_workflow_with_repos(["https://github.com/acme/app"])
+        result = ExecuteWorkflowHandler._resolve_repos({}, wf)
+
+        assert result == ["https://github.com/acme/app"]
+
+    def test_multiple_repos_all_resolved(self):
+        """All repos in the list get substitution applied."""
+        wf = _make_workflow_with_repos(["{{owner}}/app1", "{{owner}}/app2"])
+        result = ExecuteWorkflowHandler._resolve_repos({"owner": "acme"}, wf)
+
+        assert result == [
+            "https://github.com/acme/app1",
+            "https://github.com/acme/app2",
+        ]
+
+    def test_runtime_input_takes_precedence_over_workflow_repos(self):
+        """If merged_inputs contains 'repos' CSV, workflow.repos is ignored entirely."""
+        wf = _make_workflow_with_repos(["https://github.com/stored/repo"])
+        result = ExecuteWorkflowHandler._resolve_repos(
+            {"repos": "https://github.com/runtime/repo"}, wf
+        )
+
+        assert result == ["https://github.com/runtime/repo"]
+
+    def test_empty_repos_falls_through_to_repository_url(self):
+        """When workflow.repos is empty, falls back to repository_url (existing behaviour)."""
+        wf = MagicMock()
+        wf.repos = []
+        wf._repository_url = "https://github.com/acme/fallback"
+        wf.input_declarations = []
+
+        result = ExecuteWorkflowHandler._resolve_repos({}, wf)
+
+        assert result == ["https://github.com/acme/fallback"]


### PR DESCRIPTION
## Summary

Fixes four bugs surfaced during self-host onboarding testing (closes #661). One was already patched (JWT expiry); this PR covers the remaining three code fixes and one UI addition.

- **`syn control cancel` → `cancelled` status**: `AgentExecutionHandler._detect_exit_code` was synthesising exit code `1` for `interrupt_requested=True`, causing `WorkflowExecutionProcessor` to treat cancellation as failure and emit `WorkflowFailedEvent`. Fix: remove synthetic exit code; add `interrupt_requested` guard in the processor that dispatches `CancelExecutionCommand` → `ExecutionCancelledEvent`. Aggregate and projections were already correct — they were just never reached.

- **`syn workflow create` silently drops phases**: `create` never accepted a YAML file — it only registered metadata with a default "Initial Phase" placeholder. Adds `--from/-f <path>` flag that calls `resolvePackage()` on the provided path and includes `phases` + `input_declarations` in the POST body. Backward compatible — omitting `--from` preserves existing behaviour. Adds a tip hint when `--from` is not used.

- **`repos` field ignores `{{variable}}` substitution**: `ExecuteWorkflowHandler._resolve_repos` and `_get_preflight_repos` both returned `workflow.repos` verbatim. `{{repository}}` silently fell through to `example/repo`, producing a misleading "GitHub App not installed on repository: example/repo" error. Fix: apply substitution loop in both places; raise `ValueError` on unresolved placeholders.

- **Session page CLI-primary disclaimer**: Added a persistent informational blue banner below the session header to set correct expectations about CLI-first operation.

## Test plan

- [ ] 15 new regression tests in `test_661_regression.py` — all passing (`116 passed` full suite, no regressions)
- [ ] `ruff check` and `ruff format --check` clean across all Python changes
- [ ] TypeScript changes add no new type errors beyond pre-existing baseline
- [ ] Manually verify: `syn control cancel` on a running execution → status shows `cancelled` not `failed`
- [ ] Manually verify: `syn workflow create "Name" --from ./workflow.yaml` → phases registered, dashboard shows real phases
- [ ] Manually verify: workflow with `repos: ["{{repository}}"]` + `--input repository=org/repo` → execution uses correct repo, no `example/repo` error
- [ ] Manually verify: session detail page shows blue CLI disclaimer banner below header