### PR TITLE
test: AgentHandlerProtocol + FakeAgentExecutionHandler + processor smoke tests

### DIFF
--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -47,6 +47,7 @@ from syn_domain.contexts.orchestration.slices.execute_workflow.PhaseResultBuilde
     PhaseResultBuilder,
 )
 from syn_domain.contexts.orchestration.slices.execute_workflow.processor_types import (
+    AgentHandlerProtocol,
     ArtifactRepository,
     CommandBuilder,
     ExecutionRepository,
@@ -99,6 +100,7 @@ class WorkflowExecutionProcessor:
         prompt_builder: PromptBuilder,
         command_builder: CommandBuilder,
         todo_projection: TodoProjection | None = None,
+        agent_handler: AgentHandlerProtocol | None = None,
     ) -> None:
         self._execution_repo = execution_repository
         self._session_repo = session_repository
@@ -113,6 +115,7 @@ class WorkflowExecutionProcessor:
         self._command_builder = command_builder
         assert todo_projection is not None, "todo_projection is required"
         self._todo_projection: TodoProjection = todo_projection
+        self._agent_handler = agent_handler  # None → create fresh AgentExecutionHandler per call
         # Infrastructure state (not domain state — ephemeral)
         self._active_workspaces: dict[str, ManagedWorkspace] = {}
         self._active_workspace_cms: dict[str, AbstractAsyncContextManager[ManagedWorkspace]] = {}
@@ -464,7 +467,7 @@ class WorkflowExecutionProcessor:
             workspace_id=getattr(workspace, "id", None),
             agent_model=phase.agent_config.model,
         )
-        agent_handler = AgentExecutionHandler(controller=self._controller)
+        agent_handler = self._agent_handler or AgentExecutionHandler(controller=self._controller)
         result = await agent_handler.handle(
             todo=todo,
             workspace=workspace,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -447,6 +447,12 @@ class WorkflowExecutionProcessor:
         aggregate._handle_command(result.command)
         await self._save_and_sync(aggregate)
 
+    def _get_agent_handler(self) -> AgentHandlerProtocol:
+        """Return the injected handler, or create a fresh real one (default behaviour)."""
+        if self._agent_handler is not None:
+            return self._agent_handler
+        return AgentExecutionHandler(controller=self._controller)
+
     async def _handle_run_agent(
         self,
         todo: TodoItem,
@@ -458,34 +464,36 @@ class WorkflowExecutionProcessor:
         workspace = self._active_workspaces[todo.phase_id]
         agent_env = self._active_envs[todo.phase_id]
         claude_cmd = self._active_cmds[todo.phase_id]
+        session_id = todo.session_id or ""
+        workflow_id = aggregate.workflow_id or ""
+        timeout = phase.timeout_seconds or phase.agent_config.timeout_seconds
 
         collector = ObservabilityCollector(
             writer=self._observability_writer,
-            session_id=todo.session_id or "",
+            session_id=session_id,
             execution_id=todo.execution_id,
             phase_id=todo.phase_id,
             workspace_id=getattr(workspace, "id", None),
             agent_model=phase.agent_config.model,
         )
-        agent_handler = self._agent_handler or AgentExecutionHandler(controller=self._controller)
-        result = await agent_handler.handle(
+        result = await self._get_agent_handler().handle(
             todo=todo,
             workspace=workspace,
             agent_env=agent_env,
             claude_cmd=claude_cmd,
-            session_id=todo.session_id or "",
+            session_id=session_id,
             agent_model=phase.agent_config.model,
-            timeout_seconds=phase.timeout_seconds or phase.agent_config.timeout_seconds,
+            timeout_seconds=timeout,
             collector=collector,
         )
 
         recorder = ConversationRecorder(self._conversation_storage)
         await recorder.store(
-            session_id=todo.session_id or "",
+            session_id=session_id,
             lines=result.stream_result.conversation_lines,
             execution_id=todo.execution_id,
             phase_id=todo.phase_id,
-            workflow_id=aggregate.workflow_id or "",
+            workflow_id=workflow_id,
             model=phase.agent_config.model,
             input_tokens=result.tokens.input_tokens,
             output_tokens=result.tokens.output_tokens,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/processor_types.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/processor_types.py
@@ -15,6 +15,7 @@ from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects 
 if TYPE_CHECKING:
     from datetime import datetime
 
+    from syn_adapters.workspace_backends.service.managed_workspace import ManagedWorkspace
     from syn_domain.contexts.agent_sessions.domain.aggregate_session.AgentSessionAggregate import (
         AgentSessionAggregate,
     )
@@ -24,6 +25,12 @@ if TYPE_CHECKING:
     from syn_domain.contexts.orchestration._shared.TodoValueObjects import TodoItem
     from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
         WorkflowExecutionAggregate,
+    )
+    from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProcessor import (
+        ObservabilityCollector,
+    )
+    from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
+        AgentExecutionResult,
     )
 
 PromptBuilder = Callable[
@@ -58,6 +65,35 @@ class ArtifactRepository(Protocol):
 
     async def save(self, aggregate: ArtifactAggregate) -> None: ...
     async def get_by_id(self, aggregate_id: str) -> ArtifactAggregate | None: ...
+
+
+class AgentHandlerProtocol(Protocol):
+    """Structural Protocol for AgentExecutionHandler.
+
+    Defines the contract for running an agent phase. Any class that satisfies this
+    Protocol — including ``FakeAgentExecutionHandler`` in tests — will break pyright
+    if ``AgentExecutionHandler.handle()`` ever changes its signature, preventing silent
+    drift between the real handler and its test doubles.
+
+    Usage in tests::
+
+        processor = WorkflowExecutionProcessor(
+            ...
+            agent_handler=FakeAgentExecutionHandler.cancelled(),
+        )
+    """
+
+    async def handle(
+        self,
+        todo: TodoItem,
+        workspace: ManagedWorkspace,
+        agent_env: dict[str, str],
+        claude_cmd: list[str],
+        session_id: str,
+        agent_model: str,
+        timeout_seconds: int,
+        collector: ObservabilityCollector | None = None,
+    ) -> AgentExecutionResult: ...
 
 
 @dataclass(frozen=True)

--- a/packages/syn-domain/src/syn_domain/testing/__init__.py
+++ b/packages/syn-domain/src/syn_domain/testing/__init__.py
@@ -1,0 +1,2 @@
+# syn_domain.testing — test doubles distributed with the domain package.
+# Import these in your tests; never import from this subpackage in production code.

--- a/packages/syn-domain/src/syn_domain/testing/fake_agent_handler.py
+++ b/packages/syn-domain/src/syn_domain/testing/fake_agent_handler.py
@@ -1,0 +1,148 @@
+# ruff: noqa: ARG002  — Protocol implementation; unused params are required by the interface.
+"""Sync-safe test double for AgentExecutionHandler.
+
+The module-level type assertion at the bottom of this file ensures pyright verifies
+that ``FakeAgentExecutionHandler`` satisfies ``AgentHandlerProtocol``. If
+``AgentExecutionHandler.handle()`` ever changes its signature, the Protocol is updated,
+this module fails the type-check, and CI catches the drift — not a silent runtime bug.
+
+Usage::
+
+    from syn_domain.testing.fake_agent_handler import FakeAgentExecutionHandler
+
+    handler = FakeAgentExecutionHandler.cancelled()
+    processor = WorkflowExecutionProcessor(..., agent_handler=handler)
+    result = await processor.run(...)
+    assert result.status == "cancelled"
+    assert handler.call_count == 1
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+    AgentExecutionCompletedCommand,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProcessor import (
+    StreamResult,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
+    AgentExecutionResult,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.SubagentTracker import (
+    SubagentTracker,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.TokenAccumulator import (
+    TokenAccumulator,
+)
+
+if TYPE_CHECKING:
+    from syn_adapters.workspace_backends.service.managed_workspace import ManagedWorkspace
+    from syn_domain.contexts.orchestration._shared.TodoValueObjects import TodoItem
+    from syn_domain.contexts.orchestration.slices.execute_workflow.ObservabilityCollector import (
+        ObservabilityCollector,
+    )
+    from syn_domain.contexts.orchestration.slices.execute_workflow.processor_types import (
+        AgentHandlerProtocol,
+    )
+
+
+class FakeAgentExecutionHandler:
+    """Configurable, sync-safe test double for ``AgentExecutionHandler``.
+
+    Prefer the factory classmethods for readable test setup:
+
+    - ``FakeAgentExecutionHandler.cancelled()`` — simulates a user cancel signal
+    - ``FakeAgentExecutionHandler.success()`` — simulates clean completion
+    - ``FakeAgentExecutionHandler.failed(exit_code=1)`` — simulates agent failure
+
+    After running, inspect ``call_count`` or ``calls`` to assert how many phases
+    were attempted and which ``TodoItem`` each one received.
+    """
+
+    def __init__(
+        self,
+        *,
+        interrupt: bool = False,
+        exit_code: int = 0,
+    ) -> None:
+        self._interrupt = interrupt
+        self._exit_code = exit_code
+        self.calls: list[TodoItem] = []
+
+    # ------------------------------------------------------------------
+    # Protocol-required method
+    # ------------------------------------------------------------------
+
+    async def handle(
+        self,
+        todo: TodoItem,
+        workspace: ManagedWorkspace,
+        agent_env: dict[str, str],
+        claude_cmd: list[str],
+        session_id: str,
+        agent_model: str,
+        timeout_seconds: int,
+        collector: ObservabilityCollector | None = None,
+    ) -> AgentExecutionResult:
+        self.calls.append(todo)
+        stream_result = StreamResult(
+            line_count=0,
+            interrupt_requested=self._interrupt,
+            interrupt_reason="Cancelled by user" if self._interrupt else None,
+            agent_task_result=None,
+        )
+        command = AgentExecutionCompletedCommand(
+            execution_id=todo.execution_id,
+            phase_id=todo.phase_id or "",
+            session_id=session_id,
+            exit_code=self._exit_code,
+        )
+        return AgentExecutionResult(
+            stream_result=stream_result,
+            tokens=TokenAccumulator(),
+            subagents=SubagentTracker(),
+            command=command,
+        )
+
+    # ------------------------------------------------------------------
+    # Convenience properties
+    # ------------------------------------------------------------------
+
+    @property
+    def call_count(self) -> int:
+        """Number of times ``handle()`` has been invoked."""
+        return len(self.calls)
+
+    # ------------------------------------------------------------------
+    # Factory classmethods
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def cancelled(cls) -> FakeAgentExecutionHandler:
+        """Simulates a user-initiated cancel signal (``interrupt_requested=True``)."""
+        return cls(interrupt=True)
+
+    @classmethod
+    def success(cls) -> FakeAgentExecutionHandler:
+        """Simulates a clean agent completion (exit code 0)."""
+        return cls(interrupt=False, exit_code=0)
+
+    @classmethod
+    def failed(cls, exit_code: int = 1) -> FakeAgentExecutionHandler:
+        """Simulates an agent failure with the given non-zero exit code."""
+        return cls(interrupt=False, exit_code=exit_code)
+
+
+# ---------------------------------------------------------------------------
+# Structural type assertion
+# ---------------------------------------------------------------------------
+# pyright verifies FakeAgentExecutionHandler satisfies AgentHandlerProtocol here.
+# Any signature drift on the real AgentExecutionHandler.handle() will update the
+# Protocol definition, causing this line to fail type-checking — caught by CI before
+# a silent runtime mismatch reaches production.
+#
+# ``from __future__ import annotations`` makes the annotation a string, so
+# AgentHandlerProtocol does not need to be imported at runtime — TYPE_CHECKING only.
+_: AgentHandlerProtocol = FakeAgentExecutionHandler()

--- a/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_processor_smoke.py
+++ b/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_processor_smoke.py
@@ -91,6 +91,7 @@ class FakeArtifactRepository:
 # Shared builder
 # ---------------------------------------------------------------------------
 
+
 async def _noop_prompt_builder(
     phase: ExecutablePhase,
     execution_id: str,
@@ -189,9 +190,7 @@ class TestProcessorSmoke:
             execution_id="exec-smoke-fail-001",
         )
 
-        assert result.status == "failed", (
-            f"Expected 'failed' but got '{result.status}'."
-        )
+        assert result.status == "failed", f"Expected 'failed' but got '{result.status}'."
         assert fake.call_count == 1
 
     async def test_success_returns_completed(self) -> None:
@@ -207,7 +206,5 @@ class TestProcessorSmoke:
             execution_id="exec-smoke-success-001",
         )
 
-        assert result.status == "completed", (
-            f"Expected 'completed' but got '{result.status}'."
-        )
+        assert result.status == "completed", f"Expected 'completed' but got '{result.status}'."
         assert fake.call_count == 1

--- a/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_processor_smoke.py
+++ b/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_processor_smoke.py
@@ -1,0 +1,213 @@
+"""Processor-level smoke tests for WorkflowExecutionProcessor.run().
+
+These tests exercise the FULL run() loop — workspace provisioning, agent execution,
+projection sync, and todo-list drain — using only in-memory infrastructure. No Docker,
+no network, no real event store required.
+
+Why these tests matter
+----------------------
+The cancel-path bug fixed in #663 was caught by Copilot code review, not tests.
+``test_cancel_returns_cancelled`` would have caught it: when ``run()`` returns
+``status="failed"`` instead of ``"cancelled"``, the assertion fails immediately.
+
+Sync-safety
+-----------
+``FakeAgentExecutionHandler`` is checked against ``AgentHandlerProtocol`` at import
+time via a module-level type assertion. If ``AgentExecutionHandler.handle()`` changes
+its signature, pyright fails here on the next CI run — no silent drift.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from syn_adapters.projection_stores.memory_store import InMemoryProjectionStore
+from syn_adapters.workspace_backends.service import WorkspaceBackend, WorkspaceService
+from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+    AgentConfiguration,
+    ExecutablePhase,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.WorkflowExecutionProcessor import (
+    WorkflowExecutionProcessor,
+)
+from syn_domain.contexts.orchestration.slices.execution_todo.projection import (
+    ExecutionTodoProjection,
+)
+from syn_domain.testing.fake_agent_handler import FakeAgentExecutionHandler
+
+if TYPE_CHECKING:
+    from syn_domain.contexts.agent_sessions.domain.aggregate_session.AgentSessionAggregate import (
+        AgentSessionAggregate,
+    )
+    from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
+        WorkflowExecutionAggregate,
+    )
+
+
+# ---------------------------------------------------------------------------
+# In-memory fake repositories
+# ---------------------------------------------------------------------------
+
+
+class FakeExecutionRepository:
+    """Minimal in-memory execution repository for smoke tests.
+
+    Clears ``_uncommitted_events`` after save, mirroring what the real SDK
+    repository does — required for ``_save_and_sync`` to not re-process events
+    on subsequent saves.
+    """
+
+    def __init__(self) -> None:
+        self._aggregates: dict[str, WorkflowExecutionAggregate] = {}
+
+    async def save(self, aggregate: WorkflowExecutionAggregate) -> None:
+        self._aggregates[aggregate.id] = aggregate
+        aggregate._uncommitted_events.clear()
+
+    async def get_by_id(self, aggregate_id: str) -> WorkflowExecutionAggregate | None:
+        return self._aggregates.get(aggregate_id)
+
+
+class FakeSessionRepository:
+    """Minimal in-memory session repository (save-only) for smoke tests."""
+
+    async def save(self, aggregate: AgentSessionAggregate) -> None:
+        pass  # No-op — smoke tests don't assert on session state
+
+
+class FakeArtifactRepository:
+    """Minimal in-memory artifact repository for smoke tests."""
+
+    async def save(self, aggregate: object) -> None:
+        pass
+
+    async def get_by_id(self, aggregate_id: str) -> None:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Shared builder
+# ---------------------------------------------------------------------------
+
+async def _noop_prompt_builder(
+    phase: ExecutablePhase,
+    execution_id: str,
+    workflow_id: str,
+    repo_url: str | None,
+    phase_outputs: dict,
+    inputs: dict,
+) -> str:
+    return "smoke test prompt"
+
+
+def _noop_command_builder(phase: ExecutablePhase, prompt: str) -> list[str]:
+    return ["echo", "smoke-test-agent"]
+
+
+def _make_processor(agent_handler: FakeAgentExecutionHandler) -> WorkflowExecutionProcessor:
+    """Wire a WorkflowExecutionProcessor with all in-memory/fake dependencies."""
+    todo_store = InMemoryProjectionStore()
+    todo_projection = ExecutionTodoProjection(store=todo_store)
+
+    return WorkflowExecutionProcessor(
+        execution_repository=FakeExecutionRepository(),
+        session_repository=FakeSessionRepository(),
+        workspace_service=WorkspaceService.create(backend=WorkspaceBackend.MEMORY),
+        artifact_repository=FakeArtifactRepository(),
+        artifact_content_storage=None,
+        artifact_query=None,
+        conversation_storage=None,
+        observability_writer=None,
+        controller=None,
+        prompt_builder=_noop_prompt_builder,
+        command_builder=_noop_command_builder,
+        todo_projection=todo_projection,
+        agent_handler=agent_handler,
+    )
+
+
+def _one_phase_workflow() -> list[ExecutablePhase]:
+    return [
+        ExecutablePhase(
+            phase_id="phase-001",
+            name="Smoke Phase",
+            order=1,
+            description="Single phase for smoke testing",
+            agent_config=AgentConfiguration(),
+            prompt_template="do the thing",
+            output_artifact_type="text",
+            timeout_seconds=30,
+        )
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestProcessorSmoke:
+    """Full run() loop smoke tests — in-memory only, no Docker."""
+
+    async def test_cancel_returns_cancelled(self) -> None:
+        """Cancel signal must propagate through run() as status='cancelled'.
+
+        Regression guard for the bug caught in #663 Copilot review: when the
+        agent emits interrupt_requested=True, the processor was incorrectly
+        routing through _fail_execution(), returning status='failed'.
+        """
+        fake = FakeAgentExecutionHandler.cancelled()
+        processor = _make_processor(fake)
+
+        result = await processor.run(
+            workflow_id="wf-smoke-001",
+            workflow_name="Smoke Test Workflow",
+            phases=_one_phase_workflow(),
+            inputs={},
+            execution_id="exec-smoke-cancel-001",
+        )
+
+        assert result.status == "cancelled", (
+            f"Expected 'cancelled' but got '{result.status}'. "
+            "The cancel signal is being swallowed — check _handle_run_agent and _cancel_execution."
+        )
+        assert fake.call_count == 1, "Agent handler should have been reached exactly once"
+
+    async def test_failure_returns_failed(self) -> None:
+        """Non-zero exit code with no cancel signal must return status='failed'."""
+        fake = FakeAgentExecutionHandler.failed(exit_code=1)
+        processor = _make_processor(fake)
+
+        result = await processor.run(
+            workflow_id="wf-smoke-002",
+            workflow_name="Smoke Test Workflow",
+            phases=_one_phase_workflow(),
+            inputs={},
+            execution_id="exec-smoke-fail-001",
+        )
+
+        assert result.status == "failed", (
+            f"Expected 'failed' but got '{result.status}'."
+        )
+        assert fake.call_count == 1
+
+    async def test_success_returns_completed(self) -> None:
+        """Clean exit code 0 must return status='completed'."""
+        fake = FakeAgentExecutionHandler.success()
+        processor = _make_processor(fake)
+
+        result = await processor.run(
+            workflow_id="wf-smoke-003",
+            workflow_name="Smoke Test Workflow",
+            phases=_one_phase_workflow(),
+            inputs={},
+            execution_id="exec-smoke-success-001",
+        )
+
+        assert result.status == "completed", (
+            f"Expected 'completed' but got '{result.status}'."
+        )
+        assert fake.call_count == 1


### PR DESCRIPTION
## Summary

- Adds `AgentHandlerProtocol` to `processor_types.py` — a structural Protocol that pyright enforces at import time via a module-level type assertion in the fake. Any signature change to `AgentExecutionHandler.handle()` breaks CI before it can silently drift.
- Injects `agent_handler: AgentHandlerProtocol | None = None` into `WorkflowExecutionProcessor.__init__` — production callers pass nothing (existing behaviour unchanged), tests inject a fake.
- Adds `syn_domain.testing` subpackage with `FakeAgentExecutionHandler`:
  - Factory classmethods: `.cancelled()`, `.success()`, `.failed(exit_code=1)`
  - `call_count` / `calls` for post-run assertions
- Adds three `@pytest.mark.unit` smoke tests exercising the full `run()` loop with all in-memory/fake infrastructure (no Docker, no network):
  - `test_cancel_returns_cancelled` — regression guard for the cancel→failed bug caught in #663 Copilot review
  - `test_failure_returns_failed` — non-zero exit with no cancel signal
  - `test_success_returns_completed` — clean exit code 0

## Test plan

- [ ] `uv run pytest packages/syn-domain/tests/contexts/workflows/execute_workflow/test_processor_smoke.py -v` — 3 passed
- [ ] CI green