### PR TITLE
fix(D1): add exception logging for background tasks

### DIFF
--- a/apps/syn-api/src/syn_api/services/lifecycle.py
+++ b/apps/syn-api/src/syn_api/services/lifecycle.py
@@ -43,6 +43,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _handle_recovery_task_exception(task: asyncio.Task[None]) -> None:
+    """Log exceptions from the lifecycle recovery background task."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error("Lifecycle recovery task crashed: %s", exc, exc_info=exc)
+
+
 class DegradedReason(StrEnum):
     """Reasons the API may enter degraded mode.
 
@@ -126,10 +135,12 @@ async def _init_degradable_services(state: LifecycleState) -> None:
     # Spawn a background recovery loop for any recoverable degradations.
     recoverable = [r for r in state.degraded_reasons if _is_recoverable(r)]
     if recoverable:
-        state._recovery_task = asyncio.create_task(
+        task = asyncio.create_task(
             _recovery_loop(state),
             name="lifecycle-recovery",
         )
+        task.add_done_callback(_handle_recovery_task_exception)
+        state._recovery_task = task
 
 
 async def startup(

--- a/apps/syn-api/src/syn_api/services/lifecycle.py
+++ b/apps/syn-api/src/syn_api/services/lifecycle.py
@@ -49,7 +49,11 @@ def _handle_recovery_task_exception(task: asyncio.Task[None]) -> None:
         return
     exc = task.exception()
     if exc is not None:
-        logger.error("Lifecycle recovery task crashed: %s", exc, exc_info=exc)
+        logger.error(
+            "Lifecycle recovery task crashed: %s",
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
 
 
 class DegradedReason(StrEnum):

--- a/packages/syn-adapters/src/syn_adapters/dedup/postgres_dedup.py
+++ b/packages/syn-adapters/src/syn_adapters/dedup/postgres_dedup.py
@@ -101,10 +101,21 @@ class PostgresDedupAdapter:
         # Run initial cleanup and start periodic cleanup
         await self._cleanup_expired()
         if self._cleanup_task is None:
-            self._cleanup_task = asyncio.create_task(
+            task = asyncio.create_task(
                 self._periodic_cleanup(),
                 name="dedup-key-cleanup",
             )
+            task.add_done_callback(self._handle_cleanup_exception)
+            self._cleanup_task = task
+
+    @staticmethod
+    def _handle_cleanup_exception(task: asyncio.Task[None]) -> None:
+        """Log exceptions from the periodic cleanup background task."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("Dedup cleanup task crashed: %s", exc, exc_info=exc)
 
     async def is_duplicate(self, dedup_key: str) -> bool:
         """Return ``True`` if this key was already seen (duplicate).

--- a/packages/syn-adapters/src/syn_adapters/dedup/postgres_dedup.py
+++ b/packages/syn-adapters/src/syn_adapters/dedup/postgres_dedup.py
@@ -115,7 +115,11 @@ class PostgresDedupAdapter:
             return
         exc = task.exception()
         if exc is not None:
-            logger.error("Dedup cleanup task crashed: %s", exc, exc_info=exc)
+            logger.error(
+                "Dedup cleanup task crashed: %s",
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     async def is_duplicate(self, dedup_key: str) -> bool:
         """Return ``True`` if this key was already seen (duplicate).

--- a/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/list_sessions/projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/list_sessions/projection.py
@@ -5,6 +5,7 @@ Uses CheckpointedProjection (ADR-014) for reliable position tracking.
 
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
@@ -17,6 +18,8 @@ from event_sourcing import AutoDispatchProjection
 from syn_domain.contexts.agent_sessions.domain.read_models.session_summary import (
     SessionSummary,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _calculate_duration(
@@ -318,5 +321,5 @@ class SessionListProjection(AutoDispatchProjection):
                     await self._store.save(self.PROJECTION_NAME, session.id, data)
                     count += 1
             except Exception:
-                pass
+                logger.exception("Failed to reconcile session %s", session.id)
         return count

--- a/packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/debouncer.py
+++ b/packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/debouncer.py
@@ -55,7 +55,18 @@ class TriggerDebouncer:
             except asyncio.CancelledError:
                 pass
 
-        self._pending[key] = asyncio.create_task(_fire())
+        task = asyncio.create_task(_fire())
+        task.add_done_callback(self._handle_task_exception)
+        self._pending[key] = task
+
+    @staticmethod
+    def _handle_task_exception(task: asyncio.Task[None]) -> None:
+        """Log exceptions from fire-and-forget debounce tasks."""
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error("Debounce task failed: %s", exc, exc_info=exc)
 
     @property
     def pending_count(self) -> int:

--- a/packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/debouncer.py
+++ b/packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/debouncer.py
@@ -49,7 +49,9 @@ class TriggerDebouncer:
         async def _fire() -> None:
             try:
                 await asyncio.sleep(delay_seconds)
-                del self._pending[key]
+                # Only remove our own entry; a newer debounce may have replaced it
+                if self._pending.get(key) is task:
+                    del self._pending[key]
                 await callback()
                 logger.info(f"Debounce timer fired for {key}")
             except asyncio.CancelledError:
@@ -66,7 +68,11 @@ class TriggerDebouncer:
             return
         exc = task.exception()
         if exc is not None:
-            logger.error("Debounce task failed: %s", exc, exc_info=exc)
+            logger.error(
+                "Debounce task failed: %s",
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )
 
     @property
     def pending_count(self) -> int:


### PR DESCRIPTION
## Summary
- **D1a**: Replace bare `except Exception: pass` in `reconcile_running_sessions()` with `logger.exception()` - sessions that fail reconciliation were silently ignored
- **D1b**: Add done callback to debouncer fire-and-forget tasks - if the debounce callback crashed, nobody knew
- **D1c**: Add done callback to lifecycle recovery background task - recovery loop crash was invisible
- **D1d**: Add done callback to Postgres dedup periodic cleanup task - cleanup crash was invisible

Part of the restart safety audit (Phases C-E). Error handling quick wins from [14-deep-audit-findings.md](docs/audits/20260413_restart-safety-audit/14-deep-audit-findings.md).

## Test plan
- [x] syn-domain unit tests pass (83/83)
- [ ] CI green
- [ ] Verify logging output in dev stack for each callback