### PR TITLE
fix(E): hygiene - pagination, TTL alignment, durable SHAs, bounded dicts

### DIFF
--- a/apps/syn-api/src/syn_api/_wiring.py
+++ b/apps/syn-api/src/syn_api/_wiring.py
@@ -389,8 +389,9 @@ def _create_dedup_adapter() -> DedupPort:
             if pool is not None:
                 from syn_adapters.dedup.postgres_dedup import PostgresDedupAdapter
 
+                ttl_days = max(1, settings.polling.dedup_ttl_seconds // 86400)
                 logger.info("EventPipeline using Postgres dedup (ADR-060)")
-                return PostgresDedupAdapter(pool)  # type: ignore[arg-type]  # asyncpg.Pool vs AsyncConnectionPool
+                return PostgresDedupAdapter(pool, ttl_days=ttl_days)  # type: ignore[arg-type]  # asyncpg.Pool vs AsyncConnectionPool
         except Exception:
             logger.warning(
                 "Postgres dedup unavailable — falling back to Redis",
@@ -447,16 +448,40 @@ _pending_sha_store_singleton: object | None = None
 
 def get_pending_sha_store() -> PendingSHAStore:
     """Return the singleton PendingSHAStore for check-run polling."""
-    from syn_adapters.github.pending_sha_store import InMemoryPendingSHAStore
-
     global _pending_sha_store_singleton
     if _pending_sha_store_singleton is not None:
-        assert isinstance(_pending_sha_store_singleton, InMemoryPendingSHAStore)
-        return _pending_sha_store_singleton
+        return _pending_sha_store_singleton  # type: ignore[return-value]
 
-    store = InMemoryPendingSHAStore()
-    _pending_sha_store_singleton = store
-    return store
+    from syn_shared.settings import get_settings
+
+    settings = get_settings()
+
+    # Prefer Postgres for restart durability
+    if not settings.uses_in_memory_stores and settings.syn_observability_db_url:
+        try:
+            from syn_api._wiring_db import get_shared_db_pool
+
+            pool = get_shared_db_pool()
+            if pool is not None:
+                from syn_adapters.github.postgres_pending_sha_store import (
+                    PostgresPendingSHAStore,
+                )
+
+                store: PendingSHAStore = PostgresPendingSHAStore(pool)  # type: ignore[arg-type]  # asyncpg.Pool vs AsyncConnectionPool
+                _pending_sha_store_singleton = store
+                logger.info("PendingSHAStore using Postgres (restart-durable)")
+                return store
+        except Exception:
+            logger.warning(
+                "Postgres PendingSHAStore unavailable, falling back to in-memory",
+                exc_info=True,
+            )
+
+    from syn_adapters.github.pending_sha_store import InMemoryPendingSHAStore
+
+    mem_store: PendingSHAStore = InMemoryPendingSHAStore()
+    _pending_sha_store_singleton = mem_store
+    return mem_store
 
 
 async def sync_published_events_to_projections() -> None:

--- a/apps/syn-api/src/syn_api/_wiring.py
+++ b/apps/syn-api/src/syn_api/_wiring.py
@@ -389,7 +389,7 @@ def _create_dedup_adapter() -> DedupPort:
             if pool is not None:
                 from syn_adapters.dedup.postgres_dedup import PostgresDedupAdapter
 
-                ttl_days = max(1, settings.polling.dedup_ttl_seconds // 86400)
+                ttl_days = max(1, -(-settings.polling.dedup_ttl_seconds // 86400))
                 logger.info("EventPipeline using Postgres dedup (ADR-060)")
                 return PostgresDedupAdapter(pool, ttl_days=ttl_days)  # type: ignore[arg-type]  # asyncpg.Pool vs AsyncConnectionPool
         except Exception:

--- a/apps/syn-api/src/syn_api/routes/webhooks/signature.py
+++ b/apps/syn-api/src/syn_api/routes/webhooks/signature.py
@@ -21,8 +21,15 @@ _WINDOW_SECONDS = 60
 _sig_failures: dict[str, list[float]] = defaultdict(list)
 
 
+_MAX_TRACKED_IPS = 10_000
+
+
 def _check_sig_rate_limit(client_ip: str) -> None:
     """Raise 429 if this IP has too many recent signature failures."""
+    if len(_sig_failures) > _MAX_TRACKED_IPS:
+        _sig_failures.clear()
+        logger.warning("Signature failure tracker reset (exceeded %d unique IPs)", _MAX_TRACKED_IPS)
+
     now = time.monotonic()
     attempts = _sig_failures[client_ip]
     _sig_failures[client_ip] = [t for t in attempts if now - t < _WINDOW_SECONDS]

--- a/apps/syn-api/src/syn_api/routes/webhooks/signature.py
+++ b/apps/syn-api/src/syn_api/routes/webhooks/signature.py
@@ -6,7 +6,6 @@ import hashlib
 import hmac
 import logging
 import time
-from collections import defaultdict
 
 from fastapi import HTTPException
 
@@ -18,30 +17,49 @@ logger = logging.getLogger(__name__)
 # --- Signature-failure rate limiter ---
 _MAX_FAILURES = 5
 _WINDOW_SECONDS = 60
-_sig_failures: dict[str, list[float]] = defaultdict(list)
-
+_sig_failures: dict[str, list[float]] = {}
 
 _MAX_TRACKED_IPS = 10_000
 
 
+def _evict_stale_sig_failures() -> None:
+    """Prune stale entries to prevent unbounded growth."""
+    if len(_sig_failures) <= _MAX_TRACKED_IPS:
+        return
+    now = time.monotonic()
+    stale = [
+        ip
+        for ip, attempts in _sig_failures.items()
+        if not any(now - t < _WINDOW_SECONDS for t in attempts)
+    ]
+    for ip in stale:
+        del _sig_failures[ip]
+    if stale:
+        logger.info("Pruned %d stale signature failure entries", len(stale))
+
+
 def _check_sig_rate_limit(client_ip: str) -> None:
     """Raise 429 if this IP has too many recent signature failures."""
-    if len(_sig_failures) > _MAX_TRACKED_IPS:
-        _sig_failures.clear()
-        logger.warning("Signature failure tracker reset (exceeded %d unique IPs)", _MAX_TRACKED_IPS)
-
+    _evict_stale_sig_failures()
     now = time.monotonic()
-    attempts = _sig_failures[client_ip]
-    _sig_failures[client_ip] = [t for t in attempts if now - t < _WINDOW_SECONDS]
-    if len(_sig_failures[client_ip]) >= _MAX_FAILURES:
-        logger.warning(
-            "Webhook rate limit: %s blocked (%d failures)", client_ip, len(_sig_failures[client_ip])
-        )
+    attempts = _sig_failures.get(client_ip)
+    if attempts is None:
+        return
+    # Prune old attempts
+    recent = [t for t in attempts if now - t < _WINDOW_SECONDS]
+    if not recent:
+        del _sig_failures[client_ip]
+        return
+    _sig_failures[client_ip] = recent
+    if len(recent) >= _MAX_FAILURES:
+        logger.warning("Webhook rate limit: %s blocked (%d failures)", client_ip, len(recent))
         raise HTTPException(status_code=429, detail="Too many failed signature attempts")
 
 
 def _record_sig_failure(client_ip: str) -> None:
     """Record a signature verification failure for rate limiting."""
+    if client_ip not in _sig_failures:
+        _sig_failures[client_ip] = []
     _sig_failures[client_ip].append(time.monotonic())
 
 

--- a/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
+++ b/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Type alias for raw GitHub event payloads (heterogeneous JSON from Events API).
+GitHubEventPayload = dict[str, Any]
+
 
 class PollerCursorStore(Protocol):
     """Protocol for persisting poller ETag/cursor state across restarts."""
@@ -31,7 +34,7 @@ class PollerCursorStore(Protocol):
 class EventsAPIResponse:
     """Response from a single Events API poll."""
 
-    events: list[dict[str, Any]]
+    events: list[GitHubEventPayload]
     poll_interval: int
     """``X-Poll-Interval`` header value (seconds). GitHub recommends this as
     the minimum interval between requests."""
@@ -130,7 +133,7 @@ class GitHubEventsAPIClient:
             self._etags[etag_key] = etag
 
         data = response.json()
-        events: list[dict[str, Any]] = data if isinstance(data, list) else []
+        events: list[GitHubEventPayload] = data if isinstance(data, list) else []
 
         # Fetch remaining pages (GitHub returns max 30/page, up to 10 pages)
         auth_header = response.request.headers.get("Authorization", "")
@@ -152,9 +155,9 @@ class GitHubEventsAPIClient:
         link_header: str,
         auth_header: str,
         etag_key: str,
-    ) -> list[dict[str, Any]]:
+    ) -> list[GitHubEventPayload]:
         """Follow pagination links to collect all events."""
-        extra_events: list[dict[str, Any]] = []
+        extra_events: list[GitHubEventPayload] = []
         next_url = _parse_next_link(link_header)
         pages_fetched = 1
         while next_url and pages_fetched < _MAX_PAGES:
@@ -186,7 +189,7 @@ class GitHubEventsAPIClient:
                 break
         return extra_events
 
-    async def _persist_cursor(self, etag_key: str, etag: str, events: list[dict[str, Any]]) -> None:
+    async def _persist_cursor(self, etag_key: str, etag: str, events: list[GitHubEventPayload]) -> None:
         """Persist ETag cursor for restart safety (ADR-060)."""
         if not etag or self._cursor_store is None:
             return

--- a/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
+++ b/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
@@ -179,9 +179,7 @@ class GitHubEventsAPIClient:
     ) -> tuple[list[GitHubEventPayload] | None, str | None]:
         """Fetch a single pagination page. Returns (events, next_url) or (None, None) on failure."""
         try:
-            resp = await self._client._http.get(
-                url, headers={"Authorization": auth_header}
-            )
+            resp = await self._client._http.get(url, headers={"Authorization": auth_header})
             if resp.status_code != 200:
                 logger.warning(
                     "Events API pagination stopped: page %d returned %d for %s",
@@ -203,7 +201,9 @@ class GitHubEventsAPIClient:
             )
             return None, None
 
-    async def _persist_cursor(self, etag_key: str, etag: str, events: list[GitHubEventPayload]) -> None:
+    async def _persist_cursor(
+        self, etag_key: str, etag: str, events: list[GitHubEventPayload]
+    ) -> None:
         """Persist ETag cursor for restart safety (ADR-060)."""
         if not etag or self._cursor_store is None:
             return

--- a/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
+++ b/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
@@ -161,33 +161,47 @@ class GitHubEventsAPIClient:
         next_url = _parse_next_link(link_header)
         pages_fetched = 1
         while next_url and pages_fetched < _MAX_PAGES:
-            try:
-                resp = await self._client._http.get(
-                    next_url, headers={"Authorization": auth_header}
-                )
-                if resp.status_code != 200:
-                    logger.warning(
-                        "Events API pagination stopped: page %d returned %d for %s",
-                        pages_fetched + 1,
-                        resp.status_code,
-                        etag_key,
-                    )
-                    break
-                page_data = resp.json()
-                if not isinstance(page_data, list) or not page_data:
-                    break
-                extra_events.extend(page_data)
-                next_url = _parse_next_link(resp.headers.get("Link", ""))
-                pages_fetched += 1
-            except Exception:
-                logger.warning(
-                    "Failed to fetch events page %d for %s",
-                    pages_fetched + 1,
-                    etag_key,
-                    exc_info=True,
-                )
+            page_events, next_url = await self._fetch_single_page(
+                next_url, auth_header, etag_key, pages_fetched + 1
+            )
+            if page_events is None:
                 break
+            extra_events.extend(page_events)
+            pages_fetched += 1
         return extra_events
+
+    async def _fetch_single_page(
+        self,
+        url: str,
+        auth_header: str,
+        etag_key: str,
+        page_number: int,
+    ) -> tuple[list[GitHubEventPayload] | None, str | None]:
+        """Fetch a single pagination page. Returns (events, next_url) or (None, None) on failure."""
+        try:
+            resp = await self._client._http.get(
+                url, headers={"Authorization": auth_header}
+            )
+            if resp.status_code != 200:
+                logger.warning(
+                    "Events API pagination stopped: page %d returned %d for %s",
+                    page_number,
+                    resp.status_code,
+                    etag_key,
+                )
+                return None, None
+            page_data = resp.json()
+            if not isinstance(page_data, list) or not page_data:
+                return None, None
+            return page_data, _parse_next_link(resp.headers.get("Link", ""))
+        except Exception:
+            logger.warning(
+                "Failed to fetch events page %d for %s",
+                page_number,
+                etag_key,
+                exc_info=True,
+            )
+            return None, None
 
     async def _persist_cursor(self, etag_key: str, etag: str, events: list[GitHubEventPayload]) -> None:
         """Persist ETag cursor for restart safety (ADR-060)."""

--- a/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
+++ b/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
@@ -132,22 +132,43 @@ class GitHubEventsAPIClient:
         data = response.json()
         events: list[dict[str, Any]] = data if isinstance(data, list) else []
 
-        # Fetch additional pages (GitHub returns max 30/page, up to 10 pages)
-        next_url = _parse_next_link(response.headers.get("Link", ""))
+        # Fetch remaining pages (GitHub returns max 30/page, up to 10 pages)
+        auth_header = response.request.headers.get("Authorization", "")
+        link_header = response.headers.get("Link", "")
+        extra = await self._fetch_remaining_pages(link_header, auth_header, etag_key)
+        events.extend(extra)
+
+        # Persist cursor for restart safety (ADR-060)
+        await self._persist_cursor(etag_key, etag, events)
+
+        return EventsAPIResponse(
+            events=events,
+            poll_interval=poll_interval,
+            has_new_events=bool(events),
+        )
+
+    async def _fetch_remaining_pages(
+        self,
+        link_header: str,
+        auth_header: str,
+        etag_key: str,
+    ) -> list[dict[str, Any]]:
+        """Follow pagination links to collect all events."""
+        extra_events: list[dict[str, Any]] = []
+        next_url = _parse_next_link(link_header)
         pages_fetched = 1
         while next_url and pages_fetched < _MAX_PAGES:
             try:
-                next_resp = await self._client._http.get(
-                    next_url,
-                    headers={"Authorization": response.request.headers.get("Authorization", "")},
+                resp = await self._client._http.get(
+                    next_url, headers={"Authorization": auth_header}
                 )
-                if next_resp.status_code != 200:
+                if resp.status_code != 200:
                     break
-                page_data = next_resp.json()
+                page_data = resp.json()
                 if not isinstance(page_data, list) or not page_data:
                     break
-                events.extend(page_data)
-                next_url = _parse_next_link(next_resp.headers.get("Link", ""))
+                extra_events.extend(page_data)
+                next_url = _parse_next_link(resp.headers.get("Link", ""))
                 pages_fetched += 1
             except Exception:
                 logger.warning(
@@ -157,20 +178,17 @@ class GitHubEventsAPIClient:
                     exc_info=True,
                 )
                 break
+        return extra_events
 
-        # Persist cursor for restart safety (ADR-060)
-        if etag and self._cursor_store is not None:
-            newest_id = str(events[0].get("id", "")) if events else ""
-            try:
-                await self._cursor_store.save_cursor(etag_key, etag, newest_id)
-            except Exception:
-                logger.warning("Failed to persist poller cursor for %s", etag_key, exc_info=True)
-
-        return EventsAPIResponse(
-            events=events,
-            poll_interval=poll_interval,
-            has_new_events=bool(events),
-        )
+    async def _persist_cursor(self, etag_key: str, etag: str, events: list[dict[str, Any]]) -> None:
+        """Persist ETag cursor for restart safety (ADR-060)."""
+        if not etag or self._cursor_store is None:
+            return
+        newest_id = str(events[0].get("id", "")) if events else ""
+        try:
+            await self._cursor_store.save_cursor(etag_key, etag, newest_id)
+        except Exception:
+            logger.warning("Failed to persist poller cursor for %s", etag_key, exc_info=True)
 
     async def _load_persisted_cursors(self) -> None:
         """Load ETags from persistent store on first call (ADR-060)."""

--- a/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
+++ b/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
@@ -6,6 +6,7 @@ See ADR-060: Restart-safe trigger deduplication (persistent cursor support).
 from __future__ import annotations
 
 import logging
+import re as _re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -36,6 +37,21 @@ class EventsAPIResponse:
     the minimum interval between requests."""
     has_new_events: bool
     """``False`` when GitHub returned 304 Not Modified."""
+
+
+def _parse_next_link(link_header: str) -> str | None:
+    """Extract the 'next' URL from a GitHub Link header."""
+    if not link_header:
+        return None
+    for part in link_header.split(","):
+        if 'rel="next"' in part:
+            match = _re.search(r"<([^>]+)>", part)
+            if match:
+                return match.group(1)
+    return None
+
+
+_MAX_PAGES = 10
 
 
 class GitHubEventsAPIClient:
@@ -115,6 +131,32 @@ class GitHubEventsAPIClient:
 
         data = response.json()
         events: list[dict[str, Any]] = data if isinstance(data, list) else []
+
+        # Fetch additional pages (GitHub returns max 30/page, up to 10 pages)
+        next_url = _parse_next_link(response.headers.get("Link", ""))
+        pages_fetched = 1
+        while next_url and pages_fetched < _MAX_PAGES:
+            try:
+                next_resp = await self._client._http.get(
+                    next_url,
+                    headers={"Authorization": response.request.headers.get("Authorization", "")},
+                )
+                if next_resp.status_code != 200:
+                    break
+                page_data = next_resp.json()
+                if not isinstance(page_data, list) or not page_data:
+                    break
+                events.extend(page_data)
+                next_url = _parse_next_link(next_resp.headers.get("Link", ""))
+                pages_fetched += 1
+            except Exception:
+                logger.warning(
+                    "Failed to fetch events page %d for %s",
+                    pages_fetched + 1,
+                    etag_key,
+                    exc_info=True,
+                )
+                break
 
         # Persist cursor for restart safety (ADR-060)
         if etag and self._cursor_store is not None:

--- a/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
+++ b/packages/syn-adapters/src/syn_adapters/github/events_api_client.py
@@ -163,6 +163,12 @@ class GitHubEventsAPIClient:
                     next_url, headers={"Authorization": auth_header}
                 )
                 if resp.status_code != 200:
+                    logger.warning(
+                        "Events API pagination stopped: page %d returned %d for %s",
+                        pages_fetched + 1,
+                        resp.status_code,
+                        etag_key,
+                    )
                     break
                 page_data = resp.json()
                 if not isinstance(page_data, list) or not page_data:

--- a/packages/syn-adapters/src/syn_adapters/github/postgres_pending_sha_store.py
+++ b/packages/syn-adapters/src/syn_adapters/github/postgres_pending_sha_store.py
@@ -1,0 +1,134 @@
+"""Postgres-backed PendingSHAStore for check-run polling (#602).
+
+Persists pending SHAs across restarts so check-run polling resumes
+immediately without waiting for the next PR event.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+from syn_domain.contexts.github.slices.event_pipeline.pending_sha_port import PendingSHA
+
+logger = logging.getLogger(__name__)
+
+
+class _Row(Protocol):
+    """Protocol for database row objects (asyncpg Record compatible)."""
+
+    def __getitem__(self, key: str) -> object: ...
+
+
+@runtime_checkable
+class AsyncConnection(Protocol):
+    """Protocol for async database connections (asyncpg-compatible)."""
+
+    async def execute(self, query: str, *args: object) -> str: ...
+    async def fetch(self, query: str, *args: object) -> list[_Row]: ...
+
+
+@runtime_checkable
+class AsyncConnectionPool(Protocol):
+    """Protocol for async connection pools (asyncpg-compatible)."""
+
+    @asynccontextmanager
+    def acquire(self) -> AsyncIterator[AsyncConnection]: ...
+
+
+_CREATE_TABLE_SQL = """
+    CREATE TABLE IF NOT EXISTS pending_shas (
+        repository TEXT NOT NULL,
+        sha TEXT NOT NULL,
+        pr_number INTEGER NOT NULL,
+        branch TEXT NOT NULL,
+        installation_id TEXT NOT NULL,
+        registered_at TIMESTAMPTZ NOT NULL,
+        PRIMARY KEY (repository, sha)
+    );
+"""
+
+_REGISTER_SQL = """
+    INSERT INTO pending_shas (repository, sha, pr_number, branch, installation_id, registered_at)
+    VALUES ($1, $2, $3, $4, $5, $6)
+    ON CONFLICT (repository, sha) DO NOTHING;
+"""
+
+_LIST_SQL = (
+    "SELECT repository, sha, pr_number, branch, installation_id, registered_at FROM pending_shas;"
+)
+
+_REMOVE_SQL = "DELETE FROM pending_shas WHERE repository = $1 AND sha = $2;"
+
+_CLEANUP_SQL = "DELETE FROM pending_shas WHERE registered_at < $1;"
+
+
+class PostgresPendingSHAStore:
+    """Postgres-backed PendingSHAStore - survives restarts.
+
+    Implements :class:`~syn_domain.contexts.github.slices.event_pipeline.pending_sha_port.PendingSHAStore`.
+    """
+
+    def __init__(self, pool: AsyncConnectionPool) -> None:
+        self._pool = pool
+        self._table_created = False
+
+    async def _ensure_table(self) -> None:
+        if self._table_created:
+            return
+        async with self._pool.acquire() as conn:
+            await conn.execute(_CREATE_TABLE_SQL)
+            self._table_created = True
+            logger.info("Ensured pending_shas table exists")
+
+    async def register(self, pending: PendingSHA) -> None:
+        """Register a SHA for check-run polling. No-op if already registered."""
+        await self._ensure_table()
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                _REGISTER_SQL,
+                pending.repository,
+                pending.sha,
+                pending.pr_number,
+                pending.branch,
+                pending.installation_id,
+                pending.registered_at,
+            )
+
+    async def list_pending(self) -> list[PendingSHA]:
+        """Return all pending SHAs."""
+        await self._ensure_table()
+        async with self._pool.acquire() as conn:
+            rows = await conn.fetch(_LIST_SQL)
+            return [
+                PendingSHA(
+                    repository=row["repository"],  # type: ignore[arg-type]
+                    sha=row["sha"],  # type: ignore[arg-type]
+                    pr_number=row["pr_number"],  # type: ignore[arg-type]
+                    branch=row["branch"],  # type: ignore[arg-type]
+                    installation_id=row["installation_id"],  # type: ignore[arg-type]
+                    registered_at=row["registered_at"],  # type: ignore[arg-type]
+                )
+                for row in rows
+            ]
+
+    async def remove(self, repository: str, sha: str) -> None:
+        """Remove a SHA after all check runs have completed."""
+        await self._ensure_table()
+        async with self._pool.acquire() as conn:
+            await conn.execute(_REMOVE_SQL, repository, sha)
+
+    async def cleanup_stale(self, max_age: timedelta) -> int:
+        """Remove SHAs older than *max_age*. Returns count removed."""
+        await self._ensure_table()
+        cutoff = datetime.now(UTC) - max_age
+        async with self._pool.acquire() as conn:
+            result = await conn.execute(_CLEANUP_SQL, cutoff)
+            # asyncpg returns "DELETE N" string
+            count_str = result.split()[-1] if result else "0"
+            return int(count_str)

--- a/packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/EvaluateWebhookHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/EvaluateWebhookHandler.py
@@ -93,6 +93,11 @@ class EvaluateWebhookHandler:
             result = await self._evaluate_rule(rule, event, repository, installation_id, payload)
             if result is not None:
                 results.append(result)
+
+        # Prune _fire_locks to prevent unbounded growth
+        if len(self._fire_locks) > 1000:
+            self._fire_locks = {k: v for k, v in self._fire_locks.items() if v.locked()}
+
         return results
 
     async def _evaluate_rule(


### PR DESCRIPTION
## Summary
- **E2**: Events API pagination - fetch up to 10 pages (was limited to first 30 events)
- **E3**: Dedup TTL alignment - PostgresDedupAdapter now uses `settings.polling.dedup_ttl_seconds` instead of hardcoded 7-day default
- **E4**: PostgresPendingSHAStore - durable SHA tracking survives restarts (was in-memory only)
- **E5**: Prune `_fire_locks` dict when >1000 entries to prevent unbounded growth
- **E5-adj**: Bound `_sig_failures` dict to 10k IPs to prevent unbounded growth

Part of the restart safety audit (Phases C-E). Hygiene fixes from [14-deep-audit-findings.md](docs/audits/20260413_restart-safety-audit/14-deep-audit-findings.md).

## Test plan
- [x] syn-domain unit tests pass (83/83)
- [x] syn-api unit tests pass (11/11)
- [ ] CI green
- [ ] Verify Postgres SHA store creates table on first use
- [ ] Verify Events API pagination with >30 events