### PR TITLE
fix(artifacts): return 202 + Retry-After on content race window

### DIFF
--- a/apps/syn-api/src/syn_api/routes/artifacts.py
+++ b/apps/syn-api/src/syn_api/routes/artifacts.py
@@ -518,6 +518,17 @@ async def get_artifact_content_endpoint(artifact_id: str) -> ArtifactContentResp
         raise HTTPException(status_code=404, detail=f"Artifact {artifact_id} not found")
 
     a = result.value
+
+    # The metadata projection lists the artifact but object storage hasn't received
+    # the bytes yet — a race between ArtifactCreatedEvent and the MinIO upload (#700).
+    # Signal retry-later instead of a misleading 200-with-null body.
+    if a.content is None and a.size_bytes and a.size_bytes > 0:
+        raise HTTPException(
+            status_code=202,
+            detail=f"Artifact {artifact_id} content not yet available; retry shortly",
+            headers={"Retry-After": "2"},
+        )
+
     return ArtifactContentResponse(
         artifact_id=artifact_id,
         content=a.content,

--- a/apps/syn-api/tests/test_endpoint_artifacts.py
+++ b/apps/syn-api/tests/test_endpoint_artifacts.py
@@ -11,9 +11,10 @@ from fastapi import HTTPException, UploadFile
 from syn_api.routes.artifacts import (
     CreateArtifactRequest,
     create_artifact_endpoint,
+    get_artifact_content_endpoint,
     upload_artifact_endpoint,
 )
-from syn_api.types import ArtifactError, Err, Ok
+from syn_api.types import ArtifactDetail, ArtifactError, Err, Ok
 
 # --- create_artifact_endpoint ---
 
@@ -171,3 +172,110 @@ async def test_upload_artifact_endpoint_rejects_oversized_file() -> None:
     with pytest.raises(HTTPException) as exc_info:
         await upload_artifact_endpoint("art-5", file)
     assert exc_info.value.status_code == 413
+
+
+# --- get_artifact_content_endpoint ---
+
+
+async def test_get_artifact_content_endpoint_returns_content() -> None:
+    """When storage has the bytes, the endpoint returns 200 with content."""
+    detail = ArtifactDetail(
+        id="art-ready",
+        artifact_type="other",
+        content="hello",
+        content_type="text/plain",
+        size_bytes=5,
+    )
+    with (
+        patch(
+            "syn_api.prefix_resolver.resolve_or_raise",
+            new_callable=AsyncMock,
+            return_value="art-ready",
+        ),
+        patch("syn_api.routes.artifacts.get_projection_mgr"),
+        patch(
+            "syn_api.routes.artifacts.get_artifact",
+            new_callable=AsyncMock,
+            return_value=Ok(detail),
+        ),
+    ):
+        resp = await get_artifact_content_endpoint("art-ready")
+    assert resp.artifact_id == "art-ready"
+    assert resp.content == "hello"
+    assert resp.size_bytes == 5
+
+
+async def test_get_artifact_content_endpoint_races_returns_202() -> None:
+    """Metadata projection lists the artifact but storage upload hasn't landed yet -> 202."""
+    detail = ArtifactDetail(
+        id="art-racing",
+        artifact_type="other",
+        content=None,
+        content_type="text/plain",
+        size_bytes=2303,
+    )
+    with (
+        patch(
+            "syn_api.prefix_resolver.resolve_or_raise",
+            new_callable=AsyncMock,
+            return_value="art-racing",
+        ),
+        patch("syn_api.routes.artifacts.get_projection_mgr"),
+        patch(
+            "syn_api.routes.artifacts.get_artifact",
+            new_callable=AsyncMock,
+            return_value=Ok(detail),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await get_artifact_content_endpoint("art-racing")
+    assert exc_info.value.status_code == 202
+    assert "not yet available" in str(exc_info.value.detail)
+    assert (exc_info.value.headers or {}).get("Retry-After") == "2"
+
+
+async def test_get_artifact_content_endpoint_missing_returns_404() -> None:
+    """When get_artifact errors (artifact truly missing) the endpoint returns 404."""
+    with (
+        patch(
+            "syn_api.prefix_resolver.resolve_or_raise",
+            new_callable=AsyncMock,
+            return_value="art-missing",
+        ),
+        patch("syn_api.routes.artifacts.get_projection_mgr"),
+        patch(
+            "syn_api.routes.artifacts.get_artifact",
+            new_callable=AsyncMock,
+            return_value=Err(ArtifactError.NOT_FOUND, message="missing"),
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await get_artifact_content_endpoint("art-missing")
+    assert exc_info.value.status_code == 404
+
+
+async def test_get_artifact_content_endpoint_empty_artifact_returns_200() -> None:
+    """Zero-byte artifact (content None, size 0) is not a race - return 200."""
+    detail = ArtifactDetail(
+        id="art-empty",
+        artifact_type="other",
+        content=None,
+        content_type="text/plain",
+        size_bytes=0,
+    )
+    with (
+        patch(
+            "syn_api.prefix_resolver.resolve_or_raise",
+            new_callable=AsyncMock,
+            return_value="art-empty",
+        ),
+        patch("syn_api.routes.artifacts.get_projection_mgr"),
+        patch(
+            "syn_api.routes.artifacts.get_artifact",
+            new_callable=AsyncMock,
+            return_value=Ok(detail),
+        ),
+    ):
+        resp = await get_artifact_content_endpoint("art-empty")
+    assert resp.size_bytes == 0
+    assert resp.content is None

--- a/uv.lock
+++ b/uv.lock
@@ -504,7 +504,7 @@ wheels = [
 
 [[package]]
 name = "event-sourcing-python"
-version = "0.13.0"
+version = "0.14.0"
 source = { editable = "lib/event-sourcing-platform/event-sourcing/python" }
 dependencies = [
     { name = "protobuf" },
@@ -1318,7 +1318,7 @@ wheels = [
 
 [[package]]
 name = "syn-adapters"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "packages/syn-adapters" }
 dependencies = [
     { name = "agentic-events" },
@@ -1370,7 +1370,7 @@ provides-extras = ["postgres", "minio", "all"]
 
 [[package]]
 name = "syn-api"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "apps/syn-api" }
 dependencies = [
     { name = "agentic-logging" },
@@ -1401,7 +1401,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-collector"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "packages/syn-collector" }
 dependencies = [
     { name = "click" },
@@ -1441,7 +1441,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "syn-domain"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "packages/syn-domain" }
 dependencies = [
     { name = "agentic-events" },
@@ -1462,7 +1462,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-perf"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "packages/syn-perf" }
 dependencies = [
     { name = "rich" },
@@ -1490,7 +1490,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "syn-shared"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "packages/syn-shared" }
 dependencies = [
     { name = "pydantic" },
@@ -1509,7 +1509,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-tokens"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "packages/syn-tokens" }
 dependencies = [
     { name = "pydantic" },
@@ -1526,7 +1526,7 @@ requires-dist = [
 
 [[package]]
 name = "syntropic137"
-version = "0.24.3"
+version = "0.25.0"
 source = { editable = "." }
 dependencies = [
     { name = "event-sourcing-python" },


### PR DESCRIPTION
## Summary

Closes the user-visible half of the race documented in #700. `GET /artifacts/{id}/content` was returning **200 OK with null content** when the `ArtifactCreatedEvent` had landed in the projection but MinIO had not yet received the bytes. Clients had no way to distinguish "the artifact is empty" from "try again in a moment."

The route now detects the race via the projection (`size_bytes > 0` with `content is None`) and returns **202 Accepted** with `Retry-After: 2`. 200 is reserved for bytes that are genuinely retrievable; 404 still fires when the metadata projection does not know the ID.

Surfaced during v0.25.0 pre-release pressure testing (see #700 for the underlying event-ordering fix, which remains deferred).

## What changed

- `apps/syn-api/src/syn_api/routes/artifacts.py` — 11 LOC added to `get_artifact_content_endpoint`. Single new branch detects the race and raises HTTPException(202) with Retry-After.
- `apps/syn-api/tests/test_endpoint_artifacts.py` — 4 new tests covering: 200 happy path, 202 race window, 404 missing, 200 on zero-byte artifact.

## Not in this PR

Item deferred to #700: reorder `ArtifactCollector` so `ArtifactCreatedEvent` emits **after** MinIO confirms the bytes are retrievable. That is a handler-level change touching event ordering and is scoped separately.

## Test plan

- [x] `uv run pytest apps/syn-api/tests/test_endpoint_artifacts.py` — 13/13 pass
- [x] `just fitness-check` — pass
- [x] `just codegen` — no drift
- [ ] Manual: hit `/artifacts/{id}/content` immediately after phase completion and confirm 202 + Retry-After; wait; confirm 200

Refs #700