### PR TITLE
fix: pre-release polish for v0.25.0 (PR #664 review feedback)

### DIFF
--- a/apps/syn-api/src/syn_api/routes/webhooks/endpoint.py
+++ b/apps/syn-api/src/syn_api/routes/webhooks/endpoint.py
@@ -10,7 +10,6 @@ from fastapi import APIRouter, Header, HTTPException, Request
 
 from syn_api.routes.webhooks.processing import verify_and_process_webhook
 from syn_api.routes.webhooks.push_events import _record_push_commits
-from syn_api.routes.webhooks.signature import _check_sig_rate_limit, _record_sig_failure
 from syn_api.types import Err, WebhookResult
 
 logger = logging.getLogger(__name__)
@@ -27,11 +26,10 @@ def _handle_ping(body: bytes) -> dict[str, Any]:
     return {"status": "pong", "zen": payload.get("zen", "")}
 
 
-def _raise_for_webhook_error(result: Err[Any], client_ip: str) -> NoReturn:
+def _raise_for_webhook_error(result: Err[Any]) -> NoReturn:
     """Classify a webhook error and raise the appropriate HTTPException."""
     error_name = result.error.value if hasattr(result.error, "value") else str(result.error)
     if "signature" in error_name.lower():
-        _record_sig_failure(client_ip)
         raise HTTPException(status_code=401, detail=result.message)
     if "payload" in error_name.lower():
         raise HTTPException(status_code=400, detail=result.message)
@@ -59,16 +57,11 @@ async def github_webhook_endpoint(
     x_hub_signature_256: str | None = Header(None, alias="X-Hub-Signature-256"),
 ) -> dict[str, Any]:
     """Handle GitHub webhooks."""
-    client_ip = request.headers.get(
-        "X-Real-IP", request.client.host if request.client else "unknown"
-    )
     body = await request.body()
 
     # Handle ping separately
     if x_github_event == "ping":
         return _handle_ping(body)
-
-    _check_sig_rate_limit(client_ip)
 
     result = await verify_and_process_webhook(
         body=body,
@@ -78,7 +71,7 @@ async def github_webhook_endpoint(
     )
 
     if isinstance(result, Err):
-        _raise_for_webhook_error(result, client_ip)
+        _raise_for_webhook_error(result)
 
     response = _build_webhook_response(result.value)
 
@@ -88,6 +81,6 @@ async def github_webhook_endpoint(
             payload = json.loads(body)
             await _record_push_commits(payload, delivery_id=x_github_delivery)
         except Exception:
-            logger.exception("Failed to record push commit events — webhook response unaffected")
+            logger.exception("Failed to record push commit events, webhook response unaffected")
 
     return response

--- a/apps/syn-api/src/syn_api/routes/webhooks/signature.py
+++ b/apps/syn-api/src/syn_api/routes/webhooks/signature.py
@@ -1,67 +1,15 @@
-"""Webhook signature verification and rate limiting."""
+"""Webhook signature verification. IP-based rate limiting is handled at the edge (NGINX/Cloudflare)."""
 
 from __future__ import annotations
 
 import hashlib
 import hmac
 import logging
-import time
-
-from fastapi import HTTPException
 
 from syn_api._wiring import get_github_settings
 from syn_api.types import Err, GitHubError, Ok, Result
 
 logger = logging.getLogger(__name__)
-
-# --- Signature-failure rate limiter ---
-_MAX_FAILURES = 5
-_WINDOW_SECONDS = 60
-# PERFORMANCE: per-instance tracking, resets on restart. Multi-instance: effective limit multiplied by instance count (acceptable for rate limiting)
-_sig_failures: dict[str, list[float]] = {}
-
-_MAX_TRACKED_IPS = 10_000
-
-
-def _evict_stale_sig_failures() -> None:
-    """Prune stale entries to prevent unbounded growth."""
-    if len(_sig_failures) <= _MAX_TRACKED_IPS:
-        return
-    now = time.monotonic()
-    stale = [
-        ip
-        for ip, attempts in _sig_failures.items()
-        if not any(now - t < _WINDOW_SECONDS for t in attempts)
-    ]
-    for ip in stale:
-        del _sig_failures[ip]
-    if stale:
-        logger.info("Pruned %d stale signature failure entries", len(stale))
-
-
-def _check_sig_rate_limit(client_ip: str) -> None:
-    """Raise 429 if this IP has too many recent signature failures."""
-    _evict_stale_sig_failures()
-    now = time.monotonic()
-    attempts = _sig_failures.get(client_ip)
-    if attempts is None:
-        return
-    # Prune old attempts
-    recent = [t for t in attempts if now - t < _WINDOW_SECONDS]
-    if not recent:
-        del _sig_failures[client_ip]
-        return
-    _sig_failures[client_ip] = recent
-    if len(recent) >= _MAX_FAILURES:
-        logger.warning("Webhook rate limit: %s blocked (%d failures)", client_ip, len(recent))
-        raise HTTPException(status_code=429, detail="Too many failed signature attempts")
-
-
-def _record_sig_failure(client_ip: str) -> None:
-    """Record a signature verification failure for rate limiting."""
-    if client_ip not in _sig_failures:
-        _sig_failures[client_ip] = []
-    _sig_failures[client_ip].append(time.monotonic())
 
 
 def _verify_signature(body: bytes, signature: str | None, webhook_secret: str) -> bool:
@@ -71,7 +19,7 @@ def _verify_signature(body: bytes, signature: str | None, webhook_secret: str) -
     Raises ``ValueError`` with a human-readable message on any failure.
     """
     if not webhook_secret:
-        raise ValueError("Webhook secret not configured — rejecting unverified payload")
+        raise ValueError("Webhook secret not configured, rejecting unverified payload")
     if not signature:
         raise ValueError("Missing webhook signature")
 
@@ -92,6 +40,6 @@ def verify_webhook_signature(body: bytes, signature: str | None) -> Result[bool,
         logger.exception("Failed to verify webhook signature")
         return Err(
             GitHubError.INVALID_SIGNATURE,
-            message="Signature verification failed — rejecting payload",
+            message="Signature verification failed, rejecting payload",
         )
     return Ok(True)

--- a/apps/syn-api/tests/test_webhooks_endpoint.py
+++ b/apps/syn-api/tests/test_webhooks_endpoint.py
@@ -32,21 +32,21 @@ def test_handle_ping_invalid_json_returns_empty_zen() -> None:
 def test_raise_for_webhook_error_signature_gives_401() -> None:
     err = Err(GitHubError.INVALID_SIGNATURE, message="bad sig")
     with pytest.raises(HTTPException) as exc_info:
-        _raise_for_webhook_error(err, "1.2.3.4")
+        _raise_for_webhook_error(err)
     assert exc_info.value.status_code == 401
 
 
 def test_raise_for_webhook_error_payload_gives_400() -> None:
     err = Err(GitHubError.INVALID_PAYLOAD, message="bad json")
     with pytest.raises(HTTPException) as exc_info:
-        _raise_for_webhook_error(err, "1.2.3.4")
+        _raise_for_webhook_error(err)
     assert exc_info.value.status_code == 400
 
 
 def test_raise_for_webhook_error_other_gives_500() -> None:
     err = Err(GitHubError.PROCESSING_FAILED, message="boom")
     with pytest.raises(HTTPException) as exc_info:
-        _raise_for_webhook_error(err, "1.2.3.4")
+        _raise_for_webhook_error(err)
     assert exc_info.value.status_code == 500
 
 

--- a/apps/syn-api/tests/test_webhooks_signature.py
+++ b/apps/syn-api/tests/test_webhooks_signature.py
@@ -1,4 +1,7 @@
-"""Unit tests for webhook signature verification and rate limiting."""
+"""Unit tests for webhook signature verification.
+
+IP-based rate limiting is handled at the edge (NGINX/Cloudflare), not in the app.
+"""
 
 from __future__ import annotations
 
@@ -7,23 +10,12 @@ import hmac
 from unittest.mock import patch
 
 import pytest
-from fastapi import HTTPException
 
 from syn_api.routes.webhooks.signature import (
-    _check_sig_rate_limit,
-    _record_sig_failure,
-    _sig_failures,
     _verify_signature,
     verify_webhook_signature,
 )
 from syn_api.types import Err, Ok
-
-
-@pytest.fixture(autouse=True)
-def _clear_rate_limits() -> None:
-    """Reset rate-limit state between tests."""
-    _sig_failures.clear()
-
 
 # --- _verify_signature ---
 
@@ -81,30 +73,3 @@ def test_verify_webhook_signature_returns_err_on_missing_sig() -> None:
 
     assert isinstance(result, Err)
     assert "Missing" in (result.message or "")
-
-
-# --- Rate limiting ---
-
-
-def test_check_rate_limit_allows_under_threshold() -> None:
-    for _ in range(4):
-        _record_sig_failure("1.2.3.4")
-    # Should not raise — 4 < 5
-    _check_sig_rate_limit("1.2.3.4")
-
-
-def test_check_rate_limit_blocks_at_threshold() -> None:
-    for _ in range(5):
-        _record_sig_failure("1.2.3.4")
-
-    with pytest.raises(HTTPException) as exc_info:
-        _check_sig_rate_limit("1.2.3.4")
-    assert exc_info.value.status_code == 429
-
-
-def test_check_rate_limit_different_ips_independent() -> None:
-    for _ in range(5):
-        _record_sig_failure("1.2.3.4")
-
-    # Different IP should not be affected
-    _check_sig_rate_limit("5.6.7.8")

--- a/apps/syn-cli-node/src/commands/workflow/crud.ts
+++ b/apps/syn-cli-node/src/commands/workflow/crud.ts
@@ -11,9 +11,11 @@ import { printError, printSuccess, print, printDim } from "../../output/console.
 import { style, BOLD, CYAN, DIM, GREEN, YELLOW } from "../../output/ansi.js";
 import { Table } from "../../output/table.js";
 import { resolveWorkflow } from "./resolver.js";
-import { detectFormat, resolvePackage } from "../../packages/resolver.js";
+import { detectFormat, loadSingleWorkflowFile, resolvePackage } from "../../packages/resolver.js";
 import fs from "node:fs";
 import path from "node:path";
+
+const PLACEHOLDER_REPO_URL = "https://github.com/placeholder/not-configured";
 
 type WorkflowResponse = components["schemas"]["WorkflowResponse"];
 
@@ -27,7 +29,7 @@ export const createCommand: CommandDef = {
   args: [{ name: "name", description: "Name of the workflow", required: true }],
   options: {
     type: { type: "string", short: "t", description: "Workflow type (research, planning, implementation, review, deployment, custom)", default: "custom" },
-    repo: { type: "string", short: "r", description: "Repository URL", default: "https://github.com/example/repo" },
+    repo: { type: "string", short: "r", description: "Repository URL" },
     ref: { type: "string", description: "Repository ref/branch", default: "main" },
     description: { type: "string", short: "d", description: "Workflow description" },
     repos: { type: "string", short: "R", description: "Default GitHub URLs for workspace hydration (repeatable). ADR-058.", multiple: true },
@@ -42,13 +44,17 @@ export const createCommand: CommandDef = {
     }
 
     const workflowType = (parsed.values["type"] as string | undefined) ?? "custom";
-    const repoUrl = (parsed.values["repo"] as string | undefined) ?? "https://github.com/example/repo";
+    const repoUrl = parsed.values["repo"] as string | undefined;
     const repoRef = (parsed.values["ref"] as string | undefined) ?? "main";
     const description = parsed.values["description"] as string | undefined;
     const reposValues = parsed.values["repos"];
     const templateRepos: string[] = Array.isArray(reposValues) ? reposValues as string[] : reposValues ? [reposValues as string] : [];
-    const noRepos = parsed.values["no-repos"] as boolean | undefined;
+    const noRepos = parsed.values["no-repos"] === true;
     const fromPath = parsed.values["from"] as string | undefined;
+
+    if (noRepos && repoUrl !== undefined) {
+      print(style("Warning:", YELLOW) + " --repo is ignored when --no-repos is set");
+    }
 
     let phases: Record<string, unknown>[] | undefined;
     let inputDeclarations: Record<string, unknown>[] | undefined;
@@ -59,21 +65,29 @@ export const createCommand: CommandDef = {
         printError(`Path not found: ${fromPath}`);
         throw new CLIError("Path not found", 1);
       }
-      const stat = fs.statSync(resolved);
-      const workflowDir = stat.isDirectory() ? resolved : path.dirname(resolved);
       try {
-        const { workflows } = resolvePackage(workflowDir);
-        if (workflows.length === 0) {
-          printError(`No workflows found in: ${workflowDir}`);
-          throw new CLIError("No workflows found", 1);
+        const stat = fs.statSync(resolved);
+        if (stat.isFile()) {
+          const wf = loadSingleWorkflowFile(resolved);
+          phases = wf.phases as Record<string, unknown>[];
+          inputDeclarations = wf.input_declarations;
+        } else if (stat.isDirectory()) {
+          const { workflows } = resolvePackage(resolved);
+          if (workflows.length === 0) {
+            printError(`No workflows found in: ${resolved}`);
+            throw new CLIError("No workflows found", 1);
+          }
+          if (workflows.length > 1) {
+            printError(`Multiple workflows found in: ${resolved}. Pass a specific workflow.yaml path with --from.`);
+            throw new CLIError("Multiple workflows found", 1);
+          }
+          const wf = workflows[0]!;
+          phases = wf.phases as Record<string, unknown>[];
+          inputDeclarations = wf.input_declarations;
+        } else {
+          printError(`Path is neither a file nor a directory: ${fromPath}`);
+          throw new CLIError("Invalid path", 1);
         }
-        if (workflows.length > 1) {
-          printError(`Multiple workflows found in: ${workflowDir}. Pass a specific workflow.yaml path with --from.`);
-          throw new CLIError("Multiple workflows found", 1);
-        }
-        const wf = workflows[0]!;
-        phases = wf.phases as Record<string, unknown>[];
-        inputDeclarations = wf.input_declarations;
       } catch (err) {
         if (err instanceof CLIError) throw err;
         printError(`Failed to parse workflow YAML: ${err instanceof Error ? err.message : String(err)}`);
@@ -81,13 +95,19 @@ export const createCommand: CommandDef = {
       }
     }
 
+    const resolvedRepoUrl = noRepos
+      ? ""
+      : repoUrl !== undefined
+        ? repoUrl
+        : PLACEHOLDER_REPO_URL;
+
     const data = unwrap(
       await api.POST("/workflows", {
         body: {
           name,
           workflow_type: workflowType,
           classification: "standard",
-          repository_url: repoUrl,
+          repository_url: resolvedRepoUrl,
           repository_ref: repoRef,
           description: description ?? null,
           ...(templateRepos.length > 0 ? { repos: templateRepos } : {}),

--- a/apps/syn-cli-node/src/packages/resolver.ts
+++ b/apps/syn-cli-node/src/packages/resolver.ts
@@ -58,6 +58,16 @@ export function recordInstallation(opts: {
 }
 
 // ---------------------------------------------------------------------------
+// ADR-058: requires_repos default inference
+// ---------------------------------------------------------------------------
+
+function inferRequiresRepos(data: Record<string, unknown>): boolean {
+  if (data["requires_repos"] === true) return true;
+  if (data["requires_repos"] === false) return false;
+  return data["repository"] != null;
+}
+
+// ---------------------------------------------------------------------------
 // Source parsing
 // ---------------------------------------------------------------------------
 
@@ -169,7 +179,14 @@ function loadWorkflowYaml(
   if (!fs.existsSync(yamlPath)) {
     throw new Error(`workflow.yaml not found in ${workflowDir}`);
   }
+  return loadWorkflowYamlFromPath(yamlPath, sourcePath);
+}
 
+function loadWorkflowYamlFromPath(
+  yamlPath: string,
+  sourcePath: string,
+): ResolvedWorkflow {
+  const workflowDir = path.dirname(yamlPath);
   const content = fs.readFileSync(yamlPath, "utf-8");
   const data = parseYaml(content) as Record<string, unknown>;
 
@@ -191,11 +208,26 @@ function loadWorkflowYaml(
     repository_ref: repository ? String(repository["ref"] ?? "main") : "main",
     description: data["description"] ? String(data["description"]) : null,
     project_name: data["project_name"] ? String(data["project_name"]) : null,
-    requires_repos: data["requires_repos"] !== false,
+    requires_repos: inferRequiresRepos(data),
     phases: resolvedPhases as Record<string, unknown>[],
     input_declarations: parseInputDeclarations(data),
     source_path: sourcePath,
   };
+}
+
+export function loadSingleWorkflowFile(absPath: string): ResolvedWorkflow {
+  if (!fs.existsSync(absPath)) {
+    throw new Error(`Workflow file not found: ${absPath}`);
+  }
+  const stat = fs.statSync(absPath);
+  if (!stat.isFile()) {
+    throw new Error(`Path is not a file: ${absPath}`);
+  }
+  const ext = path.extname(absPath).toLowerCase();
+  if (ext !== ".yaml" && ext !== ".yml") {
+    throw new Error(`Workflow file must be .yaml or .yml: ${absPath}`);
+  }
+  return loadWorkflowYamlFromPath(absPath, absPath);
 }
 
 function resolvePhase(
@@ -332,7 +364,7 @@ function resolveStandaloneYaml(
       repository_ref: "main",
       description: data["description"] ? String(data["description"]) : null,
       project_name: data["project_name"] ? String(data["project_name"]) : null,
-      requires_repos: data["requires_repos"] !== false,
+      requires_repos: inferRequiresRepos(data),
       phases: Array.isArray(data["phases"])
         ? (data["phases"] as Record<string, unknown>[])
         : [],

--- a/apps/syn-cli-node/tests/packages/resolver.test.ts
+++ b/apps/syn-cli-node/tests/packages/resolver.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { parseSource } from "../../src/packages/resolver.js";
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  parseSource,
+  loadSingleWorkflowFile,
+  resolvePackage,
+} from "../../src/packages/resolver.js";
 
 describe("parseSource", () => {
   it("detects HTTPS URLs as remote", () => {
@@ -33,5 +40,109 @@ describe("parseSource", () => {
   it("treats bare names as local", () => {
     const result = parseSource("my-workflow");
     expect(result).toEqual({ resolved: "my-workflow", isRemote: false });
+  });
+});
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "syn-test-requires-repos-"));
+}
+
+function cleanup(dir: string): void {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe("requires_repos inference (ADR-058)", () => {
+  let tmpDir: string;
+
+  afterEach(() => {
+    if (tmpDir) cleanup(tmpDir);
+  });
+
+  describe("loadSingleWorkflowFile", () => {
+    it("returns true when requires_repos: true is explicit and repository is absent", () => {
+      tmpDir = makeTmpDir();
+      const yamlPath = path.join(tmpDir, "workflow.yaml");
+      fs.writeFileSync(
+        yamlPath,
+        "id: test\nname: Test\nrequires_repos: true\nphases: []\n",
+        "utf-8",
+      );
+      const wf = loadSingleWorkflowFile(yamlPath);
+      expect(wf.requires_repos).toBe(true);
+    });
+
+    it("returns false when requires_repos: false is explicit even with a repository block", () => {
+      tmpDir = makeTmpDir();
+      const yamlPath = path.join(tmpDir, "workflow.yaml");
+      fs.writeFileSync(
+        yamlPath,
+        "id: test\nname: Test\nrequires_repos: false\nrepository:\n  url: https://github.com/org/repo\n  ref: main\nphases: []\n",
+        "utf-8",
+      );
+      const wf = loadSingleWorkflowFile(yamlPath);
+      expect(wf.requires_repos).toBe(false);
+    });
+
+    it("defaults to false when requires_repos is absent and repository is absent (ADR-058)", () => {
+      tmpDir = makeTmpDir();
+      const yamlPath = path.join(tmpDir, "workflow.yaml");
+      fs.writeFileSync(
+        yamlPath,
+        "id: test\nname: Test\nphases: []\n",
+        "utf-8",
+      );
+      const wf = loadSingleWorkflowFile(yamlPath);
+      expect(wf.requires_repos).toBe(false);
+    });
+
+    it("defaults to true when requires_repos is absent but a repository block is present", () => {
+      tmpDir = makeTmpDir();
+      const yamlPath = path.join(tmpDir, "workflow.yaml");
+      fs.writeFileSync(
+        yamlPath,
+        "id: test\nname: Test\nrepository:\n  url: https://github.com/org/repo\n  ref: main\nphases: []\n",
+        "utf-8",
+      );
+      const wf = loadSingleWorkflowFile(yamlPath);
+      expect(wf.requires_repos).toBe(true);
+    });
+  });
+
+  describe("resolveStandaloneYaml (via resolvePackage)", () => {
+    it("defaults to false when requires_repos is absent (standalone has no repository field)", () => {
+      tmpDir = makeTmpDir();
+      fs.writeFileSync(
+        path.join(tmpDir, "my-workflow.yaml"),
+        "id: standalone\nname: Standalone\nphases: []\n",
+        "utf-8",
+      );
+      const { workflows } = resolvePackage(tmpDir);
+      expect(workflows).toHaveLength(1);
+      expect(workflows[0]!.requires_repos).toBe(false);
+    });
+
+    it("returns true when requires_repos: true is explicit in standalone YAML", () => {
+      tmpDir = makeTmpDir();
+      fs.writeFileSync(
+        path.join(tmpDir, "my-workflow.yaml"),
+        "id: standalone\nname: Standalone\nrequires_repos: true\nphases: []\n",
+        "utf-8",
+      );
+      const { workflows } = resolvePackage(tmpDir);
+      expect(workflows).toHaveLength(1);
+      expect(workflows[0]!.requires_repos).toBe(true);
+    });
+
+    it("returns false when requires_repos: false is explicit in standalone YAML", () => {
+      tmpDir = makeTmpDir();
+      fs.writeFileSync(
+        path.join(tmpDir, "my-workflow.yaml"),
+        "id: standalone\nname: Standalone\nrequires_repos: false\nphases: []\n",
+        "utf-8",
+      );
+      const { workflows } = resolvePackage(tmpDir);
+      expect(workflows).toHaveLength(1);
+      expect(workflows[0]!.requires_repos).toBe(false);
+    });
   });
 });

--- a/apps/syn-docs/content/docs/cli/workflow.mdx
+++ b/apps/syn-docs/content/docs/cli/workflow.mdx
@@ -24,7 +24,7 @@ syn workflow create <name> [options]
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
 | `--type`, `-t` | `text` | `custom` | Workflow type (research, planning, implementation, review, deployment, custom) |
-| `--repo`, `-r` | `text` | `https://github.com/example/repo` | Repository URL |
+| `--repo`, `-r` | `text` | --- | Repository URL |
 | `--ref` | `text` | `main` | Repository ref/branch |
 | `--description`, `-d` | `text` | --- | Workflow description |
 | `--repos`, `-R` | `text` | --- | Default GitHub URLs for workspace hydration (repeatable). ADR-058. |

--- a/ci/fitness/fitness_exceptions.toml
+++ b/ci/fitness/fitness_exceptions.toml
@@ -49,7 +49,6 @@ allowed_prefixes = [
 "packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/EvaluateWebhookHandler.py" = { variable = "_fire_locks", description = "per-(trigger, pr) asyncio.Lock dict for concurrency guard" }
 "packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/debouncer.py" = { variable = "_pending", description = "pending debounce task dict" }
 "packages/syn-domain/src/syn_domain/contexts/github/slices/evaluate_webhook/safety_guards.py" = { variable = "_dispatch_timestamps", description = "dispatch rate limit timestamp list" }
-"apps/syn-api/src/syn_api/routes/webhooks/signature.py" = { variable = "_sig_failures", description = "signature failure rate limiter dict" }
 
 [aggregate_guards]
 # @command_handler methods exempt from the guard requirement.

--- a/docker/docker-compose.selfhost.yaml
+++ b/docker/docker-compose.selfhost.yaml
@@ -201,6 +201,7 @@ services:
         max-file: "3"
     networks:
       - syn-internal
+      - docker-proxy
 
   # ===========================================================================
   # FRONTEND (nginx)

--- a/docker/docker-compose.syntropic137.yaml
+++ b/docker/docker-compose.syntropic137.yaml
@@ -258,6 +258,7 @@ services:
       start_period: 15s
     networks:
     - syn-internal
+    - docker-proxy
     container_name: syn137-api
     volumes:
     - ./selfhost-entrypoint.sh:/selfhost-entrypoint.sh:ro

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_workflow_execution_processor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_workflow_execution_processor.py
@@ -223,3 +223,118 @@ class TestProcessorReposPersistence:
         )
 
         assert inputs["repos"] == "https://github.com/org/explicit"
+
+
+@pytest.mark.unit
+class TestProcessorCancellation:
+    """Tests for cancellation cleanup semantics."""
+
+    @pytest.mark.anyio
+    async def test_cancel_execution_clears_all_active_state_and_sets_error_message(
+        self,
+    ) -> None:
+        """_cancel_execution closes workspace CMs, clears all in-memory state, and
+        propagates the cancel reason into the result's error_message.
+        """
+        from datetime import UTC, datetime
+
+        processor = _make_processor()
+
+        # Seed session managers (expose complete_cancelled as AsyncMock).
+        session_mgr_a = MagicMock()
+        session_mgr_a.complete_cancelled = AsyncMock()
+        session_mgr_b = MagicMock()
+        session_mgr_b.complete_cancelled = AsyncMock()
+        processor._session_managers["phase-a"] = session_mgr_a
+        processor._session_managers["phase-b"] = session_mgr_b
+
+        # Seed workspace context managers (async context manager protocol).
+        workspace_cm_a = MagicMock()
+        workspace_cm_a.__aexit__ = AsyncMock(return_value=None)
+        workspace_cm_b = MagicMock()
+        workspace_cm_b.__aexit__ = AsyncMock(return_value=None)
+        processor._active_workspace_cms["phase-a"] = workspace_cm_a
+        processor._active_workspace_cms["phase-b"] = workspace_cm_b
+
+        # Seed the remaining per-phase state dicts.
+        processor._active_workspaces["phase-a"] = MagicMock()
+        processor._active_workspaces["phase-b"] = MagicMock()
+        processor._active_envs["phase-a"] = {"FOO": "bar"}
+        processor._active_envs["phase-b"] = {"BAZ": "qux"}
+        processor._active_cmds["phase-a"] = ["claude", "--model", "haiku"]
+        processor._active_cmds["phase-b"] = ["claude", "--model", "sonnet"]
+
+        started_at = datetime.now(UTC)
+        result = await processor._cancel_execution(
+            execution_id="exec-cancel",
+            workflow_id="wf-cancel",
+            phase_results=[],
+            all_artifact_ids=[],
+            started_at=started_at,
+            cancel_reason="user requested",
+        )
+
+        # Each workspace CM was closed via the async context manager exit.
+        workspace_cm_a.__aexit__.assert_awaited_once_with(None, None, None)
+        workspace_cm_b.__aexit__.assert_awaited_once_with(None, None, None)
+
+        # Each session manager was told to complete-as-cancelled with the reason.
+        session_mgr_a.complete_cancelled.assert_awaited_once_with(reason="user requested")
+        session_mgr_b.complete_cancelled.assert_awaited_once_with(reason="user requested")
+
+        # All five per-phase state dicts are empty after cancellation.
+        assert processor._session_managers == {}
+        assert processor._active_workspace_cms == {}
+        assert processor._active_workspaces == {}
+        assert processor._active_envs == {}
+        assert processor._active_cmds == {}
+
+        # The result reflects the cancellation with the reason as error_message.
+        assert result.status == "cancelled"
+        assert result.error_message == "user requested"
+        assert result.execution_id == "exec-cancel"
+        assert result.workflow_id == "wf-cancel"
+
+    @pytest.mark.anyio
+    async def test_cancel_execution_survives_workspace_cleanup_failure(self) -> None:
+        """A workspace CM that raises during __aexit__ does not abort the cleanup
+        loop; remaining state is still cleared and the cancelled result is still
+        produced.
+        """
+        from datetime import UTC, datetime
+
+        processor = _make_processor()
+
+        session_mgr = MagicMock()
+        session_mgr.complete_cancelled = AsyncMock()
+        processor._session_managers["phase-a"] = session_mgr
+
+        failing_cm = MagicMock()
+        failing_cm.__aexit__ = AsyncMock(side_effect=RuntimeError("cleanup exploded"))
+        healthy_cm = MagicMock()
+        healthy_cm.__aexit__ = AsyncMock(return_value=None)
+        processor._active_workspace_cms["phase-a"] = failing_cm
+        processor._active_workspace_cms["phase-b"] = healthy_cm
+
+        processor._active_workspaces["phase-a"] = MagicMock()
+        processor._active_envs["phase-a"] = {}
+        processor._active_cmds["phase-a"] = []
+
+        result = await processor._cancel_execution(
+            execution_id="exec-cancel",
+            workflow_id="wf-cancel",
+            phase_results=[],
+            all_artifact_ids=[],
+            started_at=datetime.now(UTC),
+            cancel_reason="timeout",
+        )
+
+        failing_cm.__aexit__.assert_awaited_once_with(None, None, None)
+        healthy_cm.__aexit__.assert_awaited_once_with(None, None, None)
+        assert processor._session_managers == {}
+        assert processor._active_workspace_cms == {}
+        assert processor._active_workspaces == {}
+        assert processor._active_envs == {}
+        assert processor._active_cmds == {}
+        assert result.status == "cancelled"
+        assert result.error_message == "timeout"


### PR DESCRIPTION
## Summary

Addresses P0+P1 Copilot review threads on PR #664 before cutting v0.25.0.

- **Issue 4 (P0):** Docker Compose api service was missing from `docker-proxy` network, so it could not reach `docker-socket-proxy:2375` in the selfhost stack.
- **Issue 5:** CLI `workflow create --from <file>` now handles single YAML files (previously only directories).
- **Issue 6:** CLI `workflow create --no-repos` no longer silently stamps a placeholder repo URL; emits a warning when `--repo` is passed with `--no-repos`.
- **Issue 7:** `requires_repos` inference follows ADR-058 (absent + no repo block = false; absent + repo block = true).
- **Issue 2:** Deleted the app-layer IP rate limiter in `signature.py`. IP rate limiting is an edge-layer concern (NGINX / Cloudflare), not in-app. Reinforces the restart-safe invariant (no in-memory dedup/counter backing stores in production code paths).
- **Issue 9:** Added regression tests for `_cancel_execution` clearing all active state dicts and surviving workspace cleanup failures.

### Scope

11 files changed (+315 / -130):
- `docker/docker-compose.selfhost.yaml`, `docker/docker-compose.syntropic137.yaml`
- `apps/syn-cli-node/src/commands/workflow/crud.ts`, `apps/syn-cli-node/src/packages/resolver.ts`, `apps/syn-cli-node/tests/packages/resolver.test.ts`
- `apps/syn-api/src/syn_api/routes/webhooks/signature.py`, `apps/syn-api/src/syn_api/routes/webhooks/endpoint.py`, `apps/syn-api/tests/test_webhooks_signature.py`, `apps/syn-api/tests/test_webhooks_endpoint.py`
- `ci/fitness/fitness_exceptions.toml`
- `packages/syn-domain/.../test_workflow_execution_processor.py` (regression tests only)

## Test plan

- [x] `uv run ruff check apps/ packages/` clean
- [x] `uv run ruff format --check apps/ packages/` clean
- [x] `just fitness-check` passes
- [x] `just codegen` drift check passes
- [x] CLI tests 215/215 passing (`pnpm test --filter syn-cli-node`)
- [x] Pyright 0 errors
- [ ] CI green on PR