### PR TITLE
fix(ci): flatten release-gate reusable workflows (subdirs not supported)

### DIFF
--- a/.github/workflows/_check-changelog.yml
+++ b/.github/workflows/_check-changelog.yml
@@ -5,6 +5,10 @@
 # The PR body is used verbatim as the GitHub Release description.
 #
 # Called by: release-gate.yml
+#
+# NOTE: reusable workflows must live at the top of .github/workflows/ — no
+# subdirectories allowed (GitHub rejects with "invalid workflow reference").
+# See _check-version.yml for the full story.
 # =============================================================================
 
 name: Check - Release Notes

--- a/.github/workflows/_check-codegen-sync.yml
+++ b/.github/workflows/_check-codegen-sync.yml
@@ -12,6 +12,10 @@
 # To fix a failure locally: just codegen && git add -A && git commit
 #
 # Called by: release-gate.yml, release-create.yml (pre-publish validation)
+#
+# NOTE: reusable workflows must live at the top of .github/workflows/ — no
+# subdirectories allowed (GitHub rejects with "invalid workflow reference").
+# See _check-version.yml for the full story.
 # =============================================================================
 
 name: Check - Codegen Sync

--- a/.github/workflows/_check-docker-dry-run.yml
+++ b/.github/workflows/_check-docker-dry-run.yml
@@ -8,6 +8,10 @@
 # per-image scope) makes unchanged images near-instant on subsequent runs.
 #
 # Called by: release-gate.yml
+#
+# NOTE: reusable workflows must live at the top of .github/workflows/ — no
+# subdirectories allowed (GitHub rejects with "invalid workflow reference").
+# See _check-version.yml for the full story.
 # =============================================================================
 
 name: Check - Docker Dry-Run

--- a/.github/workflows/_check-version.yml
+++ b/.github/workflows/_check-version.yml
@@ -5,6 +5,13 @@
 # what's currently on the release branch.
 #
 # Called by: release-gate.yml
+#
+# NOTE on the `_check-` prefix and flat layout:
+# GitHub Actions does NOT support reusable workflows in subdirectories of
+# .github/workflows/ — they MUST live at the top level. Moving them into a
+# `checks/` subdir produces a cryptic "invalid workflow reference" failure
+# with 0 jobs and the path-as-name in the UI. The `_check-` prefix is our
+# convention for grouping reusable-only (workflow_call) workflows visually.
 # =============================================================================
 
 name: Check - Version Consistency

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -120,13 +120,17 @@ jobs:
           echo "Created release: ${{ steps.version.outputs.version }}"
 
   # ---------------------------------------------------------------------------
-  # Step 2: Pre-publish validation — codegen sync (reuses checks/codegen-sync.yml)
+  # Step 2: Pre-publish validation — codegen sync (reuses _check-codegen-sync.yml)
+  #
+  # NOTE: reusable workflows must live at the top of .github/workflows/ — no
+  # subdirectories. The `_check-*` prefix visually groups them. See
+  # _check-codegen-sync.yml for the constraint.
   # ---------------------------------------------------------------------------
   pre-publish-validation:
     name: Pre-Publish Validation
     needs: [create-release]
     if: needs.create-release.outputs.created == 'true'
-    uses: ./.github/workflows/checks/codegen-sync.yml
+    uses: ./.github/workflows/_check-codegen-sync.yml
 
   # ---------------------------------------------------------------------------
   # Step 3: Build, sign, push Docker images + attach release assets

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -13,7 +13,9 @@
 #
 # Full CI (tests, lint, typecheck) also runs on these PRs via ci.yml.
 #
-# Each check lives in .github/workflows/checks/ as a reusable workflow.
+# Each check lives in .github/workflows/ with the `_check-` prefix as a
+# reusable workflow. (GitHub Actions does not support subdirectories for
+# reusable workflows — they must be at the top level.)
 # =============================================================================
 
 name: Release Gate
@@ -29,20 +31,25 @@ permissions:
 jobs:
   # ---------------------------------------------------------------------------
   # Reusable checks
+  #
+  # NOTE: GitHub Actions does NOT support reusable workflows in subdirectories
+  # of .github/workflows/ — they must live at the top level. The `_check-*`
+  # prefix visually groups them and signals they only fire via workflow_call
+  # (they appear as greyed-out entries in the Actions sidebar).
   # ---------------------------------------------------------------------------
   version-check:
-    uses: ./.github/workflows/checks/version-check.yml
+    uses: ./.github/workflows/_check-version.yml
 
   changelog-check:
-    uses: ./.github/workflows/checks/changelog-check.yml
+    uses: ./.github/workflows/_check-changelog.yml
     with:
       pr_body: ${{ github.event.pull_request.body }}
 
   codegen-sync:
-    uses: ./.github/workflows/checks/codegen-sync.yml
+    uses: ./.github/workflows/_check-codegen-sync.yml
 
   docker-dry-run:
-    uses: ./.github/workflows/checks/docker-dry-run.yml
+    uses: ./.github/workflows/_check-docker-dry-run.yml
 
   # ---------------------------------------------------------------------------
   # Security Scans — inline (not duplicated elsewhere, no extraction needed)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -264,10 +264,10 @@ Merge to release
 |------|---------|
 | `.github/workflows/release-gate.yml` | Thin orchestrator - calls checks + inline security scans |
 | `.github/workflows/release-create.yml` | Release pipeline - create tag/release, publish containers + CLI |
-| `.github/workflows/checks/version-check.yml` | Version consistency: all 11 files match, bumped vs release |
-| `.github/workflows/checks/changelog-check.yml` | PR body length validation (takes `pr_body` input) |
-| `.github/workflows/checks/codegen-sync.yml` | Runs `just codegen`, checks for drift (CLI types, API docs, CLI docs) |
-| `.github/workflows/checks/docker-dry-run.yml` | All container images build successfully (single-arch, GHA cache) |
+| `.github/workflows/_check-version.yml` | Version consistency: all 11 files match, bumped vs release |
+| `.github/workflows/_check-changelog.yml` | PR body length validation (takes `pr_body` input) |
+| `.github/workflows/_check-codegen-sync.yml` | Runs `just codegen`, checks for drift (CLI types, API docs, CLI docs) |
+| `.github/workflows/_check-docker-dry-run.yml` | All container images build successfully (single-arch, GHA cache) |
 | `.github/workflows/release-containers.yaml` | Multi-arch build, cosign sign, push to GHCR, release assets |
 | `.github/workflows/release-cli.yaml` | Build + publish `@syntropic137/cli` to npm (OIDC, provenance) |
 | `scripts/workflows/bump_version.py` | Version bump script; `--check` (consistency) and `--check-release` (semver vs release branch) |

--- a/scripts/workflows/bump_version.py
+++ b/scripts/workflows/bump_version.py
@@ -16,7 +16,7 @@ missing a version field, the script fails without modifying anything.
 
 ─────────────────────────────────────────────────────────────────────────────
 CI DEPENDENCY - this script is called directly by the release gate workflow:
-  .github/workflows/checks/version-check.yml
+  .github/workflows/_check-version.yml
     → python3 scripts/workflows/bump_version.py --check          (all 11 files match)
     → python3 scripts/workflows/bump_version.py --check-release  (version > release branch)
 

--- a/scripts/workflows/check_drift.py
+++ b/scripts/workflows/check_drift.py
@@ -9,7 +9,7 @@ Exits 1 if any drift is detected, with a summary of what changed.
 
 ─────────────────────────────────────────────────────────────────────────────
 CI DEPENDENCY - called by the codegen sync check:
-  .github/workflows/checks/codegen-sync.yml
+  .github/workflows/_check-codegen-sync.yml
     → python3 scripts/workflows/check_drift.py \\
         apps/syn-cli-node/src/generated/ \\
         apps/syn-docs/content/docs/cli/ \\


### PR DESCRIPTION
## Summary

GitHub Actions does not support reusable workflows in subdirectories of `.github/workflows/`. Our refactor in #664 moved the four composable check workflows into `.github/workflows/checks/` which silently broke `release-gate.yml` and `release-create.yml` — runs appeared with 0 jobs and the filename as the run name, with error `invalid value workflow reference: workflows must be defined at the top level of the .github/workflows/ directory`.

This PR flattens the structure back out using a `_check-` prefix as a visual grouping convention for reusable-only workflows, and captures the constraint in inline comments so it can't silently regress again.

## Changes

- Rename `.github/workflows/checks/{version,changelog,codegen-sync,docker-dry-run}.yml` → `.github/workflows/_check-*.yml`
- Update `uses:` references in `release-gate.yml` and `release-create.yml`
- Update CI-dependency comment blocks in `scripts/workflows/bump_version.py` and `check_drift.py`
- Update `docs/release-process.md` workflow table
- Add rationale comment to `_check-version.yml` explaining the flat-layout requirement
- Short pointer comments in the other three check files referencing `_check-version.yml` for the full story

## Test plan

This PR itself IS the test — if Release Gate runs successfully here, the fix is validated.

- [ ] Release Gate workflow fires and completes (version-check, changelog-check, codegen-sync, docker-dry-run, security scans)
- [ ] After merge, `release-create.yml` fires and the v0.25.0 release pipeline unblocks

## Release Notes

Bug fix: Release Gate and release-create workflows were broken after the #664 refactor. Flattening the reusable-workflow layout restores the release pipeline. No behavioral changes to the checks themselves.