### PR TITLE
Release v0.25.1 (main → release)

### DIFF
--- a/.github/workflows/_check-changelog.yml
+++ b/.github/workflows/_check-changelog.yml
@@ -5,6 +5,10 @@
 # The PR body is used verbatim as the GitHub Release description.
 #
 # Called by: release-gate.yml
+#
+# NOTE: reusable workflows must live at the top of .github/workflows/ — no
+# subdirectories allowed (GitHub rejects with "invalid workflow reference").
+# See _check-version.yml for the full story.
 # =============================================================================
 
 name: Check - Release Notes

--- a/.github/workflows/_check-codegen-sync.yml
+++ b/.github/workflows/_check-codegen-sync.yml
@@ -52,6 +52,7 @@ jobs:
         run: |
           pnpm --filter @syntropic137/cli install --frozen-lockfile
           pnpm --filter syn-docs install --frozen-lockfile
+          pnpm --filter syn-dashboard-ui install --frozen-lockfile
 
       - name: Regenerate all artifacts
         run: just codegen

--- a/.github/workflows/_check-codegen-sync.yml
+++ b/.github/workflows/_check-codegen-sync.yml
@@ -12,6 +12,10 @@
 # To fix a failure locally: just codegen && git add -A && git commit
 #
 # Called by: release-gate.yml, release-create.yml (pre-publish validation)
+#
+# NOTE: reusable workflows must live at the top of .github/workflows/ — no
+# subdirectories allowed (GitHub rejects with "invalid workflow reference").
+# See _check-version.yml for the full story.
 # =============================================================================
 
 name: Check - Codegen Sync

--- a/.github/workflows/_check-docker-dry-run.yml
+++ b/.github/workflows/_check-docker-dry-run.yml
@@ -8,6 +8,10 @@
 # per-image scope) makes unchanged images near-instant on subsequent runs.
 #
 # Called by: release-gate.yml
+#
+# NOTE: reusable workflows must live at the top of .github/workflows/ — no
+# subdirectories allowed (GitHub rejects with "invalid workflow reference").
+# See _check-version.yml for the full story.
 # =============================================================================
 
 name: Check - Docker Dry-Run

--- a/.github/workflows/_check-version.yml
+++ b/.github/workflows/_check-version.yml
@@ -5,6 +5,13 @@
 # what's currently on the release branch.
 #
 # Called by: release-gate.yml
+#
+# NOTE on the `_check-` prefix and flat layout:
+# GitHub Actions does NOT support reusable workflows in subdirectories of
+# .github/workflows/ — they MUST live at the top level. Moving them into a
+# `checks/` subdir produces a cryptic "invalid workflow reference" failure
+# with 0 jobs and the path-as-name in the UI. The `_check-` prefix is our
+# convention for grouping reusable-only (workflow_call) workflows visually.
 # =============================================================================
 
 name: Check - Version Consistency

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -120,13 +120,17 @@ jobs:
           echo "Created release: ${{ steps.version.outputs.version }}"
 
   # ---------------------------------------------------------------------------
-  # Step 2: Pre-publish validation — codegen sync (reuses checks/codegen-sync.yml)
+  # Step 2: Pre-publish validation — codegen sync (reuses _check-codegen-sync.yml)
+  #
+  # NOTE: reusable workflows must live at the top of .github/workflows/ — no
+  # subdirectories. The `_check-*` prefix visually groups them. See
+  # _check-codegen-sync.yml for the constraint.
   # ---------------------------------------------------------------------------
   pre-publish-validation:
     name: Pre-Publish Validation
     needs: [create-release]
     if: needs.create-release.outputs.created == 'true'
-    uses: ./.github/workflows/checks/codegen-sync.yml
+    uses: ./.github/workflows/_check-codegen-sync.yml
 
   # ---------------------------------------------------------------------------
   # Step 3: Build, sign, push Docker images + attach release assets

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -13,7 +13,9 @@
 #
 # Full CI (tests, lint, typecheck) also runs on these PRs via ci.yml.
 #
-# Each check lives in .github/workflows/checks/ as a reusable workflow.
+# Each check lives in .github/workflows/ with the `_check-` prefix as a
+# reusable workflow. (GitHub Actions does not support subdirectories for
+# reusable workflows — they must be at the top level.)
 # =============================================================================
 
 name: Release Gate
@@ -29,20 +31,25 @@ permissions:
 jobs:
   # ---------------------------------------------------------------------------
   # Reusable checks
+  #
+  # NOTE: GitHub Actions does NOT support reusable workflows in subdirectories
+  # of .github/workflows/ — they must live at the top level. The `_check-*`
+  # prefix visually groups them and signals they only fire via workflow_call
+  # (they appear as greyed-out entries in the Actions sidebar).
   # ---------------------------------------------------------------------------
   version-check:
-    uses: ./.github/workflows/checks/version-check.yml
+    uses: ./.github/workflows/_check-version.yml
 
   changelog-check:
-    uses: ./.github/workflows/checks/changelog-check.yml
+    uses: ./.github/workflows/_check-changelog.yml
     with:
       pr_body: ${{ github.event.pull_request.body }}
 
   codegen-sync:
-    uses: ./.github/workflows/checks/codegen-sync.yml
+    uses: ./.github/workflows/_check-codegen-sync.yml
 
   docker-dry-run:
-    uses: ./.github/workflows/checks/docker-dry-run.yml
+    uses: ./.github/workflows/_check-docker-dry-run.yml
 
   # ---------------------------------------------------------------------------
   # Security Scans — inline (not duplicated elsewhere, no extraction needed)

--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.25.0"
+version = "0.25.1"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli-node/package.json
+++ b/apps/syn-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntropic137/cli",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Syntropic137 CLI - Event-sourced workflow engine for AI agents",
   "type": "module",
   "bin": {

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.25.0",
+  "version": "0.25.1",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-docs/package.json
+++ b/apps/syn-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-docs",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -264,10 +264,10 @@ Merge to release
 |------|---------|
 | `.github/workflows/release-gate.yml` | Thin orchestrator - calls checks + inline security scans |
 | `.github/workflows/release-create.yml` | Release pipeline - create tag/release, publish containers + CLI |
-| `.github/workflows/checks/version-check.yml` | Version consistency: all 11 files match, bumped vs release |
-| `.github/workflows/checks/changelog-check.yml` | PR body length validation (takes `pr_body` input) |
-| `.github/workflows/checks/codegen-sync.yml` | Runs `just codegen`, checks for drift (CLI types, API docs, CLI docs) |
-| `.github/workflows/checks/docker-dry-run.yml` | All container images build successfully (single-arch, GHA cache) |
+| `.github/workflows/_check-version.yml` | Version consistency: all 11 files match, bumped vs release |
+| `.github/workflows/_check-changelog.yml` | PR body length validation (takes `pr_body` input) |
+| `.github/workflows/_check-codegen-sync.yml` | Runs `just codegen`, checks for drift (CLI types, API docs, CLI docs) |
+| `.github/workflows/_check-docker-dry-run.yml` | All container images build successfully (single-arch, GHA cache) |
 | `.github/workflows/release-containers.yaml` | Multi-arch build, cosign sign, push to GHCR, release assets |
 | `.github/workflows/release-cli.yaml` | Build + publish `@syntropic137/cli` to npm (OIDC, provenance) |
 | `scripts/workflows/bump_version.py` | Version bump script; `--check` (consistency) and `--check-release` (semver vs release branch) |

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.25.0"
+version = "0.25.1"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.25.0"
+version = "0.25.1"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.25.0"
+version = "0.25.1"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.25.0"
+version = "0.25.1"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.25.0"
+version = "0.25.1"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.25.0"
+version = "0.25.1"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.25.0"
+version = "0.25.1"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/workflows/bump_version.py
+++ b/scripts/workflows/bump_version.py
@@ -16,7 +16,7 @@ missing a version field, the script fails without modifying anything.
 
 ─────────────────────────────────────────────────────────────────────────────
 CI DEPENDENCY - this script is called directly by the release gate workflow:
-  .github/workflows/checks/version-check.yml
+  .github/workflows/_check-version.yml
     → python3 scripts/workflows/bump_version.py --check          (all 11 files match)
     → python3 scripts/workflows/bump_version.py --check-release  (version > release branch)
 

--- a/scripts/workflows/check_drift.py
+++ b/scripts/workflows/check_drift.py
@@ -9,7 +9,7 @@ Exits 1 if any drift is detected, with a summary of what changed.
 
 ─────────────────────────────────────────────────────────────────────────────
 CI DEPENDENCY - called by the codegen sync check:
-  .github/workflows/checks/codegen-sync.yml
+  .github/workflows/_check-codegen-sync.yml
     → python3 scripts/workflows/check_drift.py \\
         apps/syn-cli-node/src/generated/ \\
         apps/syn-docs/content/docs/cli/ \\


### PR DESCRIPTION
## Summary

Release v0.25.1 — patch over v0.25.0 that never published due to the workflow-subdirectory issue fixed in 7bd3bfe4.

## Commits on main ahead of release

- `7bd3bfe4` fix(ci): flatten release-gate reusable workflows (subdirs not supported)
- `b80b7903` fix(ci): install syn-dashboard-ui deps in codegen-sync check
- `59edb0b9` chore: bump version to v0.25.1

## Context

The v0.25.0 release pipeline never fired after PR #664 merged because `release-gate.yml` and `release-create.yml` referenced reusable workflows in `.github/workflows/checks/` — a subdirectory — which GitHub Actions rejects with a cryptic "invalid workflow reference" (runs appeared with 0 jobs and the filename as the run name).

This PR flattens the layout using a `_check-` prefix convention for reusable-only workflows, fixes a pre-existing codegen-sync workflow bug (missing `syn-dashboard-ui` install), and bumps to v0.25.1 to test the full release end-to-end.

## Release Notes

**Infrastructure / CI only — no user-facing changes.**

- Fix: `release-gate` and `release-create` workflows now resolve after refactor
- Fix: `codegen-sync` check installs dashboard-ui deps so `just codegen` completes
- Chore: version bump to v0.25.1

## Test plan

- [ ] Release Gate workflow passes on this PR
- [ ] After merge, `release-create.yml` fires on push to release
- [ ] v0.25.1 tag created, GitHub Release published
- [ ] Container images pushed to GHCR (syn-api, syn-gateway, syn-collector, syn-dashboard-ui)
- [ ] `@syntropic137/cli@0.25.1` published to npm via OIDC
- [ ] NPX repo template-sync fires
- [ ] Docs site deploys to Vercel prod