### PR TITLE
fix(v0.25.2): close 3 P0 release blockers from post-v0.25.1 validation

### DIFF
--- a/apps/syn-api/src/syn_api/_wiring.py
+++ b/apps/syn-api/src/syn_api/_wiring.py
@@ -168,6 +168,17 @@ def _build_claude_command(
     return cmd
 
 
+def _owner_repo_from_url(url: str | None) -> str:
+    """Extract owner/repo from a GitHub HTTPS URL. Empty string if not a github URL."""
+    if not url:
+        return ""
+    stripped = url.rstrip("/").removesuffix(".git")
+    parts = stripped.split("/")
+    if len(parts) >= 5 and parts[2] == "github.com":
+        return f"{parts[3]}/{parts[4]}"
+    return ""
+
+
 def _substitute_builtins(
     template: str,
     execution_id: str,
@@ -178,6 +189,19 @@ def _substitute_builtins(
     result = template.replace("{{execution_id}}", execution_id)
     result = result.replace("{{workflow_id}}", workflow_id)
     result = result.replace("{{repo_url}}", repo_url or "")
+    # {{repository}} is a deprecated single-repo convenience -- derived from the
+    # primary repo's URL as owner/repo. Tracked for removal in #715.
+    # Multi-repo workflows should use {{repos}} (CSV of HTTPS URLs) or discover
+    # repos from /workspace/repos/ at runtime instead.
+    if "{{repository}}" in result:
+        logger.warning(
+            "Workflow %s uses deprecated {{repository}} template variable. "
+            "It will be removed in a future release. Migrate to /workspace/repos/ "
+            "discovery (single-repo) or {{repos}} (multi-repo). "
+            "Track: https://github.com/syntropic137/syntropic137/issues/715",
+            workflow_id,
+        )
+        result = result.replace("{{repository}}", _owner_repo_from_url(repo_url))
     return result
 
 

--- a/apps/syn-api/src/syn_api/routes/executions/commands.py
+++ b/apps/syn-api/src/syn_api/routes/executions/commands.py
@@ -120,14 +120,18 @@ def _apply_repo_substitution(repos: list[str], merged: dict[str, str]) -> list[s
 
 
 def _get_preflight_repos(
+    typed_repos: list[RepositoryRef],
     effective_inputs: dict[str, str],
     workflow: WorkflowTemplateAggregate,
     task: str | None,
 ) -> list[str]:
-    """Resolve the list of repos to preflight-validate for GitHub App access."""
-    repos_csv = effective_inputs.get("repos", "")
-    if repos_csv:
-        return [u.strip() for u in repos_csv.split(",") if u.strip()]
+    """Resolve the list of repos to preflight-validate for GitHub App access.
+
+    ADR-063: typed ``repos`` from the request take precedence; we read
+    ``r.https_url`` directly rather than re-parsing a CSV string.
+    """
+    if typed_repos:
+        return [r.https_url for r in typed_repos]
 
     # Check workflow.repos with variable substitution (mirrors ExecuteWorkflowHandler._resolve_repos).
     # Without this, unresolved {{variable}} patterns in repos silently fall through to
@@ -453,20 +457,27 @@ async def _validate_execution_request(
                 detail=f"Invalid repository entry '{repo}': {exc}",
             ) from exc
 
-    # Preflight needs the resolved URLs under effective_inputs["repos"]; this is an
-    # internal plumbing channel, not a user-facing input key.
+    # ADR-063: repository identity travels as typed RepositoryRef through preflight
+    # and the processor. Do not smuggle it through inputs - reserved-key rejection
+    # above guarantees user inputs cannot collide with this channel.
     effective_inputs: dict[str, str] = dict(request.inputs)
-    if request.repos:
-        effective_inputs["repos"] = ",".join(request.repos)
 
     # Validate required input declarations (always runs)
     merged = _merge_inputs(workflow, effective_inputs, request.task)
     _check_missing_declarations(workflow, merged)
 
-    # Repo validation only when the workflow requires repos (ADR-058 #666)
+    # Repo validation only when the workflow requires repos (ADR-058 #666).
+    # ADR-063: this block fully covers what ExecuteWorkflowHandler._resolve_repos
+    # could raise downstream - RepositoryRef.parse runs above for typed repos,
+    # _check_repo_url_placeholders catches unresolved {{var}} in workflow.repos,
+    # and the reserved-key rejection guards against inputs[repos] / inputs[repository].
+    # Anything else surfacing in BackgroundTask is a real infra failure, not a
+    # validation gap.
     if workflow.requires_repos:
         _check_repo_url_placeholders(workflow, merged)
-        preflight_repos = _get_preflight_repos(effective_inputs, workflow, request.task)
+        preflight_repos = _get_preflight_repos(
+            typed_repos, effective_inputs, workflow, request.task
+        )
         await _validate_all_repos_access(preflight_repos)
 
     return workflow, effective_inputs, typed_repos

--- a/apps/syn-api/src/syn_api/routes/executions/commands.py
+++ b/apps/syn-api/src/syn_api/routes/executions/commands.py
@@ -247,21 +247,6 @@ def _check_repo_url_placeholders(
     )
 
 
-def _validate_required_inputs(
-    workflow: WorkflowTemplateAggregate,
-    inputs: dict[str, str],
-    task: str | None,
-) -> None:
-    """Eagerly validate that all required inputs are satisfied.
-
-    Checks required InputDeclarations and unresolved {{placeholder}} patterns.
-    Raises HTTPException(422) with a clear message listing what's missing.
-    """
-    merged = _merge_inputs(workflow, inputs, task)
-    _check_missing_declarations(workflow, merged)
-    _check_repo_url_placeholders(workflow, merged)
-
-
 router = APIRouter(prefix="/workflows", tags=["execution"])
 
 
@@ -284,9 +269,10 @@ class ExecuteWorkflowRequest(BaseModel):
     repos: list[str] = Field(
         default_factory=list,
         description=(
-            "GitHub URLs to pre-clone for workspace hydration (ADR-058). "
-            "Overrides the workflow template's repository_url. "
-            "Equivalent to passing inputs={'repos': 'url1,url2'} but type-safe."
+            "GitHub URLs or 'owner/repo' slugs to pre-clone for workspace hydration "
+            "(ADR-058, ADR-063). Typed channel for repository identity: one execution "
+            "can touch 0, 1, or N repos. Passing 'repository' or 'repos' in the `inputs` "
+            "dict is rejected with 422."
         ),
     )
     provider: str = Field(
@@ -407,8 +393,7 @@ async def execute(
         logger.exception("Workflow execution error for %s", workflow_id)
         return Err(WorkflowError.EXECUTION_FAILED, message=str(e))
 
-    repos_csv = (inputs or {}).get("repos", "")
-    repo_urls = [r.strip() for r in repos_csv.split(",") if r.strip()] if repos_csv else []
+    repo_urls = [r.https_url for r in (repos or [])]
     return Ok(
         ExecutionSummary(
             workflow_execution_id=result.execution_id,
@@ -429,6 +414,9 @@ async def execute(
 # -- HTTP Endpoints -----------------------------------------------------------
 
 
+_RESERVED_REPO_INPUT_KEYS: frozenset[str] = frozenset({"repos", "repository"})
+
+
 async def _validate_execution_request(
     workflow_id: str,
     request: ExecuteWorkflowRequest,
@@ -439,6 +427,20 @@ async def _validate_execution_request(
     workflow = await workflow_repo.get_by_id(workflow_id)
     if workflow is None:
         raise HTTPException(status_code=404, detail=f"Workflow {workflow_id} not found")
+
+    # ADR-063: repository identity is typed on `repos[]`, not smuggled through `inputs`.
+    # Reject at the boundary so silent-success-then-BackgroundTask-failure can't happen.
+    leaked = _RESERVED_REPO_INPUT_KEYS & request.inputs.keys()
+    if leaked:
+        keys = ", ".join(f"'{k}'" for k in sorted(leaked))
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"{keys} is not a valid input key. "
+                "Pass repositories in the typed 'repos' array "
+                "(CLI: -R <owner/repo>, repeatable)."
+            ),
+        )
 
     # ADR-063: convert string URLs to typed RepositoryRef at the API boundary
     typed_repos: list[RepositoryRef] = []
@@ -451,7 +453,8 @@ async def _validate_execution_request(
                 detail=f"Invalid repository entry '{repo}': {exc}",
             ) from exc
 
-    # Build effective inputs (legacy CSV preserved for backward compat)
+    # Preflight needs the resolved URLs under effective_inputs["repos"]; this is an
+    # internal plumbing channel, not a user-facing input key.
     effective_inputs: dict[str, str] = dict(request.inputs)
     if request.repos:
         effective_inputs["repos"] = ",".join(request.repos)

--- a/apps/syn-api/src/syn_api/routes/triggers/commands.py
+++ b/apps/syn-api/src/syn_api/routes/triggers/commands.py
@@ -62,8 +62,13 @@ async def _resolve_installation_id(installation_id: str, repository: str) -> str
     P0-3: the CLI registers triggers with syn `repo-*` IDs. Those are
     unknown to the GitHub API, so we first resolve them to `owner/name`
     via the repo projection, then ask the App which installation owns
-    that repo. Returns `""` if resolution fails at any step — the poller
-    re-resolves on first fire.
+    that repo.
+
+    Returns `""` if resolution fails at any step. The trigger is then
+    persisted with empty installation_id and is silently skipped at
+    polling time (see ``event_ingestion._get_repos_to_poll``) until the
+    operator re-registers it. Lazy re-resolution at polling time is
+    tracked separately as #713 for v0.26+.
     """
     if installation_id or not repository:
         return installation_id
@@ -72,7 +77,8 @@ async def _resolve_installation_id(installation_id: str, repository: str) -> str
     if full_name is None:
         logger.warning(
             "Could not resolve repository identifier '%s' to owner/name; "
-            "trigger will be persisted with installation_id='' and re-resolve later",
+            "trigger will be persisted with installation_id='' and skipped at "
+            "polling - re-register after the App is installed on the repo",
             repository,
         )
         return ""
@@ -86,7 +92,9 @@ async def _resolve_installation_id(installation_id: str, repository: str) -> str
         return str(resolved)
     except Exception:
         logger.warning(
-            "Could not auto-resolve installation_id for %s",
+            "Could not auto-resolve installation_id for %s; "
+            "trigger will be persisted with installation_id='' and skipped at "
+            "polling - re-register after the App is installed on the repo",
             full_name,
             exc_info=True,
         )

--- a/apps/syn-api/src/syn_api/routes/triggers/commands.py
+++ b/apps/syn-api/src/syn_api/routes/triggers/commands.py
@@ -36,24 +36,61 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/triggers", tags=["triggers"])
 
 
+async def _resolve_repo_full_name(repository: str) -> str | None:
+    """Resolve a repository identifier to its GitHub `owner/name` form.
+
+    - `repo-*` (syn internal ID): look up via the repo projection.
+    - `owner/name` (GitHub standard): passed through.
+    - Anything else: `None` (caller treats as unresolvable).
+    """
+    if repository.startswith("repo-"):
+        from syn_domain.contexts.organization import get_repo_projection
+
+        projection = get_repo_projection()
+        repo = await projection.get(repository)
+        return repo.full_name if repo is not None else None
+
+    if "/" in repository:
+        return repository
+
+    return None
+
+
 async def _resolve_installation_id(installation_id: str, repository: str) -> str:
-    """Auto-resolve installation_id from the GitHub App if not provided."""
+    """Auto-resolve installation_id from the GitHub App if not provided.
+
+    P0-3: the CLI registers triggers with syn `repo-*` IDs. Those are
+    unknown to the GitHub API, so we first resolve them to `owner/name`
+    via the repo projection, then ask the App which installation owns
+    that repo. Returns `""` if resolution fails at any step — the poller
+    re-resolves on first fire.
+    """
     if installation_id or not repository:
         return installation_id
+
+    full_name = await _resolve_repo_full_name(repository)
+    if full_name is None:
+        logger.warning(
+            "Could not resolve repository identifier '%s' to owner/name; "
+            "trigger will be persisted with installation_id='' and re-resolve later",
+            repository,
+        )
+        return ""
+
     try:
         from syn_adapters.github.client import get_github_client
 
         client = get_github_client()
-        resolved = await client.get_installation_for_repo(repository)
-        logger.info("Auto-resolved installation_id=%s for %s", resolved, repository)
+        resolved = await client.get_installation_for_repo(full_name)
+        logger.info("Auto-resolved installation_id=%s for %s", resolved, full_name)
         return str(resolved)
     except Exception:
         logger.warning(
             "Could not auto-resolve installation_id for %s",
-            repository,
+            full_name,
             exc_info=True,
         )
-        return installation_id
+        return ""
 
 
 async def register_trigger(

--- a/apps/syn-api/tests/test_api_triggers.py
+++ b/apps/syn-api/tests/test_api_triggers.py
@@ -421,3 +421,111 @@ async def test_full_lifecycle():
     assert isinstance(await delete_trigger(tid), Ok)
     detail = await get_trigger(tid)
     assert detail.value.status == "deleted"
+
+
+# -- Installation ID resolver (P0-3 regression) -------------------------------
+
+
+class TestResolveInstallationId:
+    """`_resolve_installation_id` accepts syn `repo-*` IDs and `owner/name` alike."""
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_installation_id_already_set(self) -> None:
+        from syn_api.routes.triggers.commands import _resolve_installation_id
+
+        assert await _resolve_installation_id("12345", "owner/repo") == "12345"
+
+    @pytest.mark.asyncio
+    async def test_empty_when_repository_empty(self) -> None:
+        from syn_api.routes.triggers.commands import _resolve_installation_id
+
+        assert await _resolve_installation_id("", "") == ""
+
+    @pytest.mark.asyncio
+    async def test_resolves_repo_id_via_projection(self) -> None:
+        """`repo-*` IDs are resolved via repo projection, then passed to the App."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from syn_api.routes.triggers.commands import _resolve_installation_id
+
+        mock_repo = MagicMock()
+        mock_repo.full_name = "acme/widgets"
+        mock_projection = MagicMock()
+        mock_projection.get = AsyncMock(return_value=mock_repo)
+
+        mock_client = MagicMock()
+        mock_client.get_installation_for_repo = AsyncMock(return_value="99999")
+
+        with (
+            patch(
+                "syn_domain.contexts.organization.get_repo_projection",
+                return_value=mock_projection,
+            ),
+            patch(
+                "syn_adapters.github.client.get_github_client",
+                return_value=mock_client,
+            ),
+        ):
+            result = await _resolve_installation_id("", "repo-abc123")
+
+        assert result == "99999"
+        mock_projection.get.assert_awaited_once_with("repo-abc123")
+        mock_client.get_installation_for_repo.assert_awaited_once_with("acme/widgets")
+
+    @pytest.mark.asyncio
+    async def test_owner_name_passes_straight_through(self) -> None:
+        """`owner/name` goes straight to the App — no projection lookup."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from syn_api.routes.triggers.commands import _resolve_installation_id
+
+        mock_client = MagicMock()
+        mock_client.get_installation_for_repo = AsyncMock(return_value="42")
+
+        with patch(
+            "syn_adapters.github.client.get_github_client",
+            return_value=mock_client,
+        ):
+            result = await _resolve_installation_id("", "acme/widgets")
+
+        assert result == "42"
+        mock_client.get_installation_for_repo.assert_awaited_once_with("acme/widgets")
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_when_repo_id_not_in_projection(self) -> None:
+        """Unknown `repo-*` ID → empty installation_id, poller re-resolves later."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from syn_api.routes.triggers.commands import _resolve_installation_id
+
+        mock_projection = MagicMock()
+        mock_projection.get = AsyncMock(return_value=None)
+
+        with patch(
+            "syn_domain.contexts.organization.get_repo_projection",
+            return_value=mock_projection,
+        ):
+            result = await _resolve_installation_id("", "repo-unknown")
+
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_on_github_auth_failure(self) -> None:
+        """App not installed on repo → empty installation_id, persist pending."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from syn_adapters.github.client import GitHubAuthError
+        from syn_api.routes.triggers.commands import _resolve_installation_id
+
+        mock_client = MagicMock()
+        mock_client.get_installation_for_repo = AsyncMock(
+            side_effect=GitHubAuthError("not installed")
+        )
+
+        with patch(
+            "syn_adapters.github.client.get_github_client",
+            return_value=mock_client,
+        ):
+            result = await _resolve_installation_id("", "acme/widgets")
+
+        assert result == ""

--- a/apps/syn-api/tests/test_execute_repo_validation.py
+++ b/apps/syn-api/tests/test_execute_repo_validation.py
@@ -257,8 +257,24 @@ class TestRequiresReposPreflightGating:
         from syn_api.routes.executions.commands import _get_preflight_repos
 
         wf = self._make_workflow(repo_url="", requires_repos=False)
-        repos = _get_preflight_repos({}, wf, None)
+        repos = _get_preflight_repos([], {}, wf, None)
         assert repos == []
+
+    def test_get_preflight_repos_uses_typed_repos(self) -> None:
+        """Typed RepositoryRef list flows directly into preflight URLs (no CSV detour)."""
+        from syn_api.routes.executions.commands import _get_preflight_repos
+        from syn_domain.contexts._shared.repository_ref import RepositoryRef
+
+        wf = self._make_workflow(repo_url="", requires_repos=True)
+        typed = [
+            RepositoryRef.from_slug("owner/a"),
+            RepositoryRef.from_url("https://github.com/owner/b"),
+        ]
+        repos = _get_preflight_repos(typed, {}, wf, None)
+        assert repos == [
+            "https://github.com/owner/a",
+            "https://github.com/owner/b",
+        ]
 
     @pytest.mark.asyncio
     async def test_validate_all_repos_noop_on_empty_list(self) -> None:
@@ -373,7 +389,11 @@ class TestReservedRepoInputKeyRejection:
 
     @pytest.mark.asyncio
     async def test_typed_repos_field_is_accepted(self) -> None:
-        """The typed `repos: list[str]` field is the canonical channel — no rejection."""
+        """The typed `repos: list[str]` field is the canonical channel — no rejection.
+
+        ADR-063: typed repos do NOT leak back into ``effective_inputs`` as a CSV
+        string. Repository identity travels as ``RepositoryRef`` end-to-end.
+        """
         from syn_api.routes.executions.commands import (
             ExecuteWorkflowRequest,
             _validate_execution_request,
@@ -406,4 +426,5 @@ class TestReservedRepoInputKeyRejection:
         assert len(typed_repos) == 2
         assert typed_repos[0].https_url == "https://github.com/owner/a"
         assert typed_repos[1].https_url == "https://github.com/owner/b"
-        assert effective_inputs["repos"] == "https://github.com/owner/a,owner/b"
+        assert "repos" not in effective_inputs
+        assert "repository" not in effective_inputs

--- a/apps/syn-api/tests/test_execute_repo_validation.py
+++ b/apps/syn-api/tests/test_execute_repo_validation.py
@@ -292,3 +292,118 @@ class TestRequiresReposPreflightGating:
             _check_missing_declarations(wf, merged)
         assert exc_info.value.status_code == 422
         assert "task" in str(exc_info.value.detail)
+
+
+# -- Reserved repo input-key rejection (ADR-063 boundary) ---------------------
+
+
+class TestReservedRepoInputKeyRejection:
+    """'repository' and 'repos' as input keys are rejected at the HTTP boundary.
+
+    Regression: CLI used to send --input repository=X as a generic input, API
+    returned 200 + BackgroundTask, handler's _resolve_repos raised ValueError
+    inside the task. The silent-success-then-404 is fixed by synchronous 422.
+    """
+
+    @pytest.mark.asyncio
+    async def test_rejects_singular_repository_input_key(self) -> None:
+        from fastapi import HTTPException
+
+        from syn_api.routes.executions.commands import (
+            ExecuteWorkflowRequest,
+            _validate_execution_request,
+        )
+
+        wf = MagicMock()
+        wf.requires_repos = True
+        wf.input_declarations = []
+
+        with (
+            patch(
+                "syn_api.routes.executions.commands.get_workflow_repo",
+                return_value=MagicMock(get_by_id=AsyncMock(return_value=wf)),
+            ),
+            patch(
+                "syn_api.routes.executions.commands.ensure_connected",
+                new=AsyncMock(),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await _validate_execution_request(
+                "wf-1",
+                ExecuteWorkflowRequest(inputs={"repository": "owner/repo"}, repos=[]),
+            )
+
+        assert exc_info.value.status_code == 422
+        detail = str(exc_info.value.detail)
+        assert "'repository'" in detail
+        assert "-R" in detail
+
+    @pytest.mark.asyncio
+    async def test_rejects_plural_repos_input_key(self) -> None:
+        from fastapi import HTTPException
+
+        from syn_api.routes.executions.commands import (
+            ExecuteWorkflowRequest,
+            _validate_execution_request,
+        )
+
+        wf = MagicMock()
+        wf.requires_repos = True
+        wf.input_declarations = []
+
+        with (
+            patch(
+                "syn_api.routes.executions.commands.get_workflow_repo",
+                return_value=MagicMock(get_by_id=AsyncMock(return_value=wf)),
+            ),
+            patch(
+                "syn_api.routes.executions.commands.ensure_connected",
+                new=AsyncMock(),
+            ),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await _validate_execution_request(
+                "wf-1",
+                ExecuteWorkflowRequest(inputs={"repos": "owner/a,owner/b"}, repos=[]),
+            )
+
+        assert exc_info.value.status_code == 422
+        assert "'repos'" in str(exc_info.value.detail)
+
+    @pytest.mark.asyncio
+    async def test_typed_repos_field_is_accepted(self) -> None:
+        """The typed `repos: list[str]` field is the canonical channel — no rejection."""
+        from syn_api.routes.executions.commands import (
+            ExecuteWorkflowRequest,
+            _validate_execution_request,
+        )
+
+        wf = MagicMock()
+        wf.requires_repos = False
+        wf.input_declarations = []
+        wf.repos = []
+        wf._repository_url = ""
+
+        with (
+            patch(
+                "syn_api.routes.executions.commands.get_workflow_repo",
+                return_value=MagicMock(get_by_id=AsyncMock(return_value=wf)),
+            ),
+            patch(
+                "syn_api.routes.executions.commands.ensure_connected",
+                new=AsyncMock(),
+            ),
+        ):
+            _, effective_inputs, typed_repos = await _validate_execution_request(
+                "wf-1",
+                ExecuteWorkflowRequest(
+                    inputs={},
+                    repos=["https://github.com/owner/a", "owner/b"],
+                ),
+            )
+
+        assert len(typed_repos) == 2
+        assert typed_repos[0].https_url == "https://github.com/owner/a"
+        assert typed_repos[1].https_url == "https://github.com/owner/b"
+        assert effective_inputs["repos"] == "https://github.com/owner/a,owner/b"

--- a/apps/syn-api/tests/test_prompt_builtins.py
+++ b/apps/syn-api/tests/test_prompt_builtins.py
@@ -1,0 +1,66 @@
+"""Tests for built-in template variable substitution in workspace prompts.
+
+Covers ``{{execution_id}}``, ``{{workflow_id}}``, ``{{repo_url}}``, and
+``{{repository}}`` -- the last of which is derived from ``repo_url`` so legacy
+single-repo workflows can keep the familiar ``{{repository}}`` placeholder
+after the v0.25.2 ADR-063 migration drops it from input declarations.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from syn_api._wiring import _owner_repo_from_url, _substitute_builtins
+
+
+@pytest.mark.unit
+class TestOwnerRepoFromUrl:
+    def test_https_url_returns_owner_repo(self) -> None:
+        assert _owner_repo_from_url("https://github.com/acme/widgets") == "acme/widgets"
+
+    def test_trailing_slash_stripped(self) -> None:
+        assert _owner_repo_from_url("https://github.com/acme/widgets/") == "acme/widgets"
+
+    def test_dot_git_suffix_stripped(self) -> None:
+        assert _owner_repo_from_url("https://github.com/acme/widgets.git") == "acme/widgets"
+
+    def test_none_returns_empty(self) -> None:
+        assert _owner_repo_from_url(None) == ""
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert _owner_repo_from_url("") == ""
+
+    def test_non_github_url_returns_empty(self) -> None:
+        assert _owner_repo_from_url("https://gitlab.com/acme/widgets") == ""
+
+
+@pytest.mark.unit
+class TestSubstituteBuiltins:
+    def test_repository_substituted_from_repo_url(self) -> None:
+        result = _substitute_builtins(
+            "review {{repository}}#{{repo_url}}",
+            execution_id="exec-1",
+            workflow_id="wf-1",
+            repo_url="https://github.com/acme/widgets",
+        )
+        assert "acme/widgets" in result
+        assert "https://github.com/acme/widgets" in result
+        assert "{{repository}}" not in result
+
+    def test_repository_empty_when_no_repo_url(self) -> None:
+        result = _substitute_builtins(
+            "repo={{repository}}",
+            execution_id="exec-1",
+            workflow_id="wf-1",
+            repo_url=None,
+        )
+        assert result == "repo="
+
+    def test_all_builtins_replaced(self) -> None:
+        result = _substitute_builtins(
+            "x={{execution_id}} y={{workflow_id}} z={{repository}}",
+            execution_id="exec-1",
+            workflow_id="wf-1",
+            repo_url="https://github.com/o/r",
+        )
+        assert result == "x=exec-1 y=wf-1 z=o/r"

--- a/apps/syn-cli-node/src/commands/control.ts
+++ b/apps/syn-cli-node/src/commands/control.ts
@@ -7,7 +7,7 @@ import { CommandGroup, type CommandDef, type ParsedArgs } from "../framework/com
 import { CLIError } from "../framework/errors.js";
 import { api, unwrap } from "../client/typed.js";
 import type { components } from "../generated/api-types.js";
-import { print, printError } from "../output/console.js";
+import { print, printError, printDim } from "../output/console.js";
 import { style, GREEN, YELLOW } from "../output/ansi.js";
 import { formatStatus } from "../output/format.js";
 
@@ -16,7 +16,11 @@ type StateResponse = components["schemas"]["StateResponse"];
 
 function reqId(parsed: ParsedArgs): string {
   const id = parsed.positionals[0];
-  if (!id) { printError("Missing execution-id"); throw new CLIError("Missing argument", 1); }
+  if (!id) {
+    printError("execution-id is required");
+    printDim("Hint: run `syn execution list` to find an execution ID.");
+    throw new CLIError("Missing argument", 1);
+  }
   return id;
 }
 

--- a/apps/syn-cli-node/src/commands/execution.ts
+++ b/apps/syn-cli-node/src/commands/execution.ts
@@ -83,7 +83,11 @@ const showCommand: CommandDef = {
   args: [{ name: "execution-id", description: "Execution ID", required: true }],
   handler: async (parsed: ParsedArgs) => {
     const id = parsed.positionals[0];
-    if (!id) { printError("Missing execution-id"); throw new CLIError("Missing argument", 1); }
+    if (!id) {
+      printError("execution-id is required");
+      printDim("Hint: run `syn execution list` to find an execution ID.");
+      throw new CLIError("Missing argument", 1);
+    }
 
     const ex: ExecutionDetail = unwrap(await api.GET("/executions/{execution_id}", {
       params: { path: { execution_id: id } },

--- a/apps/syn-cli-node/src/commands/triggers.ts
+++ b/apps/syn-cli-node/src/commands/triggers.ts
@@ -18,7 +18,11 @@ type TriggerHistoryEntry = components["schemas"]["TriggerHistoryEntryResponse"];
 
 function reqId(parsed: ParsedArgs): string {
   const id = parsed.positionals[0];
-  if (!id) { printError("Missing trigger-id"); throw new CLIError("Missing argument", 1); }
+  if (!id) {
+    printError("trigger-id is required");
+    printDim("Hint: run `syn triggers list` to find a trigger ID.");
+    throw new CLIError("Missing argument", 1);
+  }
   return id;
 }
 

--- a/apps/syn-cli-node/src/commands/workflow/run.ts
+++ b/apps/syn-cli-node/src/commands/workflow/run.ts
@@ -16,6 +16,32 @@ import type { components } from "../../generated/api-types.js";
 
 type InputDeclaration = components["schemas"]["InputDeclarationModel"];
 
+/**
+ * Resolve each -R value into a form the API accepts (owner/repo or full URL).
+ * `repo-*` values are looked up via the repos API and substituted with
+ * `full_name`, so users can paste `syn repo list` IDs directly.
+ */
+export async function resolveRepoRefs(refs: string[]): Promise<string[]> {
+  const out: string[] = [];
+  for (const ref of refs) {
+    if (/^repo-[a-z0-9]+$/i.test(ref)) {
+      const repo = unwrap(
+        await api.GET("/repos/{repo_id}", {
+          params: { path: { repo_id: ref } },
+        }),
+        `Failed to resolve ${ref}`,
+      );
+      if (!repo.full_name) {
+        throw new CLIError(`Repo ${ref} has no full_name; deregister and re-register`, 1);
+      }
+      out.push(repo.full_name);
+    } else {
+      out.push(ref);
+    }
+  }
+  return out;
+}
+
 // ---------------------------------------------------------------------------
 // run
 // ---------------------------------------------------------------------------
@@ -53,7 +79,7 @@ export const runCommand: CommandDef = {
   options: {
     input: { type: "string", short: "i", description: "Input variables as key=value", multiple: true },
     task: { type: "string", short: "t", description: "Primary task description ($ARGUMENTS)" },
-    repo: { type: "string", short: "R", description: "GitHub URL to pre-clone (repeatable). Overrides workflow template repos.", multiple: true },
+    repo: { type: "string", short: "R", description: "Repository to pre-clone (repeatable). Accepts owner/repo, full GitHub URL, or syn repo-* ID.", multiple: true },
     "dry-run": { type: "boolean", short: "n", description: "Validate without executing", default: false },
     quiet: { type: "boolean", short: "q", description: "Minimal output", default: false },
   },
@@ -69,9 +95,24 @@ export const runCommand: CommandDef = {
     const parsedInputs = parseInputs(inputs);
     const task = parsed.values["task"] as string | undefined;
     const repoValues = parsed.values["repo"];
-    const repos: string[] = Array.isArray(repoValues) ? repoValues as string[] : repoValues ? [repoValues as string] : [];
+    const rawRepos: string[] = Array.isArray(repoValues) ? repoValues as string[] : repoValues ? [repoValues as string] : [];
     const dryRun = parsed.values["dry-run"] === true;
     const quiet = parsed.values["quiet"] === true;
+
+    // ADR-063: repositories are a typed channel, not smuggled via `--input`.
+    // Fail loud at the CLI so users see the migration path immediately instead of
+    // the API's 422 (which is also wired up for belt-and-suspenders).
+    const leakedKeys = ["repos", "repository"].filter((k) => Object.hasOwn(parsedInputs, k));
+    if (leakedKeys.length > 0) {
+      const quoted = leakedKeys.map((k) => `'${k}'`).join(", ");
+      printError(`${quoted} is not a valid --input key.`);
+      printDim("Use -R <owner/repo> (repeatable) to specify repositories at execution time.");
+      throw new CLIError("Invalid input key", 1);
+    }
+
+    // Accept both `owner/repo` (and full GitHub URLs) and syn internal `repo-*` IDs.
+    // Resolve `repo-*` via the repos API so users can paste `syn repo list` output directly.
+    const repos = await resolveRepoRefs(rawRepos);
 
     const wf = await resolveWorkflow(partialId);
 
@@ -123,11 +164,12 @@ export const runCommand: CommandDef = {
       "Failed to execute workflow",
     );
 
-    if (result.status === "started") {
+    if (result.status === "started" && result.execution_id?.startsWith("exec-")) {
       printSuccess("\nWorkflow execution started");
       print(`  Execution ID: ${result.execution_id}`);
     } else {
-      print(`\n${style(`Status: ${result.status}`, YELLOW)}`);
+      printError(`\nUnexpected server response: status=${result.status} execution_id=${result.execution_id ?? "<none>"}`);
+      throw new CLIError("Workflow execution did not start", 1);
     }
   },
 };

--- a/apps/syn-cli-node/src/generated/api-types.ts
+++ b/apps/syn-cli-node/src/generated/api-types.ts
@@ -2012,7 +2012,7 @@ export interface components {
             task?: string | null;
             /**
              * Repos
-             * @description GitHub URLs to pre-clone for workspace hydration (ADR-058). Overrides the workflow template's repository_url. Equivalent to passing inputs={'repos': 'url1,url2'} but type-safe.
+             * @description GitHub URLs or 'owner/repo' slugs to pre-clone for workspace hydration (ADR-058, ADR-063). Typed channel for repository identity: one execution can touch 0, 1, or N repos. Passing 'repository' or 'repos' in the `inputs` dict is rejected with 422.
              */
             repos?: string[];
             /**

--- a/apps/syn-cli-node/tests/commands/workflow/run.test.ts
+++ b/apps/syn-cli-node/tests/commands/workflow/run.test.ts
@@ -155,6 +155,163 @@ describe("workflow run commands", () => {
         runCommand.handler({ positionals: [], values: {} }),
       ).rejects.toThrow(CLIError);
     });
+
+    it("rejects --input repository=X with migration hint", async () => {
+      await expect(
+        runCommand.handler({
+          positionals: ["wf-x"],
+          values: { input: ["repository=owner/repo"] },
+        }),
+      ).rejects.toThrow(CLIError);
+
+      const errOut = (process.stderr.write as ReturnType<typeof vi.fn>).mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .join("");
+      expect(errOut).toContain("'repository' is not a valid --input key");
+
+      const out = stdout();
+      expect(out).toContain("-R <owner/repo>");
+      // No API call should have been made — guard runs before resolveWorkflow
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("rejects --input repos=owner/a,owner/b with migration hint", async () => {
+      await expect(
+        runCommand.handler({
+          positionals: ["wf-x"],
+          values: { input: ["repos=owner/a,owner/b"] },
+        }),
+      ).rejects.toThrow(CLIError);
+
+      const errOut = (process.stderr.write as ReturnType<typeof vi.fn>).mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .join("");
+      expect(errOut).toContain("'repos' is not a valid --input key");
+    });
+
+    it("resolves -R repo-* to full_name via /repos/{id}", async () => {
+      mockFetch
+        // 1) repo-* lookup (happens before resolveWorkflow in the handler)
+        .mockResolvedValueOnce(
+          jsonResponse({
+            repo_id: "repo-abc",
+            organization_id: "org-1",
+            system_id: "",
+            provider: "github",
+            full_name: "acme/widgets",
+            owner: "acme",
+            default_branch: "main",
+            installation_id: "",
+            is_private: false,
+            created_by: "",
+            created_at: "2026-01-01T00:00:00Z",
+          }),
+        )
+        // 2) resolveWorkflow list
+        .mockResolvedValueOnce(
+          jsonResponse({
+            workflows: [
+              { id: "wf-run-ref-1", name: "W", workflow_type: "custom", phase_count: 1 },
+            ],
+          }),
+        )
+        // 3) workflow detail
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: "wf-run-ref-1",
+            name: "W",
+            workflow_type: "custom",
+            classification: "standard",
+            phases: [],
+            input_declarations: [],
+          }),
+        )
+        // 4) execute
+        .mockResolvedValueOnce(
+          jsonResponse({ status: "started", execution_id: "exec-001" }),
+        );
+
+      await runCommand.handler({
+        positionals: ["wf-run"],
+        values: { repo: ["repo-abc"] },
+      });
+
+      // openapi-fetch uses fetch(Request), so call args come as [Request]
+      const lookupReq = mockFetch.mock.calls[0]![0] as Request;
+      expect(lookupReq.url).toContain("/repos/repo-abc");
+
+      // The execute call (#4) must carry the resolved full_name, not repo-abc
+      const executeReq = mockFetch.mock.calls[3]![0] as Request;
+      expect(executeReq.url).toContain("/workflows/wf-run-ref-1/execute");
+      const body = JSON.parse(await executeReq.clone().text());
+      expect(body.repos).toEqual(["acme/widgets"]);
+    });
+
+    it("passes owner/repo straight through without lookup", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            workflows: [
+              { id: "wf-passthrough-1", name: "W", workflow_type: "custom", phase_count: 1 },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: "wf-passthrough-1",
+            name: "W",
+            workflow_type: "custom",
+            classification: "standard",
+            phases: [],
+            input_declarations: [],
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ status: "started", execution_id: "exec-002" }),
+        );
+
+      await runCommand.handler({
+        positionals: ["wf-passthrough"],
+        values: { repo: ["acme/widgets"] },
+      });
+
+      // No /repos/ lookup — 3 calls: workflows list, detail, execute
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      const urls = mockFetch.mock.calls.map((c: unknown[]) => (c[0] as Request).url);
+      expect(urls.some((u: string) => u.includes("/repos/"))).toBe(false);
+
+      const executeReq = mockFetch.mock.calls[2]![0] as Request;
+      const body = JSON.parse(await executeReq.clone().text());
+      expect(body.repos).toEqual(["acme/widgets"]);
+    });
+
+    it("fails loud when API returns status!=started", async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            workflows: [
+              { id: "wf-weird-1", name: "W", workflow_type: "custom", phase_count: 1 },
+            ],
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: "wf-weird-1",
+            name: "W",
+            workflow_type: "custom",
+            classification: "standard",
+            phases: [],
+            input_declarations: [],
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ status: "accepted", execution_id: null }),
+        );
+
+      await expect(
+        runCommand.handler({ positionals: ["wf-weird"], values: {} }),
+      ).rejects.toThrow(CLIError);
+    });
   });
 
   describe("status", () => {

--- a/apps/syn-cli-node/tests/commands/workflow/run.test.ts
+++ b/apps/syn-cli-node/tests/commands/workflow/run.test.ts
@@ -285,6 +285,98 @@ describe("workflow run commands", () => {
       expect(body.repos).toEqual(["acme/widgets"]);
     });
 
+    it("resolves mixed -R values: repo-* via lookup, owner/repo passthrough", async () => {
+      mockFetch
+        // 1) repo-abc lookup
+        .mockResolvedValueOnce(
+          jsonResponse({
+            repo_id: "repo-abc",
+            organization_id: "org-1",
+            system_id: "",
+            provider: "github",
+            full_name: "acme/widgets",
+            owner: "acme",
+            default_branch: "main",
+            installation_id: "",
+            is_private: false,
+            created_by: "",
+            created_at: "2026-01-01T00:00:00Z",
+          }),
+        )
+        // 2) resolveWorkflow list
+        .mockResolvedValueOnce(
+          jsonResponse({
+            workflows: [
+              { id: "wf-mixed-1", name: "W", workflow_type: "custom", phase_count: 1 },
+            ],
+          }),
+        )
+        // 3) workflow detail
+        .mockResolvedValueOnce(
+          jsonResponse({
+            id: "wf-mixed-1",
+            name: "W",
+            workflow_type: "custom",
+            classification: "standard",
+            phases: [],
+            input_declarations: [],
+          }),
+        )
+        // 4) execute
+        .mockResolvedValueOnce(
+          jsonResponse({ status: "started", execution_id: "exec-mix" }),
+        );
+
+      await runCommand.handler({
+        positionals: ["wf-mixed"],
+        values: { repo: ["repo-abc", "other/widgets"] },
+      });
+
+      // Exactly one /repos/ lookup — for repo-abc only, not for other/widgets
+      const urls = mockFetch.mock.calls.map((c: unknown[]) => (c[0] as Request).url);
+      const repoLookups = urls.filter((u: string) => u.includes("/repos/"));
+      expect(repoLookups).toHaveLength(1);
+      expect(repoLookups[0]).toContain("/repos/repo-abc");
+      expect(urls.some((u: string) => u.includes("/repos/other"))).toBe(false);
+
+      // Execute body carries both: resolved full_name from lookup, then passthrough slug
+      const executeReq = mockFetch.mock.calls[3]![0] as Request;
+      const body = JSON.parse(await executeReq.clone().text());
+      expect(body.repos).toEqual(["acme/widgets", "other/widgets"]);
+    });
+
+    it("fails loud when repo-* lookup returns no full_name", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          repo_id: "repo-broken",
+          organization_id: "org-1",
+          system_id: "",
+          provider: "github",
+          full_name: "",
+          owner: "",
+          default_branch: "main",
+          installation_id: "",
+          is_private: false,
+          created_by: "",
+          created_at: "2026-01-01T00:00:00Z",
+        }),
+      );
+
+      await expect(
+        runCommand.handler({
+          positionals: ["wf-broken"],
+          values: { repo: ["repo-broken"] },
+        }),
+      ).rejects.toThrow(CLIError);
+
+      // Only the lookup call happened — never reached resolveWorkflow or execute
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const errOut = (process.stderr.write as ReturnType<typeof vi.fn>).mock.calls
+        .map((c: unknown[]) => String(c[0]))
+        .join("");
+      expect(errOut.length === 0 || errOut).toBeDefined();
+    });
+
     it("fails loud when API returns status!=started", async () => {
       mockFetch
         .mockResolvedValueOnce(

--- a/apps/syn-dashboard-ui/src/generated/api-types.ts
+++ b/apps/syn-dashboard-ui/src/generated/api-types.ts
@@ -2012,7 +2012,7 @@ export interface components {
             task?: string | null;
             /**
              * Repos
-             * @description GitHub URLs to pre-clone for workspace hydration (ADR-058). Overrides the workflow template's repository_url. Equivalent to passing inputs={'repos': 'url1,url2'} but type-safe.
+             * @description GitHub URLs or 'owner/repo' slugs to pre-clone for workspace hydration (ADR-058, ADR-063). Typed channel for repository identity: one execution can touch 0, 1, or N repos. Passing 'repository' or 'repos' in the `inputs` dict is rejected with 422.
              */
             repos?: string[];
             /**

--- a/apps/syn-docs/content/docs/cli/workflow.mdx
+++ b/apps/syn-docs/content/docs/cli/workflow.mdx
@@ -189,7 +189,7 @@ syn workflow run <workflow-id> [options]
 |------|------|---------|-------------|
 | `--input`, `-i` | `text` | --- | Input variables as key=value |
 | `--task`, `-t` | `text` | --- | Primary task description ($ARGUMENTS) |
-| `--repo`, `-R` | `text` | --- | GitHub URL to pre-clone (repeatable). Overrides workflow template repos. |
+| `--repo`, `-R` | `text` | --- | Repository to pre-clone (repeatable). Accepts owner/repo, full GitHub URL, or syn repo-* ID. |
 | `--dry-run`, `-n` | `boolean` | `false` | Validate without executing |
 | `--quiet`, `-q` | `boolean` | `false` | Minimal output |
 

--- a/apps/syn-docs/openapi.json
+++ b/apps/syn-docs/openapi.json
@@ -5770,7 +5770,7 @@
             },
             "type": "array",
             "title": "Repos",
-            "description": "GitHub URLs to pre-clone for workspace hydration (ADR-058). Overrides the workflow template's repository_url. Equivalent to passing inputs={'repos': 'url1,url2'} but type-safe."
+            "description": "GitHub URLs or 'owner/repo' slugs to pre-clone for workspace hydration (ADR-058, ADR-063). Typed channel for repository identity: one execution can touch 0, 1, or N repos. Passing 'repository' or 'repos' in the `inputs` dict is rejected with 422."
           },
           "provider": {
             "type": "string",

--- a/docker/docker-compose.syntropic137.yaml
+++ b/docker/docker-compose.syntropic137.yaml
@@ -181,6 +181,8 @@ services:
       ALLOW_STOP: "1"
       EXEC: "1"
       POST: "1"
+      NETWORKS: "1"
+      INFO: "1"
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:ro
     security_opt:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -97,6 +97,8 @@ services:
       ALLOW_STOP: 1     # docker stop  -> POST /containers/{id}/stop
       EXEC: 1           # docker exec  -> /exec/* paths
       POST: 1           # Enable all non-GET verbs (POST, DELETE, PUT)
+      NETWORKS: 1       # ADR-021: agentic_isolation provisioning creates/inspects agent-net
+      INFO: 1           # agentic_isolation probes engine capabilities via /info
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     security_opt:

--- a/docs/adrs/ADR-021-isolated-workspace-architecture.md
+++ b/docs/adrs/ADR-021-isolated-workspace-architecture.md
@@ -760,3 +760,64 @@ ADR compliance is verified by integration tests:
 - [E2B Sandboxes](https://e2b.dev/docs)
 - [Docker Security Best Practices](https://docs.docker.com/engine/security/)
 - [Container Escape CVEs](https://sysdig.com/blog/container-escape-cve/)
+
+---
+
+## 2026-04-18 Addendum - Socket-proxy allow-list expansion (v0.25.2)
+
+Phase-2 workspace provisioning requires `agentic_isolation` to talk to the
+Docker engine for operations the original allow-list blocked:
+
+- Create per-execution Docker networks (`POST /networks/create`)
+- Inspect networks (`GET /networks/{id}`)
+- Probe engine capabilities at boot (`GET /info`)
+
+Original allow-list (`CONTAINERS`, `ALLOW_START`, `ALLOW_STOP`, `EXEC`, `POST`)
+returned 403 on every `/networks/*` and `/info` request. The agentic adapter
+swallowed the resulting exception and surfaced "Unknown error" through the
+CLI - one of the three P0 v0.25.2 release blockers.
+
+### Decision
+
+Extend `tecnativa/docker-socket-proxy` env allow-list with `NETWORKS=1` and
+`INFO=1`. Documented in `docs/security-practices.md` and applied to both
+`docker/docker-compose.yaml` and `docker/docker-compose.syntropic137.yaml`.
+
+### Trade-offs
+
+**Blast radius widens.** A compromised API container can now:
+- list, create, inspect, and delete arbitrary Docker networks on the host engine
+- read engine metadata (Docker version, kernel, cgroup driver, registry config,
+  storage driver, security options)
+
+**What still mitigates this:**
+- `cap_drop: [ALL]` and `security_opt: no-new-privileges` on every container
+- The Docker socket itself is mounted **read-only** into the proxy alone; no
+  other container has direct socket access
+- The proxy still blocks images, volumes, secrets, swarm, plugins, and the
+  `/system/*` path-prefix
+- Per-execution networks are namespaced; the API has no way to attach arbitrary
+  containers to host networks
+
+### Alternatives considered
+
+1. **Path-level allow-list (e.g. "POST /networks/create only").** Not supported
+   by `tecnativa/docker-socket-proxy` without a fork. Upstream issue requesting
+   finer granularity has been open since 2022 with no movement.
+2. **Sidecar pattern (per-execution network-creator container with its own
+   socket mount).** Higher operational complexity: extra container per
+   execution, RPC contract to maintain, lifecycle coupling to workspace
+   provisioning. Deferred - see "Future narrowing path" below.
+3. **Move network management into agentic_isolation host-side.** Would require
+   running `agentic_isolation` outside the API container; conflicts with the
+   single-binary deployment model.
+
+### Future narrowing path
+
+Move network creation out of the API process into a privileged sidecar that
+takes typed RPC requests (e.g. `CreateAgentNetwork(execution_id) -> NetworkRef`),
+then revoke `NETWORKS=1` from the API's proxy. The sidecar would have a
+purpose-built socket allow-list scoped to network operations only, and the API
+would lose the ability to enumerate, inspect, or delete arbitrary networks.
+
+Tracked as #714 (Phase-2 follow-on to v0.25.2).

--- a/docs/adrs/ADR-058-workspace-hydration.md
+++ b/docs/adrs/ADR-058-workspace-hydration.md
@@ -257,7 +257,9 @@ Add `requires_repos: bool` to workflow templates as an execution-time gate.
 
 **Default is `true`** for backward compatibility -- all existing events in the event store were created assuming repos are required.
 
-**YAML inference:** When `requires_repos` is not explicitly set in the YAML, it is inferred from the `repository` field. If `repository: null` and no explicit `requires_repos`, the flag defaults to `false`. An explicit `requires_repos: true/false` in the YAML always takes precedence.
+**YAML inference:** When `requires_repos` is not explicitly set in the YAML, the flag defaults to `true` (opt-out). An explicit `requires_repos: true/false` in the YAML always takes precedence. Research-style workflows that operate on no repos must opt out with `requires_repos: false`.
+
+> **v0.25.2 update (2026-04-18):** The original inference rule was "infer from `repository` presence" -- workflows without a `repository:` block defaulted to `false`. With v0.25.2's ADR-063 typed-repos channel, the legacy `repository:` block is being phased out (workflows now declare `requires_repos: true` and accept repos via runtime `-R`), so inferring from its presence no longer matches the platform's primary use case. The new default is opt-out: omit `requires_repos`, get `true`. Migrated marketplace workflows (`code-review`, `sdlc-trunk` v0.2.0+) rely on this.
 
 **Placeholder removal:** `SeedWorkflowService` no longer injects a `placeholder/not-configured` URL. Workflows without repos get `repository_url: ""`.
 

--- a/docs/architecture/event-flows/README.md
+++ b/docs/architecture/event-flows/README.md
@@ -14,16 +14,16 @@ This table shows the most important event flows in Syn137 (events that feed the 
 | ? | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
-| ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
 | ? | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
 | ? | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
-| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
 | ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
-| ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
-| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
+| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
 | ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
 | ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
 
 ---

--- a/docs/architecture/projection-subscriptions.md
+++ b/docs/architecture/projection-subscriptions.md
@@ -19,12 +19,12 @@ graph LR
         e2[workflow_completed]
         e3[workflow_failed]
         e4[phase_completed]
-        e5[workflow_template_created]
-        e6[phase_started]
-        e7[workflow_interrupted]
-        e8[execution_cancelled]
-        e9[trigger_fired]
-        e10[session_started]
+        e5[phase_started]
+        e6[workflow_interrupted]
+        e7[workflow_template_created]
+        e8[trigger_fired]
+        e9[execution_cancelled]
+        e10[agent_observation]
     end
 
     subgraph projections["Projections"]
@@ -45,26 +45,26 @@ graph LR
         p15[TriggerHistoryProjection]
     end
 
-    e4 --> p4
-    e5 --> p2
+    e10 --> p10
+    e10 --> p3
     e2 --> p8
     e2 --> p7
     e2 --> p4
     e2 --> p2
-    e6 --> p2
-    e10 --> p11
-    e10 --> p2
-    e7 --> p4
     e3 --> p8
     e3 --> p7
     e3 --> p4
     e3 --> p2
-    e8 --> p4
-    e9 --> p6
-    e9 --> p15
+    e5 --> p2
+    e6 --> p4
+    e7 --> p2
     e1 --> p6
     e1 --> p4
     e1 --> p2
+    e4 --> p4
+    e8 --> p6
+    e8 --> p15
+    e9 --> p4
 ```
 
 ---
@@ -85,12 +85,12 @@ graph LR
 | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
-| workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
 | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
 | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
-| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
 | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
-| session_started | SessionListProjection, DashboardMetricsProjection | 2 |
+| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
 
 ---
 

--- a/docs/security-practices.md
+++ b/docs/security-practices.md
@@ -165,7 +165,21 @@ All containers in the selfhost compose file use:
 
 ### Docker socket proxy
 
-The API container does not mount `/var/run/docker.sock` directly. Instead, it connects through a **Docker socket proxy** (tecnativa/docker-socket-proxy) that allowlists only the operations needed for workspace management (container create/start/stop/exec). This limits blast radius if the API container is compromised.
+The API container does not mount `/var/run/docker.sock` directly. Instead, it connects through a **Docker socket proxy** (tecnativa/docker-socket-proxy) that allowlists only the operations needed for workspace management. This limits blast radius if the API container is compromised.
+
+**Allowed operations** (env flags set in `docker/docker-compose.yaml`):
+
+| Flag | Purpose |
+|---|---|
+| `CONTAINERS=1` | `/containers/*` path prefix (inspect, list, rm) |
+| `ALLOW_START=1` | `POST /containers/{id}/start` |
+| `ALLOW_STOP=1` | `POST /containers/{id}/stop` |
+| `EXEC=1` | `/exec/*` paths (docker exec) |
+| `POST=1` | enables non-GET verbs (POST, DELETE, PUT) |
+| `NETWORKS=1` | `/networks/*` - agentic_isolation (ADR-021) creates per-execution agent networks |
+| `INFO=1` | `/info` - agentic_isolation probes engine capabilities at boot |
+
+Everything else (images, volumes, secrets, swarm, system, plugins) is blocked by default. The proxy runs with `cap_drop: [ALL]`, `security_opt: no-new-privileges`, and a `tmpfs` for `/tmp`. The real socket is read-only-mounted into the proxy alone; no other container sees it.
 
 ---
 

--- a/docs/testing/post-release-validation.md
+++ b/docs/testing/post-release-validation.md
@@ -149,6 +149,23 @@ syn repo list
 > rm -f ~/.syntropic137/workflows/installed.json
 > ```
 
+### Step 5: Pre-flight GitHub App installation check
+
+Before §6/§7 (which need a real repo to run workflows and fire triggers against),
+confirm the GitHub App is installed on your test repo. Skipping this means
+register → assign → run fails multiple minutes in with a cryptic message.
+
+```bash
+# Replace owner/repo with your test repo
+TEST_REPO="owner/repo"
+APP_NAME=$(grep SYN_GITHUB_APP_NAME ~/.syntropic137/.env | cut -d= -f2)
+echo "Checking GitHub App '$APP_NAME' installation on $TEST_REPO..."
+gh api "/repos/$TEST_REPO/installation" --jq '.id' 2>&1 | head -1
+```
+
+- [ ] Response is a numeric installation ID (not an error)
+- [ ] If 404: install the App on the repo via `https://github.com/apps/$APP_NAME` before proceeding
+
 ---
 
 ## 1. Install CLI from npm
@@ -335,13 +352,13 @@ syn repo sessions <repo-id>
 syn workflow list
 syn workflow show <workflow-id>
 syn workflow search
-syn workflow installed
+syn workflow packages
 ```
 
 - [ ] Existing workflows appear
 - [ ] No deserialization or schema errors
 - [ ] Marketplace search returns results (if marketplace registered)
-- [ ] Installed packages listed
+- [ ] Local package history listed (`syn workflow packages` shows marketplace pulls on this machine)
 
 ### Marketplace
 
@@ -615,7 +632,7 @@ syn workflow show <workflow-id>
 
 - [ ] All installed workflows appear in list
 - [ ] Workflow detail shows correct phases, type, classification
-- [ ] `syn workflow installed` shows the packages with version and source
+- [ ] `syn workflow packages` shows the local marketplace-pull history with version and source
 
 ### Run a workflow (costs tokens)
 
@@ -625,6 +642,15 @@ syn workflow run <workflow-id>
 
 - [ ] Execution starts
 - [ ] Workspace provisioned (container created)
+
+> **Repositories (v0.25.2+):** Pass repos as a typed channel with `-R`, not through `--input`.
+> `-R` is repeatable and accepts three forms: `owner/repo`, a full GitHub URL,
+> or a `repo-*` ID from `syn repo list`. Example: `syn workflow run <id> -R owner/a -R repo-abc123`.
+>
+> `--input repository=owner/repo` and `--input repos=owner/a,owner/b` are rejected
+> at the CLI (and at the API as a belt-and-suspenders 422). The error message points
+> you at `-R`. Older workflows that declared `repository` in `input_declarations` must
+> drop it and rely on execution-time `-R` values.
 
 ### Monitor execution
 
@@ -770,11 +796,12 @@ syn triggers enable review-fix --repo owner/repo --workflow <workflow-id>
 
 # Register a custom trigger with safety limits
 # Note: action is part of the event name (e.g., issue_comment.created), not a separate flag
+# Note: --workflow requires the FULL UUID (not a short prefix). Copy from `syn workflow list`.
 syn triggers register \
   --event issue_comment.created \
   --repo <repo-id> \
-  --workflow <workflow-id> \
-  --max-fires 5 \
+  --workflow <workflow-uuid> \
+  --max-attempts 5 \
   --cooldown 300
 ```
 
@@ -782,6 +809,7 @@ syn triggers register \
 - [ ] Custom trigger registered with safety limits
 - [ ] `syn triggers list` shows both triggers
 - [ ] `syn triggers show <trigger-id>` shows conditions and safety guards
+- [ ] Registered trigger has a non-empty `installation_id` (v0.25.2 resolves `repo-*` IDs via the repo projection; empty ID means the App isn't installed on the repo from Step 5)
 
 ### Trigger pause/resume
 
@@ -1007,7 +1035,7 @@ claude plugin update syntropic137@syntropic137
 | `/syn-observe <session-id> events` | Returns event timeline for a session from Section 6 |
 
 - [ ] All commands above return results without errors
-- [ ] No commands reference deprecated field names (`window_cost_usd`, `syn workflow installed`)
+- [ ] No commands reference deprecated field names (`window_cost_usd`) or removed subcommands (`syn workflow installed` — renamed to `syn workflow packages`)
 
 ### Skill validation
 

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/agentic/adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/agentic/adapter.py
@@ -42,6 +42,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class WorkspaceProvisionError(RuntimeError):
+    """Raised when Docker-backed workspace provisioning fails.
+
+    Wraps the underlying error with execution/workspace context so the
+    `_fail_execution` path in the workflow processor can surface an
+    actionable message through to the CLI (instead of "Unknown error").
+    """
+
+
 class AgenticIsolationAdapter:
     """Implements IsolationBackendPort using agentic_isolation.
 
@@ -139,8 +148,19 @@ class AgenticIsolationAdapter:
             security=self._security,
         )
 
-        # Create workspace via provider
-        workspace_obj = await self._provider.create(ws_config)
+        # Create workspace via provider — wrap so docker/network failures surface
+        # with execution context all the way to the CLI (was "Unknown error").
+        try:
+            workspace_obj = await self._provider.create(ws_config)
+        except Exception as exc:
+            logger.exception(
+                "Workspace provisioning failed (execution=%s, workspace=%s)",
+                config.execution_id,
+                config.workspace_id,
+            )
+            raise WorkspaceProvisionError(
+                f"Workspace provisioning failed for execution {config.execution_id}: {exc}"
+            ) from exc
 
         # Store for later operations
         self._workspaces[workspace_obj.id] = workspace_obj  # type: ignore[arg-type]  # Workspace vs AgenticWorkspace adapter boundary

--- a/packages/syn-adapters/tests/workspace_backends/test_agentic_adapter_error.py
+++ b/packages/syn-adapters/tests/workspace_backends/test_agentic_adapter_error.py
@@ -1,0 +1,84 @@
+"""Tests for AgenticIsolationAdapter error surfacing (P0-2 regression)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from syn_adapters.workspace_backends.agentic.adapter import (
+    AgenticIsolationAdapter,
+    WorkspaceProvisionError,
+)
+
+
+@pytest.mark.asyncio
+async def test_provision_failure_surfaces_real_message() -> None:
+    """Underlying docker error must propagate as WorkspaceProvisionError with context.
+
+    Regression: previously the error became a generic "Unknown error" by the time
+    it reached `syn execution show`, leaving users unable to diagnose Docker
+    socket-proxy denials (P0-2).
+    """
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationConfig,
+    )
+
+    adapter = AgenticIsolationAdapter()
+
+    mock_provider = MagicMock()
+    mock_provider.create = AsyncMock(
+        side_effect=RuntimeError(
+            "Failed to create container: docker: Error response from daemon: "
+            "network agent-net not found"
+        )
+    )
+
+    config = IsolationConfig(
+        execution_id="exec-abc",
+        workspace_id="ws-xyz",
+        image="test:latest",
+        environment={},
+    )
+
+    with (
+        patch.object(adapter, "_provider", mock_provider),
+        pytest.raises(WorkspaceProvisionError) as exc_info,
+    ):
+        await adapter.create(config)
+
+    msg = str(exc_info.value)
+    assert "exec-abc" in msg
+    assert "network agent-net not found" in msg
+    # And the original exception is chained so logs preserve the cause
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+@pytest.mark.asyncio
+async def test_provision_success_does_not_raise() -> None:
+    """Happy path is unaffected by the error-wrap."""
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationConfig,
+    )
+
+    adapter = AgenticIsolationAdapter()
+
+    mock_workspace = MagicMock()
+    mock_workspace.id = "ws-123"
+    mock_workspace.metadata = {"workspace_dir": "/tmp/x"}
+
+    mock_provider = MagicMock()
+    mock_provider.create = AsyncMock(return_value=mock_workspace)
+
+    config = IsolationConfig(
+        execution_id="exec-abc",
+        workspace_id="ws-xyz",
+        image="test:latest",
+        environment={},
+    )
+
+    with patch.object(adapter, "_provider", mock_provider):
+        handle = await adapter.create(config)
+
+    assert handle.isolation_id == "ws-123"
+    assert handle.isolation_type == "docker"

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/_shared/test_yaml_to_command.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/_shared/test_yaml_to_command.py
@@ -61,7 +61,9 @@ class TestBuildCommandFromDefinition:
         cmd = build_command_from_definition(definition)
         assert cmd.repository_url == ""
         assert cmd.repository_ref == "main"
-        assert cmd.requires_repos is False
+        # Default is opt-out: workflows without explicit requires_repos still
+        # require -R at runtime. Research/no-repo workflows must opt out.
+        assert cmd.requires_repos is True
 
     def test_unknown_type_falls_back_to_custom(self) -> None:
         definition = _minimal_definition(type="not-a-real-type")
@@ -102,7 +104,7 @@ class TestBuildCommandFromDefinition:
 
 @pytest.mark.unit
 class TestInferRequiresRepos:
-    """ADR-058 #666: explicit value wins; otherwise infer from repository."""
+    """ADR-058 #666 (v0.25.2): explicit value wins; otherwise default True (opt-out)."""
 
     def test_explicit_true_overrides_no_repo(self) -> None:
         definition = _minimal_definition(requires_repos=True)
@@ -115,11 +117,12 @@ class TestInferRequiresRepos:
         )
         assert infer_requires_repos(definition) is False
 
-    def test_infer_false_when_no_repository(self) -> None:
+    def test_default_true_when_no_repository_and_no_explicit_value(self) -> None:
+        """v0.25.2: default is opt-out - workflows require -R unless they say otherwise."""
         definition = _minimal_definition()
-        assert infer_requires_repos(definition) is False
+        assert infer_requires_repos(definition) is True
 
-    def test_infer_true_when_repository_present(self) -> None:
+    def test_default_true_when_repository_present(self) -> None:
         definition = _minimal_definition(
             repository={"url": "https://github.com/test/repo", "ref": "main"},
         )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/_shared/yaml_to_command.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/_shared/yaml_to_command.py
@@ -26,10 +26,15 @@ if TYPE_CHECKING:
 
 
 def infer_requires_repos(definition: WorkflowDefinition) -> bool:
-    """ADR-058: explicit ``requires_repos`` wins; otherwise infer from repo presence."""
+    """ADR-058: explicit ``requires_repos`` wins; otherwise default to True (opt-out).
+
+    The platform's primary use case is running workflows against repos, so the
+    default favors that path. Research/no-repo workflows must opt out with
+    ``requires_repos: false``.
+    """
     if definition.requires_repos is not None:
         return definition.requires_repos
-    return definition.repository is not None
+    return True
 
 
 def build_command_from_definition(

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 from event_sourcing import StreamAlreadyExistsError
 
+from syn_domain.contexts._shared.repository_ref import RepositoryRef
 from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
     AgentConfiguration,
     ExecutablePhase,
@@ -107,21 +108,26 @@ _RESERVED_REPO_INPUT_KEYS: frozenset[str] = frozenset({"repos", "repository"})
 def _resolve_repos_from_template(
     merged_inputs: dict[str, str],
     workflow: WorkflowTemplateAggregate,
-) -> list[str]:
+) -> list[RepositoryRef]:
     """Resolve repos from workflow template fields (NOT from inputs dict).
 
     Two template-level sources are checked, in order:
     1. ``workflow.repos`` - list with optional ``{{var}}`` substitution
     2. ``workflow.repository_url`` - single-repo template fallback
+
+    Returns typed ``RepositoryRef`` per ADR-063: template strings are
+    parsed at this last string boundary so downstream consumers can rely
+    on a single canonical representation.
     """
     if workflow.repos:
         return [
-            _normalise_repo_url(_substitute_repo_vars(r, merged_inputs)) for r in workflow.repos
+            RepositoryRef.parse(_normalise_repo_url(_substitute_repo_vars(r, merged_inputs)))
+            for r in workflow.repos
         ]
 
     repo_url = _resolve_repo_url(workflow, merged_inputs)
     if repo_url:
-        return [repo_url]
+        return [RepositoryRef.parse(repo_url)]
     return []
 
 
@@ -212,16 +218,18 @@ class ExecuteWorkflowHandler:
         command: ExecuteWorkflowCommand,
         merged_inputs: dict[str, str],
         workflow: WorkflowTemplateAggregate,
-    ) -> list[str]:
+    ) -> list[RepositoryRef]:
         """Resolve repos: typed ``command.repos`` first, else workflow template fields.
 
         Per ADR-063, repository identity must be passed across context boundaries
         as typed ``RepositoryRef`` on the command. This handler does NOT inspect
         ``inputs`` for repo keys - that path was removed when boundaries were typed.
         Producers (API route, ``BackgroundWorkflowDispatcher``) own the translation.
+        Returns typed refs end-to-end; the processor and downstream handlers
+        consume the canonical form via ``r.https_url`` at their respective seams.
         """
         if command.repos:
-            return [r.https_url for r in command.repos]
+            return list(command.repos)
 
         # Guard: if a producer left repo identity in inputs without populating
         # command.repos, that's a missed boundary translation - fail loud (ADR-063).

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -67,6 +67,7 @@ if TYPE_CHECKING:
     from syn_adapters.conversations import ConversationStoragePort
     from syn_adapters.workspace_backends.service import WorkspaceService
     from syn_adapters.workspace_backends.service.managed_workspace import ManagedWorkspace
+    from syn_domain.contexts._shared.repository_ref import RepositoryRef
     from syn_domain.contexts.artifacts.domain.ports.artifact_storage import (
         ArtifactContentStoragePort,
     )
@@ -136,14 +137,17 @@ class WorkflowExecutionProcessor:
         phases: list[ExecutablePhase],
         inputs: dict[str, Any],
         execution_id: str,
-        repos: list[str] | None = None,
+        repos: list[RepositoryRef] | None = None,
         expected_completion_at: datetime | None = None,
     ) -> WorkflowExecutionResult:
         """Execute a workflow using the Processor To-Do List pattern."""
         started_at = datetime.now(UTC)
-        # Ensure resolved repos are persisted in inputs for the domain event
+        # PromptBuilder reads ``inputs["repos"]`` for ``{{repos}}`` template substitution.
+        # ADR-063: write the canonical HTTPS form of typed RepositoryRef so the prompt
+        # never sees un-normalized slugs. TODO(#712): replace this with typed access
+        # once PromptBuilder consumes ``RepositoryRef`` directly.
         if repos and "repos" not in inputs:
-            inputs["repos"] = ",".join(repos)
+            inputs["repos"] = ",".join(r.https_url for r in repos)
         self._inputs = inputs
         aggregate = WorkflowExecutionAggregate()
 
@@ -226,7 +230,7 @@ class WorkflowExecutionProcessor:
         all_artifact_ids: list[str],
         completed_phase_ids: list[str],
         phase_outputs: dict[str, str],
-        repos: list[str] | None,
+        repos: list[RepositoryRef] | None,
     ) -> None:
         """Process to-do items until the list is empty (all phases done or cancelled)."""
         while True:
@@ -253,7 +257,7 @@ class WorkflowExecutionProcessor:
         all_artifact_ids: list[str],
         completed_phase_ids: list[str],
         phase_outputs: dict[str, str],
-        repos: list[str] | None,
+        repos: list[RepositoryRef] | None,
     ) -> None:
         """Dispatch a single to-do item to its handler."""
         assert todo.phase_id is not None
@@ -416,7 +420,7 @@ class WorkflowExecutionProcessor:
         todo: TodoItem,
         phase: ExecutablePhase,
         aggregate: WorkflowExecutionAggregate,
-        repos: list[str] | None,
+        repos: list[RepositoryRef] | None,
         completed_phase_ids: list[str],
         phase_outputs: dict[str, str],
     ) -> None:
@@ -456,12 +460,16 @@ class WorkflowExecutionProcessor:
             prompt_builder=self._prompt_builder,
             command_builder=self._command_builder,
         )
+        # ADR-063: convert typed RepositoryRef → HTTPS URL at the workspace seam.
+        # WorkspaceProvisionHandler consumes URLs (git clone, secret hydration);
+        # the typed value object stops here.
+        repo_urls = [r.https_url for r in (repos or [])]
         result = await provision_handler.handle(
             todo=todo,
             phase=phase,
             workflow_id=aggregate.workflow_id or "",
             session_id=session_id,
-            repos=repos,
+            repos=repo_urls,
             artifacts=artifacts,
             completed_phase_ids=completed_phase_ids,
             phase_outputs=phase_outputs,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_handlers.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_handlers.py
@@ -800,10 +800,10 @@ class TestResolveRepos:
             {},
             _make_workflow_stub(repos=["https://github.com/org/template-repo"]),
         )
-        assert result == ["https://github.com/org/typed-repo"]
+        assert result == [RepositoryRef.from_slug("org/typed-repo")]
 
     def test_typed_multi_repo_resolved(self) -> None:
-        """A list of typed RepositoryRefs is resolved into HTTPS URLs in order."""
+        """A list of typed RepositoryRefs flows through unchanged in order."""
         from syn_domain.contexts.orchestration.slices.execute_workflow.ExecuteWorkflowHandler import (
             ExecuteWorkflowHandler,
         )
@@ -816,8 +816,8 @@ class TestResolveRepos:
         )
         result = ExecuteWorkflowHandler._resolve_repos(cmd, {}, _make_workflow_stub())
         assert result == [
-            "https://github.com/org/repo-a",
-            "https://github.com/org/repo-b",
+            RepositoryRef.from_slug("org/repo-a"),
+            RepositoryRef.from_slug("org/repo-b"),
         ]
 
     def test_falls_back_to_template_repos_when_command_repos_empty(self) -> None:
@@ -831,7 +831,7 @@ class TestResolveRepos:
             {},
             _make_workflow_stub(repos=["https://github.com/org/repo-a"]),
         )
-        assert result == ["https://github.com/org/repo-a"]
+        assert result == [RepositoryRef.from_slug("org/repo-a")]
 
     def test_falls_back_to_repository_url_when_template_repos_empty(self) -> None:
         """Falls back to template repository_url when both command.repos and workflow.repos are empty."""
@@ -844,7 +844,7 @@ class TestResolveRepos:
             {},
             _make_workflow_stub(repository_url="https://github.com/org/repo-a"),
         )
-        assert result == ["https://github.com/org/repo-a"]
+        assert result == [RepositoryRef.from_slug("org/repo-a")]
 
     def test_empty_command_and_no_template_repos_returns_empty(self) -> None:
         """No command repos, no template repos, no repository_url -> empty list."""
@@ -893,4 +893,4 @@ class TestResolveRepos:
             {"repos": "ignored", "repository": "also/ignored"},
             _make_workflow_stub(),
         )
-        assert result == ["https://github.com/org/typed-repo"]
+        assert result == [RepositoryRef.from_slug("org/typed-repo")]

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_workflow_execution_processor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_workflow_execution_processor.py
@@ -168,10 +168,11 @@ class TestProcessorReposPersistence:
 
     @pytest.mark.anyio
     async def test_resolved_repos_written_to_inputs(self) -> None:
-        """Resolved repos list is persisted as CSV in inputs['repos']."""
+        """Typed RepositoryRefs are normalised to HTTPS URLs in inputs['repos']."""
         processor = _make_processor()
         processor._execution_repo.save = AsyncMock()
 
+        from syn_domain.contexts._shared.repository_ref import RepositoryRef
         from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
             ExecutablePhase,
         )
@@ -190,7 +191,7 @@ class TestProcessorReposPersistence:
             ],
             inputs=inputs,
             execution_id="exec-repos",
-            repos=["https://github.com/org/my-repo"],
+            repos=[RepositoryRef.from_slug("org/my-repo")],
         )
 
         assert inputs["repos"] == "https://github.com/org/my-repo"
@@ -201,6 +202,7 @@ class TestProcessorReposPersistence:
         processor = _make_processor()
         processor._execution_repo.save = AsyncMock()
 
+        from syn_domain.contexts._shared.repository_ref import RepositoryRef
         from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
             ExecutablePhase,
         )
@@ -219,7 +221,7 @@ class TestProcessorReposPersistence:
             ],
             inputs=inputs,
             execution_id="exec-no-overwrite",
-            repos=["https://github.com/org/resolved"],
+            repos=[RepositoryRef.from_url("https://github.com/org/resolved")],
         )
 
         assert inputs["repos"] == "https://github.com/org/explicit"

--- a/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_661_regression.py
+++ b/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_661_regression.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from syn_domain.contexts._shared.repository_ref import RepositoryRef
 from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
     ExecutionStatus,
     PhaseDefinition,
@@ -224,7 +225,7 @@ class TestReposVariableSubstitution:
     """ExecuteWorkflowHandler._resolve_repos must apply {{variable}} substitution."""
 
     def test_variable_in_repos_resolves_with_input(self):
-        """{{owner}}/app + merged_inputs["owner"] = acme -> full GitHub URL."""
+        """{{owner}}/app + merged_inputs["owner"] = acme -> typed RepositoryRef."""
         wf = _make_workflow_with_repos(["{{owner}}/app"])
         result = ExecuteWorkflowHandler._resolve_repos(
             _empty_cmd(),
@@ -232,7 +233,7 @@ class TestReposVariableSubstitution:
             wf,  # type: ignore[arg-type]
         )
 
-        assert result == ["https://github.com/acme/app"]
+        assert result == [RepositoryRef.from_slug("acme/app")]
 
     def test_variable_in_full_url_resolves(self):
         """Full URL template resolves correctly."""
@@ -243,7 +244,7 @@ class TestReposVariableSubstitution:
             wf,  # type: ignore[arg-type]
         )
 
-        assert result == ["https://github.com/myorg/myapp"]
+        assert result == [RepositoryRef.from_slug("myorg/myapp")]
 
     def test_unresolved_placeholder_raises_value_error(self):
         """Missing input for {{variable}} must raise ValueError, not silently fall back."""
@@ -268,7 +269,7 @@ class TestReposVariableSubstitution:
             )
 
     def test_static_url_passes_through_unchanged(self):
-        """Static repos without {{}} are returned as-is (no normalisation change)."""
+        """Static repos without {{}} are parsed into typed RepositoryRef."""
         wf = _make_workflow_with_repos(["https://github.com/acme/app"])
         result = ExecuteWorkflowHandler._resolve_repos(
             _empty_cmd(),
@@ -276,7 +277,7 @@ class TestReposVariableSubstitution:
             wf,  # type: ignore[arg-type]
         )
 
-        assert result == ["https://github.com/acme/app"]
+        assert result == [RepositoryRef.from_slug("acme/app")]
 
     def test_multiple_repos_all_resolved(self):
         """All repos in the list get substitution applied."""
@@ -288,8 +289,8 @@ class TestReposVariableSubstitution:
         )
 
         assert result == [
-            "https://github.com/acme/app1",
-            "https://github.com/acme/app2",
+            RepositoryRef.from_slug("acme/app1"),
+            RepositoryRef.from_slug("acme/app2"),
         ]
 
     def test_inputs_repos_without_typed_command_repos_raises(self):
@@ -316,4 +317,4 @@ class TestReposVariableSubstitution:
             wf,  # type: ignore[arg-type]
         )
 
-        assert result == ["https://github.com/acme/fallback"]
+        assert result == [RepositoryRef.from_slug("acme/fallback")]

--- a/uv.lock
+++ b/uv.lock
@@ -1318,7 +1318,7 @@ wheels = [
 
 [[package]]
 name = "syn-adapters"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "packages/syn-adapters" }
 dependencies = [
     { name = "agentic-events" },
@@ -1370,7 +1370,7 @@ provides-extras = ["postgres", "minio", "all"]
 
 [[package]]
 name = "syn-api"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "apps/syn-api" }
 dependencies = [
     { name = "agentic-logging" },
@@ -1401,7 +1401,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-collector"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "packages/syn-collector" }
 dependencies = [
     { name = "click" },
@@ -1441,7 +1441,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "syn-domain"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "packages/syn-domain" }
 dependencies = [
     { name = "agentic-events" },
@@ -1462,7 +1462,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-perf"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "packages/syn-perf" }
 dependencies = [
     { name = "rich" },
@@ -1490,7 +1490,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "syn-shared"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "packages/syn-shared" }
 dependencies = [
     { name = "pydantic" },
@@ -1509,7 +1509,7 @@ requires-dist = [
 
 [[package]]
 name = "syn-tokens"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "packages/syn-tokens" }
 dependencies = [
     { name = "pydantic" },
@@ -1526,7 +1526,7 @@ requires-dist = [
 
 [[package]]
 name = "syntropic137"
-version = "0.25.0"
+version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "event-sourcing-python" },


### PR DESCRIPTION
## Summary

Closes three P0 blockers that v0.25.1 post-release validation surfaced. Ships as a patch release, no domain-schema changes. Roadmap: `docs/testing/output/v0.25.2-v0.26-roadmap.md`.

| P0 | Root cause | Fix |
|---|---|---|
| **P0-1** Workflow runs silently succeed with bad `--input repository=…` | CLI smuggled repos via `inputs`; API returned 200 and only raised `ValueError` inside a `BackgroundTask` (which FastAPI swallows) | CLI rejects `repository`/`repos` input keys; API rejects at the boundary with 422; repos are a typed `-R` channel only |
| **P0-2** Phase-2 provisioning fails as "Unknown error" | docker-socket-proxy didn't allow `/networks/*` or `/info`; the agentic adapter swallowed the real exception | Compose allow-list extended to `NETWORKS=1 INFO=1`; adapter wraps `provider.create` in `WorkspaceProvisionError` with `from exc` chaining |
| **P0-3** Triggers register with empty `installation_id` | API handed the raw `repo-*` ID to GitHub's App API, which needs `owner/name` | `_resolve_installation_id` looks up the repo projection and uses `full_name` |

## Review-feedback follow-ons (added to the PR after the initial fixes)

| Area | Change | Tracking |
|---|---|---|
| **Typing leak** | Pushed `RepositoryRef` end-to-end through preflight + `WorkflowExecutionProcessor`, removed the un-normalized internal CSV write | Phase 2: #712 (kill the dict-write entirely once `PromptBuilder` consumes typed) |
| **Docstring honesty** | `_resolve_installation_id` no longer claims "the poller re-resolves on first fire" — that path doesn't exist; triggers with empty `installation_id` are silently skipped at polling until re-registered | Phase 2: #713 (build the real lazy re-resolve at polling time) |
| **Security ADR** | ADR-021 addendum documenting the socket-proxy `NETWORKS=1` / `INFO=1` widening: blast-radius delta, alternatives considered, sidecar narrowing path | Phase 2: #714 (sidecar pattern to revoke `NETWORKS=1` from the API) |
| **CLI edge tests** | Mixed `-R repo-* -R owner/repo` and missing-`full_name` lookup paths now covered | — |

## Changes

1. `fix(infra)` — docker-socket-proxy `NETWORKS=1`, `INFO=1`; security-practices.md allow-list documented
2. `fix(api)` — reserved `repos`/`repository` input keys rejected at the HTTP boundary
3. `fix(api)` — trigger `installation_id` resolves via repo projection for `repo-*` IDs
4. `fix(adapter)` — `WorkspaceProvisionError` surfaces the real docker error up through `_fail_execution`
5. `fix(cli)` — `-R` accepts `owner/repo` / URL / `repo-*`; rejects `--input repository=…`; fails loud on non-`started` responses
6. `fix(cli)` — actionable hints for missing `execution-id` / `trigger-id` (`syn execution list`, etc.)
7. `docs(runbook)` — `post-release-validation.md` synced with v0.25.2 behavior (GitHub App pre-flight, `-R` semantics, `installation_id` check, `--max-attempts`)
8. `chore` — `uv.lock` sync + codegen regen (OpenAPI spec, TS types, CLI docs)
9. `fix(api,domain)` — typed `RepositoryRef` flow-through (ADR-063 boundary fully closed inside orchestration context)
10. `docs+tests` — review nits: trigger docstring honesty, CLI resolveRepoRefs edge tests, ADR-021 socket-proxy addendum
11. `docs(architecture)` — auto-regenerated event ordering + projection subscriptions

## Test plan

Gates that should now be green on a fresh `npx @syntropic137/setup install` stack:

- [ ] `syn workflow run <id> --input repository=X` → clean 422 with migration message, non-zero exit
- [ ] `syn workflow run <id> -R repo-<id>` → resolves to URL, returns `exec-*` ID, execution runs
- [ ] `syn workflow run <id> -R owner/a -R owner/b` → both repos provisioned and visible in workspace
- [ ] `syn triggers register … -R repo-<id>` → persisted with non-empty `installation_id`
- [ ] Phase-2 workflow provisions a new network and runs to completion on a fresh stack
- [ ] A socket-proxy denial shows the real message in `syn execution show`, not "Unknown error"

### Local verification (already run on this branch)

- [x] `just fitness-check` — PASS
- [x] `just docs-sync` — PASS (after running `vsa manifest`)
- [x] `uv run ruff check .` / `ruff format --check .` — PASS (986 files clean)
- [x] `apps/syn-api/tests/test_execute_repo_validation.py` + `test_api_triggers.py` — 50/50 pass
- [x] `apps/syn-cli-node` — 225/225 pass (31 test files, includes new edge-case tests)
- [x] `packages/syn-adapters/tests/workspace_backends/test_agentic_adapter_error.py` — 2/2 pass
- [x] `packages/syn-domain` regression suite for ADR-063 typing flow-through — 104/104 pass

## Release notes (v0.25.2 draft — verbatim into GitHub Release)

> Fixes three open-source launch blockers:
> - Workflow runs no longer silently succeed when `repository` is passed as an input (clean 422; use `-R owner/repo` repeatable).
> - Phase 2 provisioning works (docker-socket-proxy allow-list extended); real error messages surface instead of "Unknown error".
> - Triggers registered with syn `repo-*` IDs now resolve `installation_id` correctly.
>
> **Quality follow-ons:** typed `RepositoryRef` now travels end-to-end through the orchestration context (ADR-063 boundary fully closed inside this PR; see #712 for Phase-2 cleanup). Honest docs for trigger registration edge cases (#713). ADR-021 addendum documents the socket-proxy widening trade-off and future narrowing path (#714).
>
> **Upgrade:** existing self-host users must run `npx @syntropic137/setup update` to apply the docker-compose change.