### PR TITLE
fix(#720): allow workspace image auto-pull via docker-socket-proxy IMAGES=1

### DIFF
--- a/docker/docker-compose.syntropic137.yaml
+++ b/docker/docker-compose.syntropic137.yaml
@@ -183,6 +183,7 @@ services:
       POST: "1"
       NETWORKS: "1"
       INFO: "1"
+      IMAGES: "1"
     volumes:
     - /var/run/docker.sock:/var/run/docker.sock:ro
     security_opt:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -99,6 +99,10 @@ services:
       POST: 1           # Enable all non-GET verbs (POST, DELETE, PUT)
       NETWORKS: 1       # ADR-021: agentic_isolation provisioning creates/inspects agent-net
       INFO: 1           # agentic_isolation probes engine capabilities via /info
+      IMAGES: 1         # #720 / ADR-024 (2026-05-01): allow `docker run` to auto-pull missing
+                        # workspace images. Without this every selfhost user hits 403 Forbidden
+                        # on first workflow run because POST /images/create is blocked.
+                        # Trade-off documented in ADR-024 amendment.
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     security_opt:

--- a/docs/adrs/ADR-024-setup-phase-secrets.md
+++ b/docs/adrs/ADR-024-setup-phase-secrets.md
@@ -444,3 +444,51 @@ mkdir -p /workspace/repos
 | Repo cloning | Not in setup phase | Appended by `build_setup_script()` |
 | Auth failure mode | Silent / runtime git error | Fail fast before any cloning |
 | Multi-org support | Not supported | Supported via per-installation tokens |
+
+---
+
+## 2026-05-01 Update: Docker socket proxy `IMAGES=1` (Issue #720)
+
+### Context
+
+Every first-time selfhost user (`npx syntropic137 init` then any workflow run) hit `403 Forbidden` because `syn137-docker-socket-proxy` did not allow `POST /images/create`. The Docker daemon attempted to pull the missing workspace image when `docker run` was invoked, the proxy rejected the call, and the workspace failed to provision. The only workaround was SSH'ing to the host and running `docker pull` manually — unacceptable for OSS launch.
+
+### Decision
+
+`IMAGES=1` is added to the `tecnativa/docker-socket-proxy` environment in `docker/docker-compose.yaml`. This permits the platform process (syn-api) to invoke any endpoint under `/images/*` on the Docker daemon, including the `POST /images/create` that `docker run` triggers implicitly when an image is missing locally.
+
+### What this changes about the trust posture
+
+`tecnativa/docker-socket-proxy`'s ACL is grouped at the resource-prefix level, not per-endpoint. Enabling `IMAGES=1` opens **all** `/images/*` endpoints to the platform process:
+
+| Endpoint | Used by platform? | Risk if exploited |
+|---|---|---|
+| `POST /images/create` | YES (auto-pull on `docker run`) | the desired capability |
+| `GET /images/json` | NO | low (image inventory disclosure) |
+| `POST /build` | NO | HIGH (arbitrary Dockerfile execution by a compromised platform process) |
+| `POST /images/{name}/push` | NO | HIGH (image exfiltration to attacker registry) |
+| `POST /images/{name}/tag` | NO | medium (image confusion / supply-chain misdirection) |
+| `POST /commit` | NO | medium (snapshot a container as an image) |
+| `POST /images/load` | NO | HIGH (load arbitrary image from tarball) |
+| `DELETE /images/{name}` | NO | medium (DoS via deletion of in-use images) |
+
+The platform code only invokes `POST /images/create` (transitively, via `docker run`). The unused endpoints are reachable only if syn-api itself is compromised (e.g., a FastAPI dependency vuln yielding RCE). For single-tenant selfhost deployments where the operator owns the host and trusts the syn137 release, this trade-off is acceptable: the operational benefit (the system self-heals when new workspace images appear, no `npx init` re-run needed for workspace upgrades) clearly outweighs the marginal RCE blast-radius increase.
+
+For multi-tenant or untrusted-prompt deployments, this trade-off should be revisited:
+
+- A finer-grained proxy (URL-pattern + image-allowlist filter, e.g., a small Caddy or custom Go proxy) could grant only `POST /images/create` for images on a deployment-time allowlist, denying all other `/images/*` endpoints.
+- Alternatively, a dedicated "pull manager" sidecar with the same allowlist semantics, exposed to syn-api over a tiny REST API, would compose with the existing token-injector sidecar pattern.
+
+Neither is in scope for this change. They become required if/when the platform supports multi-tenant.
+
+### Where the responsibility lives
+
+The proxy ACL change is a deployment-config change (`docker/docker-compose.yaml`). It does not introduce any new platform code path. The existing `WorkspaceDockerProvider.create()` in `agentic-primitives` already issues `docker run`; that call's implicit pull was being rejected at the proxy layer. Once the proxy permits the call, the existing code path works without modification.
+
+The Syn137 HTTP API surface (`syn-api`) is unchanged. There is no new endpoint and no new external-facing capability — this change only unblocks an internal call from the platform process to the Docker daemon.
+
+### Versioning consideration
+
+This change does NOT pin the workspace image to a specific digest. The default `WORKSPACE_IMAGE_PROVIDER=claude-cli` and `DEFAULT_TAG="latest"` continue to apply, so deployments float with whatever `:latest` is at GHCR. Operators who want reproducibility can pin via the existing `SYN_WORKSPACE_DOCKER_IMAGE` env var to a specific tag or digest.
+
+This intentionally defers the "workspace image versioning + compatibility strategy" question to a follow-up issue. The right policy (recommended pin tag, compatibility matrix, what does it mean for platform vN to support workspace image vM) needs an ADR of its own.

--- a/docs/adrs/ADR-024-setup-phase-secrets.md
+++ b/docs/adrs/ADR-024-setup-phase-secrets.md
@@ -459,20 +459,20 @@ Every first-time selfhost user (`npx syntropic137 init` then any workflow run) h
 
 ### What this changes about the trust posture
 
-`tecnativa/docker-socket-proxy`'s ACL is grouped at the resource-prefix level, not per-endpoint. Enabling `IMAGES=1` opens **all** `/images/*` endpoints to the platform process:
+`tecnativa/docker-socket-proxy`'s ACL is grouped at the resource-prefix level, not per-endpoint. Enabling `IMAGES=1` opens **all `/images/*` endpoints** to the platform process:
 
 | Endpoint | Used by platform? | Risk if exploited |
 |---|---|---|
 | `POST /images/create` | YES (auto-pull on `docker run`) | the desired capability |
 | `GET /images/json` | NO | low (image inventory disclosure) |
-| `POST /build` | NO | HIGH (arbitrary Dockerfile execution by a compromised platform process) |
 | `POST /images/{name}/push` | NO | HIGH (image exfiltration to attacker registry) |
 | `POST /images/{name}/tag` | NO | medium (image confusion / supply-chain misdirection) |
-| `POST /commit` | NO | medium (snapshot a container as an image) |
 | `POST /images/load` | NO | HIGH (load arbitrary image from tarball) |
 | `DELETE /images/{name}` | NO | medium (DoS via deletion of in-use images) |
 
-The platform code only invokes `POST /images/create` (transitively, via `docker run`). The unused endpoints are reachable only if syn-api itself is compromised (e.g., a FastAPI dependency vuln yielding RCE). For single-tenant selfhost deployments where the operator owns the host and trusts the syn137 release, this trade-off is acceptable: the operational benefit (the system self-heals when new workspace images appear, no `npx init` re-run needed for workspace upgrades) clearly outweighs the marginal RCE blast-radius increase.
+`POST /build` and `POST /commit` are **not** under the `/images/*` prefix and therefore are **not** made reachable by `IMAGES=1`. They remain blocked unless their own proxy flags (`BUILD=1`, `COMMIT=1`) are enabled separately, which this change does not do.
+
+The platform code only invokes `POST /images/create` (transitively, via `docker run`). The unused `/images/*` endpoints are reachable only if syn-api itself is compromised (e.g., a FastAPI dependency vuln yielding RCE). For single-tenant selfhost deployments where the operator owns the host and trusts the syn137 release, this trade-off is acceptable: the operational benefit (the system self-heals when new workspace images appear, no `npx init` re-run needed for workspace upgrades) clearly outweighs the marginal RCE blast-radius increase.
 
 For multi-tenant or untrusted-prompt deployments, this trade-off should be revisited:
 


### PR DESCRIPTION
## Summary

Closes #720. Every first-time selfhost user (`npx syntropic137 init` then any workflow) hits `403 Forbidden` because `syn137-docker-socket-proxy` blocks `POST /images/create`. The Docker daemon's implicit pull on `docker run` gets rejected, the workspace fails to provision, the only workaround is SSH'ing to the host and running `docker pull` manually. This is a P0 launch blocker.

## Change

Three files, ~50 lines net:

- **`docker/docker-compose.yaml`**: `IMAGES: 1` added to `tecnativa/docker-socket-proxy` env with inline rationale comment.
- **`docker/docker-compose.syntropic137.yaml`**: regenerated via `scripts/generate_published_compose.py`.
- **`docs/adrs/ADR-024-setup-phase-secrets.md`**: 2026-05-01 update appended documenting the trust posture, the unused-but-now-reachable endpoints, the single-tenant/multi-tenant trade-off, and the deferred versioning question.

No platform code changes. The existing `WorkspaceDockerProvider.create()` in agentic-primitives already issues `docker run` with implicit pull semantics; we just stop blocking it at the proxy layer.

## What this does NOT do

Per discussion in cycle-002 dogfood:

- **Does not pin a workspace image digest.** `DEFAULT_TAG="latest"` continues, deployments float with GHCR's `:latest`. Operators wanting reproducibility can pin via the existing `SYN_WORKSPACE_DOCKER_IMAGE` env var. Workspace image versioning + compatibility strategy is deferred to its own ADR.
- **Does not add a CI digest-freshness workflow.** Only useful if pinning, which we are not.
- **Does not add a `ensure_image()` adapter method.** `docker run` triggers the pull natively once `IMAGES=1` is permitted; explicit progress logging is a UX polish, not a fix.
- **Does not modify the syn-api HTTP surface.** No new endpoints. The proxy ACL change unblocks an internal call from the platform process to the Docker daemon — the FastAPI surface is unchanged.

## Trade-off (accepted)

`tecnativa/docker-socket-proxy` ACL is grouped at the resource-prefix level. `IMAGES=1` opens all `/images/*` endpoints, including ones the platform does not invoke (`/build`, `/push`, `/tag`, `/load`, `DELETE`, `/commit`). Only escalation path: a syn-api RCE. Acceptable for single-tenant selfhost; multi-tenant deployments should revisit per the ADR-024 amendment (finer-grained pull-only proxy or pull-manager sidecar).

## Companion changes (separate PRs)

- `syntropic137-npx` PR (planned, this same session): pre-pull during `npx init` for first-run latency. Not required for correctness — this PR alone makes the system self-heal.
- agentic-primitives [PR #157](https://github.com/AgentParadise/agentic-primitives/pull/157): bumps Claude CLI to 2.1.126 + uv-base. Once it merges and republishes `:latest`, every selfhost auto-upgrades on next workflow run thanks to this PR.

## Test plan

- [x] `scripts/generate_published_compose.py --check` confirms regenerated published compose is up-to-date with source
- [x] YAML lint on both compose files (valid)
- [x] `ruff check` + `ruff format --check` pass
- [ ] Reviewer pulls branch, redeploys Mac mini stack, deletes the local workspace image (`docker rmi ghcr.io/agentparadise/agentic-workspace-claude-cli:latest`), runs any workflow, observes auto-pull + successful workspace provisioning
- [ ] No regression on existing executions (already-pulled image)

## Provenance

This fix was scoped via the cycle-002 dogfood loop — research-001 + plan-001 produced the original implementation plan, then human review (lens-style: trust boundary, layer responsibility, terminology) trimmed the scope from "PR 1+2+3 with constants, CI, ensure_image" to this minimal correct fix. Full discussion in `docs/experiments/cycle-002/` and `docs/experiments/findings/2026-05-01-cycle-002-planning-gaps.md`.