### PR TITLE
chore: bump version to v0.25.3

### DIFF
--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.25.2"
+version = "0.25.3"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli-node/package.json
+++ b/apps/syn-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntropic137/cli",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "description": "Syntropic137 CLI - Event-sourced workflow engine for AI agents",
   "type": "module",
   "bin": {

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.25.2",
+  "version": "0.25.3",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-docs/package.json
+++ b/apps/syn-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-docs",
-  "version": "0.25.2",
+  "version": "0.25.3",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/docs/architecture/event-flows/README.md
+++ b/docs/architecture/event-flows/README.md
@@ -14,17 +14,17 @@ This table shows the most important event flows in Syn137 (events that feed the 
 | ? | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
-| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
+| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
 | ? | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
-| ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
-| ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
 | ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
+| ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
 
 ---
 

--- a/docs/architecture/projection-subscriptions.md
+++ b/docs/architecture/projection-subscriptions.md
@@ -19,12 +19,12 @@ graph LR
         e2[workflow_failed]
         e3[workflow_completed]
         e4[phase_completed]
-        e5[execution_cancelled]
-        e6[workflow_template_created]
-        e7[trigger_fired]
-        e8[workflow_interrupted]
+        e5[workflow_template_created]
+        e6[execution_cancelled]
+        e7[workflow_interrupted]
+        e8[trigger_fired]
         e9[phase_started]
-        e10[session_completed]
+        e10[session_summary]
     end
 
     subgraph projections["Projections"]
@@ -45,17 +45,18 @@ graph LR
         p15[TriggerHistoryProjection]
     end
 
-    e10 --> p11
-    e10 --> p2
+    e10 --> p10
+    e10 --> p3
+    e5 --> p2
+    e6 --> p4
     e2 --> p8
     e2 --> p7
     e2 --> p4
     e2 --> p2
-    e5 --> p4
-    e6 --> p2
-    e7 --> p6
-    e7 --> p15
-    e8 --> p4
+    e7 --> p4
+    e4 --> p4
+    e8 --> p6
+    e8 --> p15
     e1 --> p6
     e1 --> p4
     e1 --> p2
@@ -64,7 +65,6 @@ graph LR
     e3 --> p4
     e3 --> p2
     e9 --> p2
-    e4 --> p4
 ```
 
 ---
@@ -85,12 +85,12 @@ graph LR
 | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
-| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
+| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
 | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
+| session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
 
 ---
 

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.25.2"
+version = "0.25.3"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.25.2"
+version = "0.25.3"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.25.2"
+version = "0.25.3"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.25.2"
+version = "0.25.3"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.25.2"
+version = "0.25.3"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.25.2"
+version = "0.25.3"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.25.2"
+version = "0.25.3"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch bump for the v0.25.3 release. Bundles three first-run / self-host fixes that landed since v0.25.2:

- **#722** workspace credential injection (real OAuth/API key into agent env, ADR-024 amended)
- **#727** docker-socket-proxy IMAGES=1 (workspace image auto-pull self-heals)
- **npx#61** token prefix routing (paste OAT or API key, routed to correct .env field)
- **#719** sessions + executions monitor UI (ADR-064 phase 1+2)

11 versioned files updated by `just bump-version 0.25.3`. Plus a regen of `docs/architecture/{event-flows/README.md,projection-subscriptions.md}` for row-ordering drift (preexisting, unrelated to this bump).

Once merged, the next step is opening the release PR (`release ← main`) to fire the release-gate checks.