### PR TITLE
fix: pin envoy + multi-arch dry-run (native runners) + gate CLI on containers (#736)

### DIFF
--- a/.github/workflows/_check-docker-dry-run.yml
+++ b/.github/workflows/_check-docker-dry-run.yml
@@ -11,10 +11,11 @@
 # image, but the PR-time gate had only built AMD64 and passed. Now we catch
 # this class of issue pre-merge.
 #
-# Trade-off: ARM64 emulation is 3-5x slower than native AMD64. PR-gate CI
-# time is up by ~20-30 min total across all images. Acceptable because this
-# only fires on release PRs (low frequency), and the cost of catching a
-# multi-arch flake in production (re-run + operator stress) is higher.
+# We use NATIVE GitHub-hosted runners (ubuntu-latest for amd64, ubuntu-24.04-arm
+# for arm64), NOT QEMU emulation. Each (image × arch) combination is its own
+# matrix job and builds at native speed, so wall-clock time is roughly the
+# same as the original single-arch gate. ARM64 runners are GA on public
+# repos as of early 2025; this repo is public.
 #
 # Always runs - no path-filter skip logic. Docker layer caching (GHA cache,
 # per-image-and-platform scope) makes unchanged builds near-instant on
@@ -37,32 +38,38 @@ permissions:
 
 jobs:
   docker-dry-run:
-    name: "Docker Build: ${{ matrix.image }}"
-    runs-on: ubuntu-latest
-    timeout-minutes: 60  # multi-arch ARM64 emulation is 3-5x slower than native AMD64 (#736)
+    name: "Docker Build: ${{ matrix.image }} (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          - image: syn-api
-            dockerfile: infra/docker/images/syn-api/Dockerfile
-            context: "."
-            build-args: "INCLUDE_DOCKER_CLI=1"
-          - image: syn-gateway
-            dockerfile: infra/docker/images/gateway/Dockerfile
-            context: "."
-          - image: syn-collector
-            dockerfile: packages/syn-collector/Dockerfile
-            context: "."
-          - image: syn-dashboard-ui
-            dockerfile: apps/syn-dashboard-ui/Dockerfile
-            context: "."
-          - image: sidecar-proxy
-            dockerfile: docker/sidecar-proxy/Dockerfile
-            context: docker/sidecar-proxy
-          - image: token-injector
-            dockerfile: docker/token-injector/Dockerfile
-            context: docker/token-injector
+          # syn-api — multi-arch (matches release-containers.yaml)
+          - { image: syn-api, dockerfile: infra/docker/images/syn-api/Dockerfile, context: ".", build-args: "INCLUDE_DOCKER_CLI=1", arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: syn-api, dockerfile: infra/docker/images/syn-api/Dockerfile, context: ".", build-args: "INCLUDE_DOCKER_CLI=1", arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
+          # syn-gateway — multi-arch
+          - { image: syn-gateway, dockerfile: infra/docker/images/gateway/Dockerfile, context: ".", arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: syn-gateway, dockerfile: infra/docker/images/gateway/Dockerfile, context: ".", arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
+          # syn-collector — multi-arch
+          - { image: syn-collector, dockerfile: packages/syn-collector/Dockerfile, context: ".", arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: syn-collector, dockerfile: packages/syn-collector/Dockerfile, context: ".", arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
+          # syn-dashboard-ui — amd64 only (matches release-containers.yaml; UI
+          # is shipped amd64-only because it's a static asset bundle that
+          # serves both archs identically at runtime)
+          - { image: syn-dashboard-ui, dockerfile: apps/syn-dashboard-ui/Dockerfile, context: ".", arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+
+          # sidecar-proxy — multi-arch
+          - { image: sidecar-proxy, dockerfile: docker/sidecar-proxy/Dockerfile, context: docker/sidecar-proxy, arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: sidecar-proxy, dockerfile: docker/sidecar-proxy/Dockerfile, context: docker/sidecar-proxy, arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
+          # token-injector — multi-arch
+          - { image: token-injector, dockerfile: docker/token-injector/Dockerfile, context: docker/token-injector, arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: token-injector, dockerfile: docker/token-injector/Dockerfile, context: docker/token-injector, arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
           # agentic-workspace uses build-provider.py staging - validated
           # separately in e2e-container.yml, skip in gate to save CI time.
 
@@ -71,30 +78,22 @@ jobs:
         with:
           submodules: true
 
-      # QEMU is required for cross-architecture (ARM64) builds via emulation.
-      # Without this, build-push-action fails when platforms includes a
-      # non-host architecture.
-      - uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3
-
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      - name: Build multi-arch (no push, no load)
+      - name: Build single-arch native (no push)
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          # Multi-arch matches what release-containers.yaml publishes for
-          # server images. The UI is amd64-only and publishes separately, but
-          # building it for arm64 here is harmless verification.
-          # Note: load:true is incompatible with multi-platform — Docker can
-          # only load one platform at a time. We just verify the build
-          # succeeds; nothing needs to load locally for the gate's purpose.
-          platforms: linux/amd64,linux/arm64
+          # Single-platform per matrix entry. The runner is already that arch
+          # (ubuntu-latest for amd64, ubuntu-24.04-arm for arm64), so the
+          # build is native — no QEMU emulation overhead.
+          platforms: ${{ matrix.platform }}
           push: false
+          load: true
           tags: test/${{ matrix.image }}:gate
           build-args: ${{ matrix.build-args }}
-          # Per-image cache scope. Suffixed with -multiarch so this cache
-          # doesn't collide with any other workflow that builds the same
-          # image single-arch (#736).
-          cache-from: type=gha,scope=${{ matrix.image }}-multiarch
-          cache-to: type=gha,scope=${{ matrix.image }}-multiarch,mode=max
+          # Per-(image,arch) cache scope so amd64 and arm64 caches don't
+          # collide. (#736)
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }},mode=max

--- a/.github/workflows/_check-docker-dry-run.yml
+++ b/.github/workflows/_check-docker-dry-run.yml
@@ -1,11 +1,24 @@
 # =============================================================================
 # Check: Docker Dry-Run
 # =============================================================================
-# Builds all container images (single-arch, no push) to verify Dockerfiles
-# are valid and all build contexts resolve correctly.
+# Builds all container images MULTI-ARCH (linux/amd64 + linux/arm64) without
+# push, to verify Dockerfiles are valid AND that both target architectures
+# build cleanly. ARM64 cross-builds via QEMU emulation hit different package
+# mirrors than AMD64 native builds and have a different failure profile.
+#
+# Multi-arch was added per #736: v0.25.3 release pipeline failed at the
+# multi-arch publish step on a stale Debian apt source in the envoy base
+# image, but the PR-time gate had only built AMD64 and passed. Now we catch
+# this class of issue pre-merge.
+#
+# Trade-off: ARM64 emulation is 3-5x slower than native AMD64. PR-gate CI
+# time is up by ~20-30 min total across all images. Acceptable because this
+# only fires on release PRs (low frequency), and the cost of catching a
+# multi-arch flake in production (re-run + operator stress) is higher.
 #
 # Always runs - no path-filter skip logic. Docker layer caching (GHA cache,
-# per-image scope) makes unchanged images near-instant on subsequent runs.
+# per-image-and-platform scope) makes unchanged builds near-instant on
+# subsequent runs.
 #
 # Called by: release-gate.yml
 #
@@ -26,7 +39,7 @@ jobs:
   docker-dry-run:
     name: "Docker Build: ${{ matrix.image }}"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60  # multi-arch ARM64 emulation is 3-5x slower than native AMD64 (#736)
     strategy:
       fail-fast: false
       matrix:
@@ -58,16 +71,30 @@ jobs:
         with:
           submodules: true
 
+      # QEMU is required for cross-architecture (ARM64) builds via emulation.
+      # Without this, build-push-action fails when platforms includes a
+      # non-host architecture.
+      - uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3
+
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      - name: Build (no push)
+      - name: Build multi-arch (no push, no load)
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          # Multi-arch matches what release-containers.yaml publishes for
+          # server images. The UI is amd64-only and publishes separately, but
+          # building it for arm64 here is harmless verification.
+          # Note: load:true is incompatible with multi-platform — Docker can
+          # only load one platform at a time. We just verify the build
+          # succeeds; nothing needs to load locally for the gate's purpose.
+          platforms: linux/amd64,linux/arm64
           push: false
-          load: true
           tags: test/${{ matrix.image }}:gate
           build-args: ${{ matrix.build-args }}
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+          # Per-image cache scope. Suffixed with -multiarch so this cache
+          # doesn't collide with any other workflow that builds the same
+          # image single-arch (#736).
+          cache-from: type=gha,scope=${{ matrix.image }}-multiarch
+          cache-to: type=gha,scope=${{ matrix.image }}-multiarch,mode=max

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -146,10 +146,19 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Step 4: Build, test, publish CLI to npm
+  #
+  # Gated on `release-containers` success: the published CLI's compose template
+  # references container images at this version tag. If a container build
+  # failed, those tags don't exist on GHCR, and operators upgrading via
+  # `npx @syntropic137/setup update` would pull a CLI that points at missing
+  # images. Wait for containers to be reachable before publishing the CLI.
+  #
+  # See post-mortem on the v0.25.3 release: sidecar-proxy failed but CLI
+  # published anyway, leaving npm v0.25.3 in a broken state.
   # ---------------------------------------------------------------------------
   release-cli:
     name: CLI
-    needs: [create-release, pre-publish-validation]
+    needs: [create-release, pre-publish-validation, release-containers]
     if: needs.create-release.outputs.created == 'true'
     uses: ./.github/workflows/release-cli.yaml
     with:

--- a/docker/sidecar-proxy/Dockerfile
+++ b/docker/sidecar-proxy/Dockerfile
@@ -3,7 +3,10 @@
 #
 # Build: docker build -t envoy-proxy:latest .
 
-FROM envoyproxy/envoy:v1.31-latest
+# Pinned to a specific patch version. v1.31-latest was last pushed 2025-07-18
+# and its baked Debian apt sources went stale, breaking apt-get install (#736).
+# Bumping to v1.34.14 (pushed 2026-04-10). Update via the same PR pattern.
+FROM envoyproxy/envoy:v1.34.14
 
 # Install CA certificates for TLS verification and curl for health checks
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*

--- a/docs/architecture/event-flows/README.md
+++ b/docs/architecture/event-flows/README.md
@@ -11,20 +11,20 @@ This table shows the most important event flows in Syn137 (events that feed the 
 | Command | Event | Projections | Count |
 |---------|-------|-------------|-------|
 | ? | workflow_execution_started | RepoCorrelationProjection, WorkflowExecutionDetailProjection, WorkflowDetailProjection... | 7 |
-| ? | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
+| ? | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
-| ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
 | ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
+| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
-| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
 | ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
 | ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
+| ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
 
 ---
 

--- a/docs/architecture/projection-subscriptions.md
+++ b/docs/architecture/projection-subscriptions.md
@@ -16,15 +16,15 @@ This diagram shows which events feed which projections in the Syn137 system.
 graph LR
     subgraph events["Key Events"]
         e1[workflow_execution_started]
-        e2[workflow_failed]
-        e3[workflow_completed]
+        e2[workflow_completed]
+        e3[workflow_failed]
         e4[phase_completed]
-        e5[workflow_template_created]
-        e6[execution_cancelled]
-        e7[workflow_interrupted]
-        e8[trigger_fired]
+        e5[workflow_interrupted]
+        e6[workflow_template_created]
+        e7[trigger_fired]
+        e8[execution_cancelled]
         e9[phase_started]
-        e10[session_summary]
+        e10[agent_observation]
     end
 
     subgraph projections["Projections"]
@@ -47,19 +47,19 @@ graph LR
 
     e10 --> p10
     e10 --> p3
-    e5 --> p2
-    e6 --> p4
+    e4 --> p4
     e2 --> p8
     e2 --> p7
     e2 --> p4
     e2 --> p2
-    e7 --> p4
-    e4 --> p4
-    e8 --> p6
-    e8 --> p15
+    e5 --> p4
     e1 --> p6
     e1 --> p4
     e1 --> p2
+    e6 --> p2
+    e7 --> p6
+    e7 --> p15
+    e8 --> p4
     e3 --> p8
     e3 --> p7
     e3 --> p4
@@ -82,15 +82,15 @@ graph LR
 | Event | Projections | Count |
 |-------|-------------|-------|
 | workflow_execution_started | RepoCorrelationProjection, WorkflowExecutionDetailProjection, WorkflowDetailProjection... | 7 |
-| workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
+| workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
-| workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
 | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
+| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
+| agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
 
 ---
 


### PR DESCRIPTION
Closes #736.

## Three fixes in one PR (release pipeline hygiene)

The v0.25.3 release pipeline failed twice and left npm in a half-published state. This PR addresses the root causes plus the orchestration ordering that let the partial state happen.

### 1. \`docker/sidecar-proxy/Dockerfile\`: pin envoy to v1.34.14

Was: \`envoyproxy/envoy:v1.31-latest\` (last pushed 2025-07-18; baked apt sources stale).
Now: \`envoyproxy/envoy:v1.34.14\` (last pushed 2026-04-10).

Failure was \`apt-get install: E: Unable to locate package curl\` because the v1.31 image's Debian sources had broken. Pinning to v1.34.14 is the unblock; future bumps follow the same pattern.

### 2. \`.github/workflows/_check-docker-dry-run.yml\`: multi-arch via NATIVE runners (#736)

Was: AMD64-only build, missed the multi-arch failure entirely.
Now: each (image x arch) is its own matrix job on the native runner — \`ubuntu-latest\` for amd64, \`ubuntu-24.04-arm\` for arm64. No QEMU emulation. Wall-clock roughly equal to the original single-arch gate because everything runs in parallel.

\`syn-dashboard-ui\` stays amd64-only (matches \`release-containers.yaml\`).

### 3. \`.github/workflows/release-create.yml\`: gate CLI publish on containers success

Was: \`release-cli\` and \`release-containers\` ran in parallel, both only depending on \`[create-release, pre-publish-validation]\`. CLI shipped to npm even when a container failed.
Now: \`release-cli.needs\` includes \`release-containers\`. CLI only publishes if all containers built+pushed+signed successfully.

This is what left npm in a broken state on v0.25.3: the CLI shipped, but its compose template references container image tags that didn't exist on GHCR because sidecar-proxy failed mid-pipeline.

## Test plan

This PR's own gate run will exercise the new multi-arch-on-native-runners logic. Once it goes green:

- Merge into \`main\`
- Bump version 0.25.4
- Open release PR \`release ← main\` — the gate will fire the multi-arch dry-run for real, and the CLI publish will be properly gated on containers
- Approve the deployment gate when ready

If anything in the release pipeline still fails, we catch it now instead of after partial publish.

## Related

- v0.25.3 release post-mortem (this PR is the fix)
- #736 — multi-arch dry-run (closed by this PR)