### PR TITLE
chore: bump version to v0.25.4

### DIFF
--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.25.3"
+version = "0.25.4"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli-node/package.json
+++ b/apps/syn-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntropic137/cli",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "Syntropic137 CLI - Event-sourced workflow engine for AI agents",
   "type": "module",
   "bin": {

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.25.3",
+  "version": "0.25.4",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-docs/package.json
+++ b/apps/syn-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-docs",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/docs/architecture/event-flows/README.md
+++ b/docs/architecture/event-flows/README.md
@@ -11,20 +11,20 @@ This table shows the most important event flows in Syn137 (events that feed the 
 | Command | Event | Projections | Count |
 |---------|-------|-------------|-------|
 | ? | workflow_execution_started | RepoCorrelationProjection, WorkflowExecutionDetailProjection, WorkflowDetailProjection... | 7 |
-| ? | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
+| ? | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
+| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
-| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
-| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
+| ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
 | ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
 | ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
 
 ---
 

--- a/docs/architecture/projection-subscriptions.md
+++ b/docs/architecture/projection-subscriptions.md
@@ -16,15 +16,15 @@ This diagram shows which events feed which projections in the Syn137 system.
 graph LR
     subgraph events["Key Events"]
         e1[workflow_execution_started]
-        e2[workflow_completed]
-        e3[workflow_failed]
+        e2[workflow_failed]
+        e3[workflow_completed]
         e4[phase_completed]
-        e5[workflow_interrupted]
-        e6[workflow_template_created]
-        e7[trigger_fired]
-        e8[execution_cancelled]
-        e9[phase_started]
-        e10[agent_observation]
+        e5[execution_cancelled]
+        e6[workflow_interrupted]
+        e7[workflow_template_created]
+        e8[phase_started]
+        e9[trigger_fired]
+        e10[session_cost_finalized]
     end
 
     subgraph projections["Projections"]
@@ -53,18 +53,18 @@ graph LR
     e2 --> p4
     e2 --> p2
     e5 --> p4
-    e1 --> p6
-    e1 --> p4
-    e1 --> p2
-    e6 --> p2
-    e7 --> p6
-    e7 --> p15
-    e8 --> p4
+    e6 --> p4
+    e7 --> p2
+    e8 --> p2
     e3 --> p8
     e3 --> p7
     e3 --> p4
     e3 --> p2
-    e9 --> p2
+    e1 --> p6
+    e1 --> p4
+    e1 --> p2
+    e9 --> p6
+    e9 --> p15
 ```
 
 ---
@@ -82,15 +82,15 @@ graph LR
 | Event | Projections | Count |
 |-------|-------------|-------|
 | workflow_execution_started | RepoCorrelationProjection, WorkflowExecutionDetailProjection, WorkflowDetailProjection... | 7 |
-| workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
+| workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
+| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
-| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
+| trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
+| session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
 
 ---
 

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.25.3"
+version = "0.25.4"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.25.3"
+version = "0.25.4"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.25.3"
+version = "0.25.4"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.25.3"
+version = "0.25.4"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.25.3"
+version = "0.25.4"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.25.3"
+version = "0.25.4"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.25.3"
+version = "0.25.4"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch release. Hotfixes the v0.25.3 release pipeline failures.

## What's in v0.25.4

| | |
|---|---|
| [#737](https://github.com/syntropic137/syntropic137/pull/737) | Pin envoy v1.34.14 (was \`v1.31-latest\`, stale apt sources) + multi-arch dry-run on native ARM64 runners + gate CLI publish on containers success |

## Why now

v0.25.3 release pipeline left npm in a half-published state: CLI shipped but \`sidecar-proxy\` container build failed mid-pipeline. This release ships the v0.25.3 content properly + adds the gate logic that prevents the next release from doing the same.

11 versioned files updated by \`just bump-version 0.25.4\` + arch-doc regen drift.