### PR TITLE
release: v0.25.4

### DIFF
--- a/.github/workflows/_check-docker-dry-run.yml
+++ b/.github/workflows/_check-docker-dry-run.yml
@@ -1,11 +1,25 @@
 # =============================================================================
 # Check: Docker Dry-Run
 # =============================================================================
-# Builds all container images (single-arch, no push) to verify Dockerfiles
-# are valid and all build contexts resolve correctly.
+# Builds all container images MULTI-ARCH (linux/amd64 + linux/arm64) without
+# push, to verify Dockerfiles are valid AND that both target architectures
+# build cleanly. ARM64 cross-builds via QEMU emulation hit different package
+# mirrors than AMD64 native builds and have a different failure profile.
+#
+# Multi-arch was added per #736: v0.25.3 release pipeline failed at the
+# multi-arch publish step on a stale Debian apt source in the envoy base
+# image, but the PR-time gate had only built AMD64 and passed. Now we catch
+# this class of issue pre-merge.
+#
+# We use NATIVE GitHub-hosted runners (ubuntu-latest for amd64, ubuntu-24.04-arm
+# for arm64), NOT QEMU emulation. Each (image × arch) combination is its own
+# matrix job and builds at native speed, so wall-clock time is roughly the
+# same as the original single-arch gate. ARM64 runners are GA on public
+# repos as of early 2025; this repo is public.
 #
 # Always runs - no path-filter skip logic. Docker layer caching (GHA cache,
-# per-image scope) makes unchanged images near-instant on subsequent runs.
+# per-image-and-platform scope) makes unchanged builds near-instant on
+# subsequent runs.
 #
 # Called by: release-gate.yml
 #
@@ -24,32 +38,38 @@ permissions:
 
 jobs:
   docker-dry-run:
-    name: "Docker Build: ${{ matrix.image }}"
-    runs-on: ubuntu-latest
+    name: "Docker Build: ${{ matrix.image }} (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         include:
-          - image: syn-api
-            dockerfile: infra/docker/images/syn-api/Dockerfile
-            context: "."
-            build-args: "INCLUDE_DOCKER_CLI=1"
-          - image: syn-gateway
-            dockerfile: infra/docker/images/gateway/Dockerfile
-            context: "."
-          - image: syn-collector
-            dockerfile: packages/syn-collector/Dockerfile
-            context: "."
-          - image: syn-dashboard-ui
-            dockerfile: apps/syn-dashboard-ui/Dockerfile
-            context: "."
-          - image: sidecar-proxy
-            dockerfile: docker/sidecar-proxy/Dockerfile
-            context: docker/sidecar-proxy
-          - image: token-injector
-            dockerfile: docker/token-injector/Dockerfile
-            context: docker/token-injector
+          # syn-api — multi-arch (matches release-containers.yaml)
+          - { image: syn-api, dockerfile: infra/docker/images/syn-api/Dockerfile, context: ".", build-args: "INCLUDE_DOCKER_CLI=1", arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: syn-api, dockerfile: infra/docker/images/syn-api/Dockerfile, context: ".", build-args: "INCLUDE_DOCKER_CLI=1", arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
+          # syn-gateway — multi-arch
+          - { image: syn-gateway, dockerfile: infra/docker/images/gateway/Dockerfile, context: ".", arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: syn-gateway, dockerfile: infra/docker/images/gateway/Dockerfile, context: ".", arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
+          # syn-collector — multi-arch
+          - { image: syn-collector, dockerfile: packages/syn-collector/Dockerfile, context: ".", arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: syn-collector, dockerfile: packages/syn-collector/Dockerfile, context: ".", arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
+          # syn-dashboard-ui — amd64 only (matches release-containers.yaml; UI
+          # is shipped amd64-only because it's a static asset bundle that
+          # serves both archs identically at runtime)
+          - { image: syn-dashboard-ui, dockerfile: apps/syn-dashboard-ui/Dockerfile, context: ".", arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+
+          # sidecar-proxy — multi-arch
+          - { image: sidecar-proxy, dockerfile: docker/sidecar-proxy/Dockerfile, context: docker/sidecar-proxy, arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: sidecar-proxy, dockerfile: docker/sidecar-proxy/Dockerfile, context: docker/sidecar-proxy, arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
+          # token-injector — multi-arch
+          - { image: token-injector, dockerfile: docker/token-injector/Dockerfile, context: docker/token-injector, arch: amd64, runner: ubuntu-latest, platform: linux/amd64 }
+          - { image: token-injector, dockerfile: docker/token-injector/Dockerfile, context: docker/token-injector, arch: arm64, runner: ubuntu-24.04-arm, platform: linux/arm64 }
+
           # agentic-workspace uses build-provider.py staging - validated
           # separately in e2e-container.yml, skip in gate to save CI time.
 
@@ -60,14 +80,20 @@ jobs:
 
       - uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
 
-      - name: Build (no push)
+      - name: Build single-arch native (no push)
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
+          # Single-platform per matrix entry. The runner is already that arch
+          # (ubuntu-latest for amd64, ubuntu-24.04-arm for arm64), so the
+          # build is native — no QEMU emulation overhead.
+          platforms: ${{ matrix.platform }}
           push: false
           load: true
           tags: test/${{ matrix.image }}:gate
           build-args: ${{ matrix.build-args }}
-          cache-from: type=gha,scope=${{ matrix.image }}
-          cache-to: type=gha,scope=${{ matrix.image }},mode=max
+          # Per-(image,arch) cache scope so amd64 and arm64 caches don't
+          # collide. (#736)
+          cache-from: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }}
+          cache-to: type=gha,scope=${{ matrix.image }}-${{ matrix.arch }},mode=max

--- a/.github/workflows/release-create.yml
+++ b/.github/workflows/release-create.yml
@@ -146,10 +146,19 @@ jobs:
 
   # ---------------------------------------------------------------------------
   # Step 4: Build, test, publish CLI to npm
+  #
+  # Gated on `release-containers` success: the published CLI's compose template
+  # references container images at this version tag. If a container build
+  # failed, those tags don't exist on GHCR, and operators upgrading via
+  # `npx @syntropic137/setup update` would pull a CLI that points at missing
+  # images. Wait for containers to be reachable before publishing the CLI.
+  #
+  # See post-mortem on the v0.25.3 release: sidecar-proxy failed but CLI
+  # published anyway, leaving npm v0.25.3 in a broken state.
   # ---------------------------------------------------------------------------
   release-cli:
     name: CLI
-    needs: [create-release, pre-publish-validation]
+    needs: [create-release, pre-publish-validation, release-containers]
     if: needs.create-release.outputs.created == 'true'
     uses: ./.github/workflows/release-cli.yaml
     with:

--- a/apps/syn-api/pyproject.toml
+++ b/apps/syn-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-api"
-version = "0.25.3"
+version = "0.25.4"
 description = "HTTP API server for the Syntropic137"
 requires-python = ">=3.12"
 dependencies = [

--- a/apps/syn-cli-node/package.json
+++ b/apps/syn-cli-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@syntropic137/cli",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "Syntropic137 CLI - Event-sourced workflow engine for AI agents",
   "type": "module",
   "bin": {

--- a/apps/syn-dashboard-ui/package.json
+++ b/apps/syn-dashboard-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "syn-dashboard-ui",
   "private": true,
-  "version": "0.25.3",
+  "version": "0.25.4",
   "type": "module",
   "scripts": {
     "predev": "[ -d node_modules ] || npm install",

--- a/apps/syn-docs/package.json
+++ b/apps/syn-docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syn-docs",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/docker/sidecar-proxy/Dockerfile
+++ b/docker/sidecar-proxy/Dockerfile
@@ -3,10 +3,13 @@
 #
 # Build: docker build -t envoy-proxy:latest .
 
-# Pinned to a specific patch version. v1.31-latest was last pushed 2025-07-18
-# and its baked Debian apt sources went stale, breaking apt-get install (#736).
-# Bumping to v1.34.14 (pushed 2026-04-10). Update via the same PR pattern.
-FROM envoyproxy/envoy:v1.34.14
+# Pinned to a specific patch version. Older envoy tags ship with stale baked
+# Debian apt sources, breaking `apt-get install`:
+#   - v1.31-latest (last pushed 2025-07-18) - original break (#736)
+#   - v1.34.14 - libcurl4 deps (libbrotli1, libpsl5, librtmp1) unsatisfiable
+# When the next bump is needed, build locally first to confirm
+# `apt-get install -y ca-certificates curl` resolves cleanly.
+FROM envoyproxy/envoy:v1.35.10
 
 # Install CA certificates for TLS verification and curl for health checks
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*

--- a/docker/sidecar-proxy/Dockerfile
+++ b/docker/sidecar-proxy/Dockerfile
@@ -3,7 +3,10 @@
 #
 # Build: docker build -t envoy-proxy:latest .
 
-FROM envoyproxy/envoy:v1.31-latest
+# Pinned to a specific patch version. v1.31-latest was last pushed 2025-07-18
+# and its baked Debian apt sources went stale, breaking apt-get install (#736).
+# Bumping to v1.34.14 (pushed 2026-04-10). Update via the same PR pattern.
+FROM envoyproxy/envoy:v1.34.14
 
 # Install CA certificates for TLS verification and curl for health checks
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*

--- a/docs/architecture/event-flows/README.md
+++ b/docs/architecture/event-flows/README.md
@@ -11,20 +11,20 @@ This table shows the most important event flows in Syn137 (events that feed the 
 | Command | Event | Projections | Count |
 |---------|-------|-------------|-------|
 | ? | workflow_execution_started | RepoCorrelationProjection, WorkflowExecutionDetailProjection, WorkflowDetailProjection... | 7 |
-| ? | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
+| ? | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
-| ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
 | ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
+| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
-| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
 | ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
 | ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
+| ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
 
 ---
 

--- a/docs/architecture/event-flows/README.md
+++ b/docs/architecture/event-flows/README.md
@@ -11,20 +11,20 @@ This table shows the most important event flows in Syn137 (events that feed the 
 | Command | Event | Projections | Count |
 |---------|-------|-------------|-------|
 | ? | workflow_execution_started | RepoCorrelationProjection, WorkflowExecutionDetailProjection, WorkflowDetailProjection... | 7 |
-| ? | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
+| ? | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | ? | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
+| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
-| ? | execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | ? | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
-| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
-| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
+| ? | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
 | ? | session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
 | ? | session_started | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | session_completed | SessionListProjection, DashboardMetricsProjection | 2 |
+| ? | agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
+| ? | artifact_created | ArtifactListProjection, DashboardMetricsProjection | 2 |
 
 ---
 

--- a/docs/architecture/projection-subscriptions.md
+++ b/docs/architecture/projection-subscriptions.md
@@ -16,15 +16,15 @@ This diagram shows which events feed which projections in the Syn137 system.
 graph LR
     subgraph events["Key Events"]
         e1[workflow_execution_started]
-        e2[workflow_failed]
-        e3[workflow_completed]
+        e2[workflow_completed]
+        e3[workflow_failed]
         e4[phase_completed]
-        e5[workflow_template_created]
-        e6[execution_cancelled]
-        e7[workflow_interrupted]
-        e8[trigger_fired]
+        e5[workflow_interrupted]
+        e6[workflow_template_created]
+        e7[trigger_fired]
+        e8[execution_cancelled]
         e9[phase_started]
-        e10[session_summary]
+        e10[agent_observation]
     end
 
     subgraph projections["Projections"]
@@ -47,19 +47,19 @@ graph LR
 
     e10 --> p10
     e10 --> p3
-    e5 --> p2
-    e6 --> p4
+    e4 --> p4
     e2 --> p8
     e2 --> p7
     e2 --> p4
     e2 --> p2
-    e7 --> p4
-    e4 --> p4
-    e8 --> p6
-    e8 --> p15
+    e5 --> p4
     e1 --> p6
     e1 --> p4
     e1 --> p2
+    e6 --> p2
+    e7 --> p6
+    e7 --> p15
+    e8 --> p4
     e3 --> p8
     e3 --> p7
     e3 --> p4
@@ -82,15 +82,15 @@ graph LR
 | Event | Projections | Count |
 |-------|-------------|-------|
 | workflow_execution_started | RepoCorrelationProjection, WorkflowExecutionDetailProjection, WorkflowDetailProjection... | 7 |
-| workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
+| workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
-| workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
+| workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
 | trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
+| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| session_summary | SessionCostProjection, ExecutionCostProjection | 2 |
+| agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
 
 ---
 

--- a/docs/architecture/projection-subscriptions.md
+++ b/docs/architecture/projection-subscriptions.md
@@ -16,15 +16,15 @@ This diagram shows which events feed which projections in the Syn137 system.
 graph LR
     subgraph events["Key Events"]
         e1[workflow_execution_started]
-        e2[workflow_completed]
-        e3[workflow_failed]
+        e2[workflow_failed]
+        e3[workflow_completed]
         e4[phase_completed]
-        e5[workflow_interrupted]
-        e6[workflow_template_created]
-        e7[trigger_fired]
-        e8[execution_cancelled]
-        e9[phase_started]
-        e10[agent_observation]
+        e5[execution_cancelled]
+        e6[workflow_interrupted]
+        e7[workflow_template_created]
+        e8[phase_started]
+        e9[trigger_fired]
+        e10[session_cost_finalized]
     end
 
     subgraph projections["Projections"]
@@ -53,18 +53,18 @@ graph LR
     e2 --> p4
     e2 --> p2
     e5 --> p4
-    e1 --> p6
-    e1 --> p4
-    e1 --> p2
-    e6 --> p2
-    e7 --> p6
-    e7 --> p15
-    e8 --> p4
+    e6 --> p4
+    e7 --> p2
+    e8 --> p2
     e3 --> p8
     e3 --> p7
     e3 --> p4
     e3 --> p2
-    e9 --> p2
+    e1 --> p6
+    e1 --> p4
+    e1 --> p2
+    e9 --> p6
+    e9 --> p15
 ```
 
 ---
@@ -82,15 +82,15 @@ graph LR
 | Event | Projections | Count |
 |-------|-------------|-------|
 | workflow_execution_started | RepoCorrelationProjection, WorkflowExecutionDetailProjection, WorkflowDetailProjection... | 7 |
-| workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | workflow_failed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
+| workflow_completed | RepoHealthProjection, RepoCostProjection, WorkflowExecutionDetailProjection... | 6 |
 | phase_completed | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection... | 4 |
+| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | workflow_interrupted | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | workflow_template_created | WorkflowDetailProjection, WorkflowListProjection, DashboardMetricsProjection | 3 |
-| trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
-| execution_cancelled | WorkflowExecutionDetailProjection, WorkflowExecutionListProjection, ExecutionTodoProjection | 3 |
 | phase_started | WorkflowExecutionDetailProjection, WorkflowPhaseMetricsProjection, DashboardMetricsProjection | 3 |
-| agent_observation | SessionCostProjection, ExecutionCostProjection | 2 |
+| trigger_fired | RepoCorrelationProjection, TriggerHistoryProjection, TriggerRuleProjection | 3 |
+| session_cost_finalized | SessionCostProjection, ExecutionCostProjection | 2 |
 
 ---
 

--- a/packages/syn-adapters/pyproject.toml
+++ b/packages/syn-adapters/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-adapters"
-version = "0.25.3"
+version = "0.25.4"
 description = "External integrations for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-collector/pyproject.toml
+++ b/packages/syn-collector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-collector"
-version = "0.25.3"
+version = "0.25.4"
 description = "Event collection service for Syn137 agent observability"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-domain/pyproject.toml
+++ b/packages/syn-domain/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-domain"
-version = "0.25.3"
+version = "0.25.4"
 description = "Core domain model for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-perf/pyproject.toml
+++ b/packages/syn-perf/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-perf"
-version = "0.25.3"
+version = "0.25.4"
 description = "Performance benchmarking suite for Syntropic137 isolated workspaces"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/packages/syn-shared/pyproject.toml
+++ b/packages/syn-shared/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-shared"
-version = "0.25.3"
+version = "0.25.4"
 description = "Shared utilities for Syntropic137"
 requires-python = ">=3.12"
 

--- a/packages/syn-tokens/pyproject.toml
+++ b/packages/syn-tokens/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syn-tokens"
-version = "0.25.3"
+version = "0.25.4"
 description = "Token vending and spend tracking for Syntropic137"
 requires-python = ">=3.12"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "syntropic137"
-version = "0.25.3"
+version = "0.25.4"
 description = "Event-sourced system for tracking AI agent work across workflows"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Hotfix patch release for v0.25.3.

## Why this exists

The v0.25.3 release pipeline left npm in a half-published state: CLI shipped successfully but \`sidecar-proxy\` container build failed with a stale Debian apt source in the \`envoyproxy/envoy:v1.31-latest\` base image. Operators upgrading via \`npx @syntropic137/setup update\` got the new CLI but its compose template references container tags that don't all exist on GHCR.

v0.25.4 ships the v0.25.3 content properly and adds two pipeline-hygiene fixes so this class of issue is caught pre-merge next time.

## What's in v0.25.4

| | PR | Summary |
|---|---|---|
| fix | [#737](https://github.com/syntropic137/syntropic137/pull/737) | Pin \`envoyproxy/envoy:v1.34.14\` (was floating \`v1.31-latest\`, stale apt sources). Add multi-arch dry-run in release gate using **native ARM64 runners** (\`ubuntu-24.04-arm\`, no QEMU). Gate npm CLI publish on container builds success. |
| chore | [#738](https://github.com/syntropic137/syntropic137/pull/738) | Bump 11 versioned files to 0.25.4 + arch-doc regen drift. |
| (carried) | [#722, #727, #719, npx#61](https://github.com/syntropic137/syntropic137/pull/722) | All v0.25.3 content (workspace credential injection, \`IMAGES=1\` proxy, sessions/executions UI, npx token routing). Closes the EOD self-host trio. |

## What's new about the release pipeline

This release PR is the first run of the new **multi-arch dry-run gate**:

- Each (image × arch) combo runs as its own matrix job on a native runner
- ARM64 builds on \`ubuntu-24.04-arm\` (GA on public repos), NOT QEMU
- Wall-clock roughly equal to the prior single-arch gate because everything runs in parallel
- If ANY platform fails, the gate fails — operator can fix before merge instead of mid-release

If the gate passes, that's strong evidence v0.25.4 will publish cleanly. If it fails, we have a real signal to fix.

The release pipeline itself also gets the **CLI publish gating fix**: \`release-cli\` now \`needs: [..., release-containers]\`, so npm only publishes if all containers built+pushed+signed successfully. No more partial-publish state.

## Release-gate checks

Will fire automatically on this PR. **DO NOT merge until:**
- All required gates green (including the new multi-arch dry-run)
- @NeuralEmpowerment confirms before approving the deployment gate

Per project policy + \`feedback_release_approval\` rule: this PR will not be merged by an agent. Human approval only.

## Companion (already shipped)

- syntropic137-npx [#61](https://github.com/syntropic137/syntropic137-npx/pull/61) — token prefix routing. Merged earlier, npm published. v0.25.4 release pipeline does NOT touch the npx package.
- agentic-primitives [#157](https://github.com/AgentParadise/agentic-primitives/pull/157) — Claude CLI 2.1.126 + uv-base. Merged + republished. \`agentic-workspace-claude-cli:latest\` now points at \`b9fb217d2cba\`. Selfhost users will auto-pull this on next workflow run thanks to v0.25.3's \`IMAGES=1\` change.