### PR TITLE
fix(sidecar-proxy): bump envoy to v1.35.10 (broken apt deps in v1.34.14)

### DIFF
--- a/docker/sidecar-proxy/Dockerfile
+++ b/docker/sidecar-proxy/Dockerfile
@@ -3,10 +3,13 @@
 #
 # Build: docker build -t envoy-proxy:latest .
 
-# Pinned to a specific patch version. v1.31-latest was last pushed 2025-07-18
-# and its baked Debian apt sources went stale, breaking apt-get install (#736).
-# Bumping to v1.34.14 (pushed 2026-04-10). Update via the same PR pattern.
-FROM envoyproxy/envoy:v1.34.14
+# Pinned to a specific patch version. Older envoy tags ship with stale baked
+# Debian apt sources, breaking `apt-get install`:
+#   - v1.31-latest (last pushed 2025-07-18) - original break (#736)
+#   - v1.34.14 - libcurl4 deps (libbrotli1, libpsl5, librtmp1) unsatisfiable
+# When the next bump is needed, build locally first to confirm
+# `apt-get install -y ca-certificates curl` resolves cleanly.
+FROM envoyproxy/envoy:v1.35.10
 
 # Install CA certificates for TLS verification and curl for health checks
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- Bump `envoyproxy/envoy` base image from `v1.34.14` to `v1.35.10`.
- v1.34.14 ships with stale Debian apt sources where `libcurl4` transitive deps (`libbrotli1`, `libpsl5`, `librtmp1`) are unsatisfiable, breaking `apt-get install ca-certificates curl` in CI and the release pipeline.
- Updated the header comment to log both stale-tag incidents (v1.31, v1.34) and to require a local build sanity check on the next bump.

This unblocks the sidecar-proxy multi-arch dry-run gate failing on PR #739 (release v0.25.4).

## Why v1.34.14 broke

The pinned tag had the same failure profile as the v1.31 break documented in #736: the base image was published months ago, Debian moved its package index forward, and the cached apt sources inside the image now point at versions that no longer exist in the mirror. Bumping to a more recent envoy tag picks up a rebuilt base layer with current sources.

## Test plan

- [x] Local `docker build docker/sidecar-proxy/` succeeds on macOS (linux/arm64) with v1.35.10 (failed with v1.34.14).
- [ ] CI `_check-docker-dry-run.yml` passes for both `sidecar-proxy (amd64)` and `sidecar-proxy (arm64)`.
- [ ] After merge, re-run release-gate on PR #739 and confirm sidecar-proxy build is green.