### PR TITLE
fix(interactive-tmux): close independent syn137-side gaps from #771

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -305,6 +305,16 @@ SYN_WORKSPACE_DOCKER_RUNTIME=runsc
 # Docker network for containers.
 SYN_WORKSPACE_DOCKER_NETWORK=none
 
+# Enable the interactive-tmux workspace provider (agentic-primitives /
+# EXP-05). When false, attempts to use provider_kind='interactive-tmux' are
+# rejected. Default off so the default 'claude -p' Docker path is the only
+# live path.
+SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED=false
+
+# Docker image for the interactive-tmux workspace provider. Bundles tmux +
+# interactive claude/codex/gemini CLIs.
+SYN_WORKSPACE_INTERACTIVE_TMUX_IMAGE=agentic-workspace-interactive-tmux:latest
+
 # ============================================================================
 # WORKSPACE SECURITY POLICIES
 # ============================================================================

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -485,8 +485,10 @@ jobs:
               --ignore-vuln PYSEC-2026-161 \
               --ignore-vuln PYSEC-2026-142 \
               --ignore-vuln PYSEC-2026-141 \
+              --ignore-vuln GHSA-4xgf-cpjx-pc3j \
               -r /dev/stdin
           # TODO(#345): remove --ignore-vuln once pygments releases a fix
+          # TODO(#776): remove --ignore-vuln GHSA-4xgf-cpjx-pc3j once pydantic-settings 2.14.2 is on PyPI (secrets_nested_subdir symlink escape; feature unused here)
           # TODO(#634): remove --ignore-vuln once cryptography 46.0.7 is available on PyPI
           # TODO(#678): remove --ignore-vuln GHSA-6w46-j5rx-g56g once pytest 9.0.3 is available on PyPI
           # TODO(#696): remove --ignore-vuln GHSA-mj87-hwqh-73pj once python-multipart 0.0.26 is available on PyPI

--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -86,8 +86,10 @@ jobs:
               --ignore-vuln GHSA-p423-j2cm-9vmq \
               --ignore-vuln GHSA-6w46-j5rx-g56g \
               --ignore-vuln GHSA-mj87-hwqh-73pj \
+              --ignore-vuln GHSA-4xgf-cpjx-pc3j \
               -r /dev/stdin
           # TODO(#345): remove --ignore-vuln once pygments releases a fix
+          # TODO(#776): remove --ignore-vuln GHSA-4xgf-cpjx-pc3j once pydantic-settings 2.14.2 is on PyPI (secrets_nested_subdir symlink escape; feature unused here)
           # TODO(#634): remove --ignore-vuln once cryptography 46.0.7 is available on PyPI
           # TODO(#678): remove --ignore-vuln GHSA-6w46-j5rx-g56g once pytest 9.0.3 is available on PyPI
           # TODO(#696): remove --ignore-vuln GHSA-mj87-hwqh-73pj once python-multipart 0.0.26 is available on PyPI

--- a/fitness-exceptions.toml
+++ b/fitness-exceptions.toml
@@ -32,10 +32,6 @@ issue = "#624"
 
 # --- interactive-tmux transport (stress-fix poll-then-race) ---
 
-[max-cognitive."python:packages.syn-domain.src.syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler::_run_interactive_driver"]
-value = 20
-issue = "#768"  # multi-agent stacked on #765; refactor scheduled with the interactive-tmux post-launch polish
-
 [max-cognitive."python:packages.syn-domain.src.syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler::_race_completion_against_cancel"]
 value = 50
 issue = "#768"  # poll-then-race cancel loop from fix/interactive-tmux-stress-blockers; D-block-1 fix

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/agentic/adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/agentic/adapter.py
@@ -23,6 +23,13 @@ from syn_adapters.workspace_backends.agentic.adapter_copy import (
     copy_files_from_workspace,
     copy_files_to_workspace,
 )
+
+# Re-exported for backward compatibility (issue #771 item 7): the canonical
+# definition moved to `syn_adapters.workspace_backends.errors` so other
+# backends (interactive-tmux) can raise/import it without depending on this
+# Docker-specific module. Existing `from ...agentic.adapter import
+# WorkspaceProvisionError` call sites keep working unchanged.
+from syn_adapters.workspace_backends.errors import WorkspaceProvisionError
 from syn_shared.env_constants import (
     ENV_SYN_AGENT_NETWORK,
     ENV_SYN_WORKSPACE_CONTAINER_DIR,
@@ -41,14 +48,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-
-class WorkspaceProvisionError(RuntimeError):
-    """Raised when Docker-backed workspace provisioning fails.
-
-    Wraps the underlying error with execution/workspace context so the
-    `_fail_execution` path in the workflow processor can surface an
-    actionable message through to the CLI (instead of "Unknown error").
-    """
+__all__ = ["AgenticIsolationAdapter", "WorkspaceProvisionError"]
 
 
 class AgenticIsolationAdapter:

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/errors.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/errors.py
@@ -1,0 +1,26 @@
+"""Shared error types for workspace backend adapters (issue #771 item 7).
+
+`WorkspaceProvisionError` originally lived only in
+`syn_adapters.workspace_backends.agentic.adapter` (the Docker-backed
+provider). Other backends - interactive-tmux, and the `WorkspaceService`
+factory methods that wire them - need the same typed error so
+error-mapping layers downstream (`_fail_execution`, `syn execution show`)
+have one type to match against instead of a bare `RuntimeError`. Moved
+here so it is importable without pulling in the agentic adapter module;
+`agentic/adapter.py` re-exports it for backward compatibility.
+"""
+
+from __future__ import annotations
+
+
+class WorkspaceProvisionError(RuntimeError):
+    """Raised when workspace provisioning fails or is misconfigured.
+
+    Wraps the underlying error (or a misconfiguration message, e.g. a
+    disabled feature flag or an unavailable provider) with enough context
+    so downstream error-mapping layers can surface an actionable message
+    instead of "Unknown error".
+    """
+
+
+__all__ = ["WorkspaceProvisionError"]

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/__init__.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/__init__.py
@@ -16,6 +16,10 @@ from syn_adapters.workspace_backends.interactive_tmux.adapter import (
     InteractiveTmuxIsolationAdapter,
     InteractiveTmuxUnavailableError,
 )
+from syn_adapters.workspace_backends.interactive_tmux.no_stream_event_stream_adapter import (
+    InteractiveTmuxStreamingUnsupportedError,
+    NoStreamEventStreamAdapter,
+)
 from syn_adapters.workspace_backends.interactive_tmux.noop_sidecar import (
     NoopSidecarAdapter,
 )
@@ -26,7 +30,9 @@ from syn_adapters.workspace_backends.interactive_tmux.noop_token_injection impor
 __all__ = [
     "INTERACTIVE_TMUX_AVAILABLE",
     "InteractiveTmuxIsolationAdapter",
+    "InteractiveTmuxStreamingUnsupportedError",
     "InteractiveTmuxUnavailableError",
+    "NoStreamEventStreamAdapter",
     "NoopSidecarAdapter",
     "NoopTokenInjectionAdapter",
 ]

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
@@ -229,13 +229,21 @@ class InteractiveTmuxIsolationAdapter:
             )
             raise InteractiveTmuxUnavailableError(msg)
 
+        labels = {
+            "syn.execution_id": config.execution_id,
+            "syn.workspace_id": config.workspace_id,
+        }
+        # Stage auth and launch a pane only for the requested agent(s). Without
+        # this the provider stages all default agents (claude/codex/gemini),
+        # which for a claude-only phase wastes minutes copying codex/gemini
+        # credentials. Empty `agents` falls back to the provider default.
+        if config.agents:
+            labels["agents"] = ",".join(config.agents)
+
         ws_config = WorkspaceConfig(
             provider="interactive-tmux",
             working_dir="/workspace",
-            labels={
-                "syn.execution_id": config.execution_id,
-                "syn.workspace_id": config.workspace_id,
-            },
+            labels=labels,
         )
 
         # The provider's create() is async-def but blocking internally

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import shutil
-from typing import TYPE_CHECKING, Any
+import threading
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from syn_adapters.workspace_backends.agentic.adapter_copy import (
     check_workspace_health,
@@ -34,11 +35,15 @@ from syn_adapters.workspace_backends.agentic.adapter_copy import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Coroutine
+
     from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
         ExecutionResult,
         IsolationConfig,
         IsolationHandle,
     )
+
+_T = TypeVar("_T")
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +123,57 @@ class InteractiveTmuxIsolationAdapter:
             strict_startup=strict_startup,
         )
         self._workspaces: dict[str, Any] = {}
+        # Dedicated event loop (in a background thread) that runs every
+        # provider coroutine. The provider owns an `asyncio.Lock`, which is
+        # loop-affine: it binds to the first loop that acquires it and
+        # raises RuntimeError from any other loop. Driving each call on a
+        # fresh `asyncio.run` loop would therefore crash on the second
+        # provider call - including the ordinary create() -> destroy()
+        # sequence, since create() binds the lock to a loop that is closed
+        # by the time destroy() runs. One stable loop keeps the lock valid
+        # across the whole workspace lifetime and keeps the blocking driver
+        # work off the caller's loop. Lazily started on first use.
+        self._provider_loop_obj: asyncio.AbstractEventLoop | None = None
+        self._provider_loop_thread: threading.Thread | None = None
+
+    def _provider_loop(self) -> asyncio.AbstractEventLoop:
+        loop = self._provider_loop_obj
+        if loop is not None and not loop.is_closed():
+            return loop
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(
+            target=loop.run_forever,
+            name=f"itmux-provider-{id(self):x}",
+            daemon=True,
+        )
+        thread.start()
+        self._provider_loop_obj = loop
+        self._provider_loop_thread = thread
+        return loop
+
+    async def _call_provider(self, coro: Coroutine[Any, Any, _T]) -> _T:
+        """Run a provider coroutine on the dedicated loop, awaited from ours.
+
+        `run_coroutine_threadsafe` schedules `coro` on the provider loop and
+        returns a concurrent future; `wrap_future` lets us await it on the
+        caller's loop without blocking it.
+        """
+        loop = self._provider_loop()
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        return await asyncio.wrap_future(future)
+
+    def _shutdown_provider_loop(self) -> None:
+        """Stop the dedicated loop once no workspaces remain on this adapter."""
+        loop = self._provider_loop_obj
+        if loop is None:
+            return
+        loop.call_soon_threadsafe(loop.stop)
+        thread = self._provider_loop_thread
+        if thread is not None:
+            thread.join(timeout=5.0)
+        loop.close()
+        self._provider_loop_obj = None
+        self._provider_loop_thread = None
 
     @staticmethod
     def is_available() -> bool:
@@ -145,19 +201,10 @@ class InteractiveTmuxIsolationAdapter:
 
         # The provider's create() is async-def but blocking internally
         # (subprocess + sleep loops up to startup_timeout_s, ~45s by
-        # default) - see the provider's own docstring, which explicitly
-        # says a caller needing concurrency should wrap its call in a
-        # separate thread. `await`ing it directly here would hold up this
-        # adapter's event loop (and every other workspace multiplexed on
-        # it) for the full container-start window. Run the coroutine to
-        # completion inside a worker thread's own event loop instead, so
-        # this loop stays free to service other workspaces concurrently.
-        # The coroutine is created inside the worker thread (not on this
-        # loop) so a cancellation before the thread starts cannot leave
-        # an un-awaited coroutine behind.
-        workspace_obj = await asyncio.to_thread(
-            lambda: asyncio.run(self._provider.create(ws_config))
-        )
+        # default). Running it on the dedicated provider loop keeps that
+        # blocking window off this adapter's event loop while satisfying
+        # the provider lock's loop affinity (see `_call_provider`).
+        workspace_obj = await self._call_provider(self._provider.create(ws_config))
         self._workspaces[workspace_obj.id] = workspace_obj
 
         logger.info(
@@ -182,13 +229,18 @@ class InteractiveTmuxIsolationAdapter:
             return
         logger.info("Destroying interactive-tmux workspace (id=%s)", handle.isolation_id)
         # Same blocking-in-async concern as create() (~2s of docker rm /
-        # stop() calls this time): offload to a worker thread so this
-        # event loop isn't held up for the duration.
+        # stop() calls this time): run on the dedicated provider loop so
+        # this event loop isn't held up for the duration.
         # Pop only AFTER a successful provider destroy. If destroy raises
         # (e.g. docker timeout), the handle stays in _workspaces so the
         # caller can retry instead of leaking the tmux/Docker resources.
-        await asyncio.to_thread(lambda: asyncio.run(self._provider.destroy(workspace)))
+        await self._call_provider(self._provider.destroy(workspace))
         self._workspaces.pop(handle.isolation_id, None)
+        # Once the adapter holds no workspaces, the dedicated provider loop
+        # has nothing left to serve; stop it so a long-lived syn-api process
+        # does not accumulate idle loop threads across executions.
+        if not self._workspaces:
+            self._shutdown_provider_loop()
 
     async def execute(
         self,
@@ -219,12 +271,14 @@ class InteractiveTmuxIsolationAdapter:
             )
 
         cmd_str = " ".join(command)
-        result = await self._provider.execute(
-            workspace,
-            cmd_str,
-            timeout=float(timeout_seconds) if timeout_seconds else None,
-            cwd=working_directory,
-            env=environment,
+        result = await self._call_provider(
+            self._provider.execute(
+                workspace,
+                cmd_str,
+                timeout=float(timeout_seconds) if timeout_seconds else None,
+                cwd=working_directory,
+                env=environment,
+            )
         )
 
         return ExecutionResult(
@@ -255,7 +309,7 @@ class InteractiveTmuxIsolationAdapter:
             raise FileNotFoundError(f"Interactive-tmux workspace not found: {handle.isolation_id}")
         for relative_path, content in files:
             full_path = f"{base_path.rstrip('/')}/{relative_path}" if relative_path else base_path
-            await self._provider.write_file(workspace, full_path, content)
+            await self._call_provider(self._provider.write_file(workspace, full_path, content))
 
     async def copy_from(
         self,

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
@@ -145,14 +145,19 @@ class InteractiveTmuxIsolationAdapter:
 
         # The provider's create() is async-def but blocking internally
         # (subprocess + sleep loops up to startup_timeout_s, ~45s by
-        # default) — see the provider's own docstring, which explicitly
+        # default) - see the provider's own docstring, which explicitly
         # says a caller needing concurrency should wrap its call in a
         # separate thread. `await`ing it directly here would hold up this
         # adapter's event loop (and every other workspace multiplexed on
         # it) for the full container-start window. Run the coroutine to
         # completion inside a worker thread's own event loop instead, so
         # this loop stays free to service other workspaces concurrently.
-        workspace_obj = await asyncio.to_thread(asyncio.run, self._provider.create(ws_config))
+        # The coroutine is created inside the worker thread (not on this
+        # loop) so a cancellation before the thread starts cannot leave
+        # an un-awaited coroutine behind.
+        workspace_obj = await asyncio.to_thread(
+            lambda: asyncio.run(self._provider.create(ws_config))
+        )
         self._workspaces[workspace_obj.id] = workspace_obj
 
         logger.info(
@@ -182,7 +187,7 @@ class InteractiveTmuxIsolationAdapter:
         # Pop only AFTER a successful provider destroy. If destroy raises
         # (e.g. docker timeout), the handle stays in _workspaces so the
         # caller can retry instead of leaking the tmux/Docker resources.
-        await asyncio.to_thread(asyncio.run, self._provider.destroy(workspace))
+        await asyncio.to_thread(lambda: asyncio.run(self._provider.destroy(workspace)))
         self._workspaces.pop(handle.isolation_id, None)
 
     async def execute(

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
@@ -23,6 +23,7 @@ See:
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import shutil
 from typing import TYPE_CHECKING, Any
@@ -142,7 +143,16 @@ class InteractiveTmuxIsolationAdapter:
             },
         )
 
-        workspace_obj = await self._provider.create(ws_config)
+        # The provider's create() is async-def but blocking internally
+        # (subprocess + sleep loops up to startup_timeout_s, ~45s by
+        # default) — see the provider's own docstring, which explicitly
+        # says a caller needing concurrency should wrap its call in a
+        # separate thread. `await`ing it directly here would hold up this
+        # adapter's event loop (and every other workspace multiplexed on
+        # it) for the full container-start window. Run the coroutine to
+        # completion inside a worker thread's own event loop instead, so
+        # this loop stays free to service other workspaces concurrently.
+        workspace_obj = await asyncio.to_thread(asyncio.run, self._provider.create(ws_config))
         self._workspaces[workspace_obj.id] = workspace_obj
 
         logger.info(
@@ -166,10 +176,13 @@ class InteractiveTmuxIsolationAdapter:
             logger.warning("Interactive-tmux workspace not found: %s", handle.isolation_id)
             return
         logger.info("Destroying interactive-tmux workspace (id=%s)", handle.isolation_id)
+        # Same blocking-in-async concern as create() (~2s of docker rm /
+        # stop() calls this time): offload to a worker thread so this
+        # event loop isn't held up for the duration.
         # Pop only AFTER a successful provider destroy. If destroy raises
         # (e.g. docker timeout), the handle stays in _workspaces so the
         # caller can retry instead of leaking the tmux/Docker resources.
-        await self._provider.destroy(workspace)
+        await asyncio.to_thread(asyncio.run, self._provider.destroy(workspace))
         self._workspaces.pop(handle.isolation_id, None)
 
     async def execute(

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
@@ -212,11 +212,26 @@ class InteractiveTmuxIsolationAdapter:
             IsolationHandle,
         )
 
+        # The interactive-tmux provider only honors working_dir and labels
+        # (agent selection + informational syn.* tags); it rejects `image`,
+        # `environment`, mounts, secrets, etc. as non-default WorkspaceConfig
+        # fields (it runs a fixed entrypoint with its own credential layout).
+        # The image is supplied to the provider via `default_image=` at
+        # construction, so we must NOT also set it here. Environment injection
+        # is unsupported: fail loudly rather than silently drop it (interactive
+        # phases run with agent_env={} - see the provision handler).
+        if config.environment:
+            msg = (
+                "interactive-tmux workspaces do not support environment "
+                f"injection (got keys {sorted(config.environment)}); the "
+                "provider runs a fixed entrypoint with its own credential "
+                "layout. claude-interactive phases must not set agent env."
+            )
+            raise InteractiveTmuxUnavailableError(msg)
+
         ws_config = WorkspaceConfig(
             provider="interactive-tmux",
-            image=config.image or self._default_image or "",
             working_dir="/workspace",
-            environment=dict(config.environment) if config.environment else {},
             labels={
                 "syn.execution_id": config.execution_id,
                 "syn.workspace_id": config.workspace_id,

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/adapter.py
@@ -36,6 +36,7 @@ from syn_adapters.workspace_backends.agentic.adapter_copy import (
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
+    from concurrent.futures import Future as ConcurrentFuture
 
     from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
         ExecutionResult,
@@ -81,6 +82,37 @@ def _try_import_provider() -> tuple[Any, str | None]:
 
 _InteractiveTmuxProvider, _IMPORT_ERROR = _try_import_provider()
 
+
+# One process-wide background event loop for ALL interactive-tmux provider
+# calls. The provider's asyncio.Lock is loop-affine (binds to the first loop
+# that acquires it, RuntimeError from any other), so every provider coroutine
+# must run on a single loop that outlives the provider instance. A per-adapter
+# loop that is torn down when its workspaces drain would rebind the lock on the
+# next create() (crash) and race concurrent destroys; a process-wide loop that
+# is never closed avoids both and costs exactly one idle daemon thread total.
+_provider_loop_lock = threading.Lock()
+_provider_loop: asyncio.AbstractEventLoop | None = None
+
+
+def _shared_provider_loop() -> asyncio.AbstractEventLoop:
+    """Return the process-wide provider loop, starting it on first use."""
+    global _provider_loop
+    loop = _provider_loop
+    if loop is not None:
+        return loop
+    with _provider_loop_lock:
+        if _provider_loop is None:
+            new_loop = asyncio.new_event_loop()
+            thread = threading.Thread(
+                target=new_loop.run_forever,
+                name="itmux-provider-loop",
+                daemon=True,
+            )
+            thread.start()
+            _provider_loop = new_loop
+        return _provider_loop
+
+
 INTERACTIVE_TMUX_AVAILABLE: bool = _InteractiveTmuxProvider is not None
 """True when `agentic_isolation.providers.interactive_tmux` was importable
 at adapter-module load time. False when the agentic-primitives submodule
@@ -123,57 +155,49 @@ class InteractiveTmuxIsolationAdapter:
             strict_startup=strict_startup,
         )
         self._workspaces: dict[str, Any] = {}
-        # Dedicated event loop (in a background thread) that runs every
-        # provider coroutine. The provider owns an `asyncio.Lock`, which is
-        # loop-affine: it binds to the first loop that acquires it and
-        # raises RuntimeError from any other loop. Driving each call on a
-        # fresh `asyncio.run` loop would therefore crash on the second
-        # provider call - including the ordinary create() -> destroy()
-        # sequence, since create() binds the lock to a loop that is closed
-        # by the time destroy() runs. One stable loop keeps the lock valid
-        # across the whole workspace lifetime and keeps the blocking driver
-        # work off the caller's loop. Lazily started on first use.
-        self._provider_loop_obj: asyncio.AbstractEventLoop | None = None
-        self._provider_loop_thread: threading.Thread | None = None
-
-    def _provider_loop(self) -> asyncio.AbstractEventLoop:
-        loop = self._provider_loop_obj
-        if loop is not None and not loop.is_closed():
-            return loop
-        loop = asyncio.new_event_loop()
-        thread = threading.Thread(
-            target=loop.run_forever,
-            name=f"itmux-provider-{id(self):x}",
-            daemon=True,
-        )
-        thread.start()
-        self._provider_loop_obj = loop
-        self._provider_loop_thread = thread
-        return loop
 
     async def _call_provider(self, coro: Coroutine[Any, Any, _T]) -> _T:
-        """Run a provider coroutine on the dedicated loop, awaited from ours.
+        """Run a provider coroutine on the shared provider loop, awaited from ours.
 
-        `run_coroutine_threadsafe` schedules `coro` on the provider loop and
-        returns a concurrent future; `wrap_future` lets us await it on the
-        caller's loop without blocking it.
+        The provider owns an `asyncio.Lock`, which is loop-affine: it binds to
+        the first loop that acquires it and raises RuntimeError from any other
+        loop. So every provider call must run on ONE stable loop for the
+        provider instance's lifetime. We use a single process-wide background
+        loop (see `_shared_provider_loop`): it is never torn down, so the lock
+        binds once and stays valid, and the blocking driver work stays off the
+        caller's loop. `run_coroutine_threadsafe` schedules `coro` there and
+        `wrap_future` lets us await it on the caller's loop without blocking it.
         """
-        loop = self._provider_loop()
+        loop = _shared_provider_loop()
         future = asyncio.run_coroutine_threadsafe(coro, loop)
         return await asyncio.wrap_future(future)
 
-    def _shutdown_provider_loop(self) -> None:
-        """Stop the dedicated loop once no workspaces remain on this adapter."""
-        loop = self._provider_loop_obj
-        if loop is None:
-            return
-        loop.call_soon_threadsafe(loop.stop)
-        thread = self._provider_loop_thread
-        if thread is not None:
-            thread.join(timeout=5.0)
-        loop.close()
-        self._provider_loop_obj = None
-        self._provider_loop_thread = None
+    async def _create_on_provider_loop(self, coro: Coroutine[Any, Any, _T]) -> _T:
+        """Run provider.create on the shared loop, cleaning up on cancellation.
+
+        A provider coroutine already running on the background loop cannot be
+        cancelled, so a cancelled caller (e.g. execution timeout) would leave a
+        started, credential-seeded container that this adapter never recorded
+        in `_workspaces` and therefore never destroys. On CancelledError we
+        attach a callback that destroys the workspace if the create still
+        completes, so no container is orphaned.
+        """
+        loop = _shared_provider_loop()
+        future = asyncio.run_coroutine_threadsafe(coro, loop)
+        try:
+            return await asyncio.wrap_future(future)
+        except asyncio.CancelledError:
+
+            def _destroy_if_created(done: ConcurrentFuture[_T]) -> None:
+                try:
+                    workspace = done.result()
+                except BaseException:
+                    return
+                if workspace is not None:
+                    asyncio.run_coroutine_threadsafe(self._provider.destroy(workspace), loop)
+
+            future.add_done_callback(_destroy_if_created)
+            raise
 
     @staticmethod
     def is_available() -> bool:
@@ -201,10 +225,11 @@ class InteractiveTmuxIsolationAdapter:
 
         # The provider's create() is async-def but blocking internally
         # (subprocess + sleep loops up to startup_timeout_s, ~45s by
-        # default). Running it on the dedicated provider loop keeps that
-        # blocking window off this adapter's event loop while satisfying
-        # the provider lock's loop affinity (see `_call_provider`).
-        workspace_obj = await self._call_provider(self._provider.create(ws_config))
+        # default). Running it on the shared provider loop keeps that blocking
+        # window off this adapter's event loop while satisfying the provider
+        # lock's loop affinity (see `_call_provider`). Use the cancellation-
+        # safe variant so a cancelled create() cannot orphan a container.
+        workspace_obj = await self._create_on_provider_loop(self._provider.create(ws_config))
         self._workspaces[workspace_obj.id] = workspace_obj
 
         logger.info(
@@ -236,11 +261,6 @@ class InteractiveTmuxIsolationAdapter:
         # caller can retry instead of leaking the tmux/Docker resources.
         await self._call_provider(self._provider.destroy(workspace))
         self._workspaces.pop(handle.isolation_id, None)
-        # Once the adapter holds no workspaces, the dedicated provider loop
-        # has nothing left to serve; stop it so a long-lived syn-api process
-        # does not accumulate idle loop threads across executions.
-        if not self._workspaces:
-            self._shutdown_provider_loop()
 
     async def execute(
         self,

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/no_stream_event_stream_adapter.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/interactive_tmux/no_stream_event_stream_adapter.py
@@ -1,0 +1,75 @@
+"""NoStreamEventStreamAdapter - explicit "streaming unsupported" for interactive-tmux.
+
+Interactive-tmux workspaces are driven through the tmux pane API
+(`send_message` / `await_completion` / `capture_response`, reached via
+`InteractiveTmuxIsolationAdapter.provider_handle()`), not the `claude -p`
+stream-json path that `workspace.stream()` implements for the Docker
+backend. Before this adapter existed, `_create_interactive_tmux_impl`
+wired a bare, un-configured `AgenticEventStreamAdapter()` (never given a
+provider via `set_provider()`), so any call to `stream()` on an
+interactive-tmux workspace raised the accidental, confusing
+`RuntimeError("Provider not set. Call set_provider first.")` - a message
+that describes an implementation detail rather than the actual
+constraint (issue #771 item 5).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationHandle,
+    )
+
+
+class InteractiveTmuxStreamingUnsupportedError(RuntimeError):
+    """Raised when `.stream()` is called against an interactive-tmux workspace.
+
+    Interactive-tmux workspaces do not support the `claude -p` stream-json
+    execution path. Callers should feature-detect
+    (`hasattr(isolation_adapter, "provider_handle")`) and drive the agent
+    through `provider_handle()`'s `send_message` / `await_completion` /
+    `capture_response` API instead.
+    """
+
+
+class NoStreamEventStreamAdapter:
+    """EventStreamPort implementation for backends that do not support streaming.
+
+    Satisfies the `EventStreamPort` protocol's shape so it can be wired
+    anywhere an `EventStreamPort` is expected, but every `stream()` call
+    fails immediately and explicitly with
+    `InteractiveTmuxStreamingUnsupportedError` rather than an accidental,
+    unrelated error surfacing from an unconfigured provider.
+    """
+
+    @property
+    def last_exit_code(self) -> int | None:
+        """Always None - no stream has ever run on this backend."""
+        return None
+
+    async def stream(
+        self,
+        handle: IsolationHandle,
+        command: list[str],
+        *,
+        timeout_seconds: int | None = None,
+        working_directory: str | None = None,
+        environment: dict[str, str] | None = None,
+    ) -> AsyncIterator[str]:
+        """Raise immediately; interactive-tmux does not support streaming."""
+        del command, timeout_seconds, working_directory, environment
+        msg = (
+            f"interactive-tmux workspace {handle.isolation_id!r} does not "
+            "support claude -p stream-json execution. Use "
+            "provider_handle() and the send_message/await_completion/"
+            "capture_response pane API instead."
+        )
+        raise InteractiveTmuxStreamingUnsupportedError(msg)
+        yield ""  # pragma: no cover - unreachable; satisfies AsyncIterator typing
+
+
+__all__ = ["InteractiveTmuxStreamingUnsupportedError", "NoStreamEventStreamAdapter"]

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/service/workspace_lifecycle.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/service/workspace_lifecycle.py
@@ -84,6 +84,7 @@ def build_isolation_config(
     workflow_id: str | None,
     phase_id: str | None,
     extra_environment: dict[str, str] | None,
+    agents: tuple[str, ...] = (),
 ) -> IsolationConfig:
     """Build IsolationConfig with merged environment variables.
 
@@ -94,6 +95,7 @@ def build_isolation_config(
         workflow_id: Optional workflow ID
         phase_id: Optional phase ID
         extra_environment: Additional environment variables
+        agents: Interactive agent name(s) to provision (interactive-tmux only)
 
     Returns:
         IsolationConfig for container creation
@@ -115,6 +117,7 @@ def build_isolation_config(
             cpu_limit_cores=config.cpu_limit_cores,
         ),
         environment=merged_environment,
+        agents=agents,
     )
 
 

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/service/workspace_service.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/service/workspace_service.py
@@ -298,12 +298,13 @@ class WorkspaceService:
         top — see ``docs/plans/interactive-tmux-integration.md`` §3.4
         for the rationale (credential-confusion risk).
         """
-        from syn_adapters.workspace_backends.agentic import AgenticEventStreamAdapter
+        from syn_adapters.workspace_backends.errors import WorkspaceProvisionError
         from syn_adapters.workspace_backends.interactive_tmux import (
             INTERACTIVE_TMUX_AVAILABLE,
             InteractiveTmuxIsolationAdapter,
             NoopSidecarAdapter,
             NoopTokenInjectionAdapter,
+            NoStreamEventStreamAdapter,
         )
         from syn_shared.settings.workspace import WorkspaceSettings
 
@@ -316,7 +317,7 @@ class WorkspaceService:
                 "docs/plans/interactive-tmux-integration.md for the "
                 "rollout plan."
             )
-            raise RuntimeError(msg)
+            raise WorkspaceProvisionError(msg)
 
         if not INTERACTIVE_TMUX_AVAILABLE:
             msg = (
@@ -326,15 +327,19 @@ class WorkspaceService:
                 "commit on the `agentprims-lab` branch (or its "
                 "successor) that ships the provider."
             )
-            raise RuntimeError(msg)
+            raise WorkspaceProvisionError(msg)
 
         isolation = InteractiveTmuxIsolationAdapter(
             default_image=settings.interactive_tmux_image,
         )
-        # Reuse the agentic event-stream adapter shape; interactive-tmux
-        # does not emit stream-json today, so the stream is effectively
-        # a single-shot capture, but the adapter remains plumbable.
-        event_stream = AgenticEventStreamAdapter()
+        # interactive-tmux does not emit stream-json - it's driven through
+        # the tmux pane API (send_message/await_completion/capture_response,
+        # reached via provider_handle()), not workspace.stream(). Wiring a
+        # bare, un-configured AgenticEventStreamAdapter here used to make any
+        # accidental stream() call fail with a confusing "Provider not set"
+        # RuntimeError; NoStreamEventStreamAdapter fails loudly and
+        # explicitly instead (issue #771 item 5).
+        event_stream = NoStreamEventStreamAdapter()
 
         # NO SidecarTokenInjectionAdapter on this path — OAuth-on-disk
         # authenticates outbound calls; injecting an API key on top is

--- a/packages/syn-adapters/src/syn_adapters/workspace_backends/service/workspace_service.py
+++ b/packages/syn-adapters/src/syn_adapters/workspace_backends/service/workspace_service.py
@@ -478,6 +478,7 @@ class WorkspaceService:
         workflow_id: str | None,
         phase_id: str | None,
         extra_environment: dict[str, str] | None,
+        agents: tuple[str, ...] = (),
     ) -> tuple[WorkspaceAggregate, IsolationConfig]:
         """Create aggregate and isolation config for a new workspace.
 
@@ -487,6 +488,7 @@ class WorkspaceService:
             workflow_id: Optional workflow ID
             phase_id: Optional phase ID
             extra_environment: Additional environment variables
+            agents: Interactive agent name(s) to provision (interactive-tmux only)
 
         Returns:
             Tuple of (WorkspaceAggregate, IsolationConfig).
@@ -508,6 +510,7 @@ class WorkspaceService:
             workflow_id=workflow_id,
             phase_id=phase_id,
             extra_environment=extra_environment,
+            agents=agents,
         )
 
         return aggregate, isolation_config
@@ -523,6 +526,7 @@ class WorkspaceService:
         inject_tokens: bool = False,
         token_types: list[TokenType] | None = None,
         extra_environment: dict[str, str] | None = None,
+        agents: tuple[str, ...] = (),
     ) -> AsyncIterator[ManagedWorkspace]:
         """Create a managed workspace with full lifecycle.
 
@@ -537,6 +541,7 @@ class WorkspaceService:
             inject_tokens: Whether to inject tokens automatically
             token_types: Token types to inject (if inject_tokens=True)
             extra_environment: Additional environment variables
+            agents: Interactive agent name(s) to provision (interactive-tmux only)
 
         Yields:
             ManagedWorkspace for command execution
@@ -551,6 +556,7 @@ class WorkspaceService:
             workflow_id,
             phase_id,
             extra_environment,
+            agents=agents,
         )
 
         isolation_handle: IsolationHandle | None = None

--- a/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
+++ b/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
@@ -325,6 +325,42 @@ async def test_concurrent_creates_survive_provider_loop_affine_lock() -> None:
     assert {h.isolation_id for h in handles} == {"itws-lock-1", "itws-lock-2"}
 
 
+@pytest.mark.asyncio
+async def test_create_destroy_create_cycle_does_not_rebind_lock() -> None:
+    """A create -> destroy(all) -> create cycle on one adapter must not crash.
+
+    Regression for the loop-teardown rebind (focused review of #773): an
+    earlier version tore the provider loop down when the adapter's workspace
+    set drained, then lazily started a fresh loop on the next create(). The
+    provider instance (and its loop-affine asyncio.Lock) is reused across that
+    teardown, so the second round of concurrent creates acquired the lock -
+    still bound to the closed loop - from the new loop and raised RuntimeError.
+    The process-wide loop is never torn down, so this cycle must run cleanly.
+    """
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationConfig,
+    )
+
+    with (
+        patch.object(adapter_mod, "_InteractiveTmuxProvider", _LockOwningProvider),
+        patch.object(adapter_mod, "INTERACTIVE_TMUX_AVAILABLE", True),
+    ):
+        adapter = InteractiveTmuxIsolationAdapter()
+        cfg = IsolationConfig(execution_id="e", workspace_id="w", image="i", environment={})
+        # Round 1: concurrent creates bind the lock (contention), then destroy
+        # both so the adapter's workspace set drains to empty.
+        r1 = await asyncio.gather(adapter.create(cfg), adapter.create(cfg))
+        for handle in r1:
+            await adapter.destroy(handle)
+        assert adapter._workspaces == {}
+        # Round 2: concurrent creates again on the SAME adapter instance. This
+        # is where the torn-down-loop version raised "bound to a different
+        # event loop".
+        r2 = await asyncio.gather(adapter.create(cfg), adapter.create(cfg))
+
+    assert {h.isolation_id for h in r2} == {"itws-lock-3", "itws-lock-4"}
+
+
 def test_constructor_raises_when_provider_missing() -> None:
     """Constructor MUST fail loudly when the provider class is absent.
 

--- a/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
+++ b/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
@@ -58,6 +58,42 @@ async def test_create_delegates_to_provider_and_returns_handle() -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_sets_agents_label_from_config() -> None:
+    """config.agents becomes WorkspaceConfig.labels['agents'] so the provider
+    stages only those agents; empty config.agents omits the label (default)."""
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationConfig,
+    )
+
+    fake_workspace = MagicMock()
+    fake_workspace.id = "itws-agents"
+    fake_workspace.metadata = {}
+    fake_workspace._handle = MagicMock()
+
+    fake_provider_cls = MagicMock()
+    fake_provider = fake_provider_cls.return_value
+    fake_provider.create = AsyncMock(return_value=fake_workspace)
+
+    with (
+        patch.object(adapter_mod, "_InteractiveTmuxProvider", fake_provider_cls),
+        patch.object(adapter_mod, "INTERACTIVE_TMUX_AVAILABLE", True),
+    ):
+        adapter = InteractiveTmuxIsolationAdapter()
+        # With agents -> label set.
+        await adapter.create(
+            IsolationConfig(execution_id="e", workspace_id="w", image="i", agents=("claude",))
+        )
+        ws_config = fake_provider.create.await_args.args[0]
+        assert ws_config.labels["agents"] == "claude"
+
+        # Without agents -> no label (provider default: all agents).
+        fake_provider.create.reset_mock()
+        await adapter.create(IsolationConfig(execution_id="e", workspace_id="w", image="i"))
+        ws_config = fake_provider.create.await_args.args[0]
+        assert "agents" not in ws_config.labels
+
+
+@pytest.mark.asyncio
 async def test_create_rejects_environment_injection() -> None:
     """Interactive-tmux does not support env injection; create() must fail loud.
 

--- a/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
+++ b/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
@@ -6,6 +6,8 @@ so they run without Docker or any host credentials.
 
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -92,6 +94,109 @@ async def test_destroy_calls_provider_destroy_and_drops_handle() -> None:
 
     fake_provider.destroy.assert_awaited_once()
     assert "itws-xyz" not in adapter._workspaces
+
+
+async def _run_ticker(iterations: int, *, interval_s: float = 0.01) -> int:
+    """Advance a counter on the event loop via `asyncio.sleep`, and return the count.
+
+    Used as a canary: if a concurrently-running coroutine is blocking the
+    event loop, this ticker starves and its final count stays low even
+    though `iterations * interval_s` of wall-clock time elapsed.
+    """
+    ticks = 0
+    for _ in range(iterations):
+        await asyncio.sleep(interval_s)
+        ticks += 1
+    return ticks
+
+
+@pytest.mark.asyncio
+async def test_create_does_not_block_event_loop() -> None:
+    """create() must offload the blocking provider call to a worker thread.
+
+    `agentic_isolation.providers.interactive_tmux.InteractiveTmuxProvider.create()`
+    is async-def but synchronous internally (subprocess + sleep loops up
+    to ~45s) — its own docstring says callers needing concurrency must
+    wrap the call in their own thread. Simulate that blocking behaviour
+    with a fake provider whose create() does a real `time.sleep()`, and
+    assert a concurrently-scheduled ticker keeps making progress
+    throughout (issue #771 item 2).
+    """
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationConfig,
+    )
+
+    fake_workspace = MagicMock()
+    fake_workspace.id = "itws-block-create"
+    fake_workspace.metadata = {}
+    fake_workspace._handle = MagicMock()
+
+    async def blocking_create(_config: object) -> MagicMock:
+        time.sleep(0.3)  # simulates the provider's synchronous subprocess/sleep work
+        return fake_workspace
+
+    fake_provider_cls = MagicMock()
+    fake_provider_cls.return_value.create = blocking_create
+
+    with (
+        patch.object(adapter_mod, "_InteractiveTmuxProvider", fake_provider_cls),
+        patch.object(adapter_mod, "INTERACTIVE_TMUX_AVAILABLE", True),
+    ):
+        adapter = InteractiveTmuxIsolationAdapter()
+        ticker_task = asyncio.ensure_future(_run_ticker(30))
+        await adapter.create(
+            IsolationConfig(execution_id="e", workspace_id="w", image="i", environment={})
+        )
+        ticks = await ticker_task
+
+    # 30 x 10ms ticks should complete uninterrupted while create() blocks
+    # for 300ms in its own thread. If create() blocked this event loop
+    # instead, the ticker would have made near-zero progress by the time
+    # create() returned.
+    assert ticks > 10
+
+
+@pytest.mark.asyncio
+async def test_destroy_does_not_block_event_loop() -> None:
+    """destroy() must also offload its blocking provider call (issue #771 item 2)."""
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationConfig,
+        IsolationHandle,
+    )
+
+    fake_workspace = MagicMock()
+    fake_workspace.id = "itws-block-destroy"
+    fake_workspace.metadata = {}
+    fake_workspace._handle = MagicMock()
+
+    async def blocking_destroy(_workspace: object) -> None:
+        time.sleep(0.3)  # simulates the provider's synchronous stop() call
+
+    fake_provider_cls = MagicMock()
+    fake_provider_cls.return_value.create = AsyncMock(return_value=fake_workspace)
+    fake_provider_cls.return_value.destroy = blocking_destroy
+
+    with (
+        patch.object(adapter_mod, "_InteractiveTmuxProvider", fake_provider_cls),
+        patch.object(adapter_mod, "INTERACTIVE_TMUX_AVAILABLE", True),
+    ):
+        adapter = InteractiveTmuxIsolationAdapter()
+        await adapter.create(
+            IsolationConfig(execution_id="e", workspace_id="w", image="i", environment={})
+        )
+        ticker_task = asyncio.ensure_future(_run_ticker(30))
+        await adapter.destroy(
+            IsolationHandle(
+                isolation_id="itws-block-destroy",
+                isolation_type="interactive-tmux",
+                proxy_url=None,
+                workspace_path="/workspace",
+                host_workspace_path="",
+            )
+        )
+        ticks = await ticker_task
+
+    assert ticks > 10
 
 
 @pytest.mark.asyncio

--- a/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
+++ b/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
@@ -251,6 +251,80 @@ async def test_destroy_failure_retains_handle_for_retry() -> None:
     assert "itws-fail" not in adapter._workspaces
 
 
+class _LockOwningProvider:
+    """Fake provider that owns an asyncio.Lock like the real one.
+
+    The real InteractiveTmuxProvider guards its `_workspaces` dict with a
+    single `asyncio.Lock` created in __init__ and acquired in create() and
+    destroy(). `asyncio.Lock` is loop-affine: it binds to the first event
+    loop that acquires it and raises RuntimeError from any other loop. This
+    fake reproduces that so a regression in how the adapter schedules
+    provider coroutines (e.g. a fresh `asyncio.run` per call) surfaces as
+    the same RuntimeError a real workspace would hit on its second call.
+    """
+
+    def __init__(self, **_kwargs: object) -> None:
+        self._lock = asyncio.Lock()
+        self._workspaces: dict[str, object] = {}
+        self._counter = 0
+
+    async def create(self, _config: object) -> MagicMock:
+        ws = MagicMock()
+        ws.metadata = {}
+        ws._handle = MagicMock()
+        async with self._lock:
+            self._counter += 1
+            ws.id = f"itws-lock-{self._counter}"
+            self._workspaces[ws.id] = ws
+            # Hold the lock across an await so concurrent creates actually
+            # contend it - contention is what forces asyncio.Lock to bind to
+            # a loop (uncontended acquisitions take a fast path that never
+            # binds, so they would not surface the cross-loop bug).
+            await asyncio.sleep(0.05)
+        return ws
+
+    async def execute(self, _workspace: object, _command: str, **_kwargs: object) -> MagicMock:
+        result = MagicMock()
+        result.exit_code = 0
+        result.success = True
+        result.duration_ms = 1.0
+        result.stdout = ""
+        result.stderr = ""
+        result.timed_out = False
+        return result
+
+    async def destroy(self, workspace: MagicMock) -> None:
+        async with self._lock:
+            self._workspaces.pop(workspace.id, None)
+
+
+@pytest.mark.asyncio
+async def test_concurrent_creates_survive_provider_loop_affine_lock() -> None:
+    """Concurrent create() calls must not trip the provider's loop-affine lock.
+
+    Regression for the cross-loop RuntimeError (Codex review of #773): the
+    provider guards its state with a single asyncio.Lock, which binds to
+    whichever loop first contends it and raises RuntimeError from any other
+    loop. Driving each provider call on a throwaway `asyncio.run` loop makes
+    two concurrent provisions (the multi-agent workflow case, #768) acquire
+    that lock from two different loops and crash. The adapter must run every
+    provider coroutine on one stable loop, so this must complete cleanly.
+    """
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationConfig,
+    )
+
+    with (
+        patch.object(adapter_mod, "_InteractiveTmuxProvider", _LockOwningProvider),
+        patch.object(adapter_mod, "INTERACTIVE_TMUX_AVAILABLE", True),
+    ):
+        adapter = InteractiveTmuxIsolationAdapter()
+        cfg = IsolationConfig(execution_id="e", workspace_id="w", image="i", environment={})
+        handles = await asyncio.gather(adapter.create(cfg), adapter.create(cfg))
+
+    assert {h.isolation_id for h in handles} == {"itws-lock-1", "itws-lock-2"}
+
+
 def test_constructor_raises_when_provider_missing() -> None:
     """Constructor MUST fail loudly when the provider class is absent.
 

--- a/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
+++ b/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_adapter.py
@@ -45,7 +45,7 @@ async def test_create_delegates_to_provider_and_returns_handle() -> None:
                 execution_id="exec-1",
                 workspace_id="ws-1",
                 image="img:tag",
-                environment={"FOO": "bar"},
+                environment={},
             )
         )
 
@@ -55,6 +55,35 @@ async def test_create_delegates_to_provider_and_returns_handle() -> None:
     assert handle.workspace_path == "/workspace"
     # provider_handle exposes the underlying InteractiveTmuxWorkspace driver
     assert adapter.provider_handle(handle) is fake_workspace._handle
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_environment_injection() -> None:
+    """Interactive-tmux does not support env injection; create() must fail loud.
+
+    The provider rejects a non-default WorkspaceConfig.environment (it runs a
+    fixed entrypoint with its own credential layout). The adapter surfaces
+    that as a clear error at its own boundary instead of silently dropping
+    the env or letting a deeper ValueError leak.
+    """
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationConfig,
+    )
+
+    with (
+        patch.object(adapter_mod, "_InteractiveTmuxProvider", MagicMock()),
+        patch.object(adapter_mod, "INTERACTIVE_TMUX_AVAILABLE", True),
+    ):
+        adapter = InteractiveTmuxIsolationAdapter()
+        with pytest.raises(InteractiveTmuxUnavailableError, match="environment"):
+            await adapter.create(
+                IsolationConfig(
+                    execution_id="e",
+                    workspace_id="w",
+                    image="i",
+                    environment={"FOO": "bar"},
+                )
+            )
 
 
 @pytest.mark.asyncio

--- a/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_integration.py
+++ b/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_integration.py
@@ -76,6 +76,10 @@ async def test_send_message_round_trip_against_real_container() -> None:
         workspace_id="itws-integration-test-ws",
         image="agentic-workspace-interactive-tmux:latest",
         environment={},
+        # Stage only claude (the agent this test drives) - matches what the
+        # real provision path does and avoids the multi-minute cost of also
+        # staging codex/gemini credentials.
+        agents=("claude",),
     )
     handle = None
     try:

--- a/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_token_injection_bypass.py
+++ b/packages/syn-adapters/tests/workspace_backends/interactive_tmux/test_token_injection_bypass.py
@@ -20,9 +20,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import syn_adapters.workspace_backends.interactive_tmux as interactive_tmux_pkg
+from syn_adapters.workspace_backends.errors import WorkspaceProvisionError
 from syn_adapters.workspace_backends.interactive_tmux import (
     NoopSidecarAdapter,
     NoopTokenInjectionAdapter,
+    NoStreamEventStreamAdapter,
 )
 from syn_adapters.workspace_backends.interactive_tmux import adapter as adapter_mod
 from syn_adapters.workspace_backends.service import (
@@ -47,6 +50,47 @@ def test_interactive_factory_uses_noop_token_injection() -> None:
 
     assert isinstance(service._token_injection, NoopTokenInjectionAdapter)
     assert isinstance(service._sidecar, NoopSidecarAdapter)
+    # issue #771 item 5: interactive-tmux does not emit stream-json, so the
+    # factory must wire the explicit "streaming unsupported" adapter rather
+    # than a bare, un-configured AgenticEventStreamAdapter (which raised a
+    # confusing "Provider not set" error if stream() was ever called).
+    assert isinstance(service._event_stream, NoStreamEventStreamAdapter)
+
+
+@pytest.mark.asyncio
+async def test_interactive_event_stream_rejects_stream_calls() -> None:
+    """The wired event-stream adapter fails loudly and explicitly on stream().
+
+    Regression guard for issue #771 item 5: previously
+    `_create_interactive_tmux_impl` wired `AgenticEventStreamAdapter()`
+    without `set_provider()`, so any `stream()` call raised
+    `RuntimeError("Provider not set. Call set_provider first.")` - a message
+    describing an implementation detail rather than the real constraint.
+    """
+    from syn_adapters.workspace_backends.interactive_tmux import (
+        InteractiveTmuxStreamingUnsupportedError,
+    )
+    from syn_domain.contexts.orchestration.domain.aggregate_workspace.value_objects import (
+        IsolationHandle,
+    )
+
+    with (
+        patch.dict(os.environ, {"SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED": "true"}),
+        patch.object(adapter_mod, "_InteractiveTmuxProvider", MagicMock()),
+        patch.object(adapter_mod, "INTERACTIVE_TMUX_AVAILABLE", True),
+    ):
+        service = WorkspaceService.create(config=_interactive_cfg())
+
+    handle = IsolationHandle(
+        isolation_id="itws-x",
+        isolation_type="interactive-tmux",
+        proxy_url=None,
+        workspace_path="/workspace",
+        host_workspace_path="",
+    )
+    with pytest.raises(InteractiveTmuxStreamingUnsupportedError, match="interactive-tmux"):
+        async for _ in service._event_stream.stream(handle, ["claude", "-p", "hi"]):
+            pass
 
 
 @pytest.mark.asyncio
@@ -76,22 +120,36 @@ async def test_noop_token_injection_inject_yields_zero_tokens() -> None:
 
 
 def test_flag_off_rejects_interactive_provider_kind() -> None:
-    """Without the feature flag the factory MUST refuse — no silent fallback."""
+    """Without the feature flag the factory MUST refuse — no silent fallback.
+
+    Also asserts the typed error (issue #771 item 7): a bare RuntimeError
+    gives error-mapping layers (`_fail_execution`, `syn execution show`)
+    nothing to match against.
+    """
     with (
         patch.dict(os.environ, {"SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED": "false"}),
-        pytest.raises(RuntimeError) as exc,
+        pytest.raises(WorkspaceProvisionError) as exc,
     ):
         WorkspaceService.create(config=_interactive_cfg())
     assert "SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED" in str(exc.value)
 
 
 def test_provider_unavailable_raises_when_flag_on_but_import_missing() -> None:
-    """If the submodule pin lacks the provider, the factory must say so."""
+    """If the submodule pin lacks the provider, the factory must say so.
+
+    Patches both `adapter_mod.INTERACTIVE_TMUX_AVAILABLE` and the
+    re-exported package-level name: `_create_interactive_tmux_impl` reads
+    the latter (`from syn_adapters.workspace_backends.interactive_tmux
+    import INTERACTIVE_TMUX_AVAILABLE`), which is a separate binding
+    captured when the package's `__init__` ran — patching only the
+    submodule attribute leaves that binding untouched.
+    """
     with (
         patch.dict(os.environ, {"SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED": "true"}),
         patch.object(adapter_mod, "INTERACTIVE_TMUX_AVAILABLE", False),
+        patch.object(interactive_tmux_pkg, "INTERACTIVE_TMUX_AVAILABLE", False),
         patch.object(adapter_mod, "_InteractiveTmuxProvider", None),
-        pytest.raises(RuntimeError) as exc,
+        pytest.raises(WorkspaceProvisionError) as exc,
     ):
         WorkspaceService.create(config=_interactive_cfg())
     assert "agentic_isolation" in str(exc.value)

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_workspace/value_objects.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_workspace/value_objects.py
@@ -205,6 +205,13 @@ class IsolationConfig:
     # Labels for tracking
     labels: Mapping[str, str] = field(default_factory=dict)
 
+    # Interactive-agent selection: the agent name(s) to provision (e.g.
+    # ("claude",)). Only the interactive-tmux backend reads this - it stages
+    # auth and launches a tmux pane for each named agent, so a claude-only
+    # phase does not pay to stage codex/gemini. Empty means "backend default"
+    # (the docker `claude -p` backend ignores it entirely).
+    agents: tuple[str, ...] = ()
+
 
 @dataclass(frozen=True)
 class SidecarConfig:

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/ports/WorkspaceServicePort.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/ports/WorkspaceServicePort.py
@@ -32,6 +32,7 @@ class WorkspaceServicePort(Protocol):
         phase_id: str | None = None,
         with_sidecar: bool = False,
         inject_tokens: bool = False,
+        agents: tuple[str, ...] = (),
     ) -> AbstractAsyncContextManager["ManagedWorkspace"]:
         """Create an isolated workspace for agent execution.
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/WorkflowExecutionProcessor.py
@@ -31,6 +31,9 @@ from syn_domain.contexts.orchestration.slices.execute_workflow.ArtifactCollector
 from syn_domain.contexts.orchestration.slices.execute_workflow.ConversationRecorder import (
     ConversationRecorder,
 )
+from syn_domain.contexts.orchestration.slices.execute_workflow.errors import (
+    WorkspaceMisconfiguredError,
+)
 from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
     AgentExecutionHandler,
     AgentExecutionResult,
@@ -655,7 +658,7 @@ class WorkflowExecutionProcessor:
                 "is configured. Set SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED=true "
                 "so the interactive-tmux provider is wired in."
             )
-            raise RuntimeError(msg)
+            raise WorkspaceMisconfiguredError(msg)
         return self._interactive_workspace_service
 
     def _get_agent_handler(self) -> AgentHandlerProtocol:

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/errors.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/errors.py
@@ -43,6 +43,28 @@ class WorkflowExecutionError(Exception):
         self.__cause__ = cause
 
 
+class WorkspaceMisconfiguredError(RuntimeError):
+    """Raised when a phase and its workspace disagree about the interactive-tmux backend.
+
+    Covers two misconfigurations (issue #771 items 5 and 7):
+      * `WorkflowExecutionProcessor._workspace_service_for` selects a phase
+        declaring `agent.provider="claude-interactive"` but no interactive
+        workspace service was wired in (``SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED``
+        never set).
+      * `WorkspaceProvisionHandler._is_interactive_phase` finds the phase's
+        explicit provider and the workspace's actual isolation backend
+        disagree — this used to be silently resolved by an implicit OR
+        over `isolation_handle.isolation_type`; that fallback is gone, so
+        a mismatch is now a loud failure instead of a silent flip.
+
+    Subclasses ``RuntimeError`` (rather than the plain ``Exception`` used
+    by sibling errors in this module) so it is a drop-in replacement for
+    the bare ``raise RuntimeError(...)`` calls it supersedes — existing
+    ``except RuntimeError`` / ``pytest.raises(RuntimeError)`` call sites
+    keep working unchanged.
+    """
+
+
 class WorkflowInterruptedError(Exception):
     """Raised when workflow execution is forcefully interrupted via SIGINT.
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
@@ -462,7 +462,7 @@ async def _run_interactive_driver(
             tokens=tokens,
             subagents=subagents,
             error_reason=(
-                f"interactive driver did not return within {timeout_seconds}s (transport hang?)"
+                f"interactive driver did not return within {overall_timeout_s:g}s (transport hang?)"
             ),
         )
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
@@ -365,6 +365,31 @@ def _interactive_driver_unavailable(
     )
 
 
+def _drive_round_trip(
+    driver: InteractiveTmuxDriver,
+    agent_id: str,
+    prompt: str,
+    timeout_seconds: int,
+) -> tuple[int, str, str]:
+    """Blocking send -> await -> capture round-trip; runs in a worker thread.
+
+    Raises InteractiveTmuxTransportError (D2 fix) on raw subprocess
+    failures so the workflow's error_message is operator-readable
+    instead of a raw Python repr leaking the docker-exec arglist.
+    """
+    from subprocess import CalledProcessError
+
+    try:
+        driver.send_message(agent_id, prompt)
+        result = driver.await_completion(agent_id, timeout=float(timeout_seconds))
+        pane = driver.capture_response(agent_id)
+    except CalledProcessError as exc:
+        raise InteractiveTmuxTransportError.from_called_process(exc) from exc
+    exit_code = 0 if result.ready else 124  # 124 = standard timeout exit code
+    reason = getattr(result, "reason", "ready" if result.ready else "timeout")
+    return exit_code, pane, reason
+
+
 async def _run_interactive_driver(
     *,
     driver: InteractiveTmuxDriver,
@@ -397,24 +422,10 @@ async def _run_interactive_driver(
     assert todo.phase_id is not None
     loop = asyncio.get_running_loop()
 
-    def _drive() -> tuple[int, str, str]:
-        from subprocess import CalledProcessError
-
-        try:
-            driver.send_message(agent_id, prompt)
-            result = driver.await_completion(agent_id, timeout=float(timeout_seconds))
-            pane = driver.capture_response(agent_id)
-        except CalledProcessError as exc:
-            # D2: convert raw subprocess errors to a typed domain error
-            # so error_message is not a raw Python repr leaking the
-            # docker-exec arglist.
-            raise InteractiveTmuxTransportError.from_called_process(exc) from exc
-        exit_code = 0 if result.ready else 124  # 124 = standard timeout exit code
-        reason = getattr(result, "reason", "ready" if result.ready else "timeout")
-        return exit_code, pane, reason
-
     round_trip_started_at = time.monotonic()
-    completion_future = loop.run_in_executor(None, _drive)
+    completion_future = loop.run_in_executor(
+        None, _drive_round_trip, driver, agent_id, prompt, timeout_seconds
+    )
 
     # Bound the entire wait (cancel-race + drive) at timeout_seconds + margin
     # (#771 item 1). A stalled transport (e.g. a wedged `docker exec`) would

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
@@ -9,6 +9,7 @@ Reports AgentExecutionCompletedCommand to the aggregate.
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
@@ -36,6 +37,15 @@ if TYPE_CHECKING:
     )
 
 logger = logging.getLogger(__name__)
+
+# Margin added on top of a phase's timeout_seconds when bounding the total
+# wait for the interactive driver round-trip (send_message + await_completion
+# + capture_response). await_completion already has its own internal deadline
+# equal to timeout_seconds; the margin covers the driver's own bookkeeping
+# (send_message, capture_response) plus scheduling jitter so we don't fire the
+# outer timeout before the driver's own has a fair chance to return normally.
+# See issue #771, item 1.
+_INTERACTIVE_TIMEOUT_MARGIN_SECONDS: float = 30.0
 
 
 class InteractiveCompletionResult(Protocol):
@@ -403,14 +413,47 @@ async def _run_interactive_driver(
         reason = getattr(result, "reason", "ready" if result.ready else "timeout")
         return exit_code, pane, reason
 
+    round_trip_started_at = time.monotonic()
     completion_future = loop.run_in_executor(None, _drive)
 
-    cancel_signal_obj = await _race_completion_against_cancel(
-        completion_future=completion_future,
-        controller=controller,
-        execution_id=todo.execution_id,
-        driver=driver,
-    )
+    # Bound the entire wait (cancel-race + drive) at timeout_seconds + margin
+    # (#771 item 1). A stalled transport (e.g. a wedged `docker exec`) would
+    # otherwise wedge the execution forever, since `await_completion`'s own
+    # internal deadline is advisory only - a hung subprocess can ignore it.
+    #
+    # NOTE: `run_in_executor` futures cannot be cancelled once the underlying
+    # callable is running in its worker thread - cancelling `completion_future`
+    # (or the wrapping `wait_for`) does not stop `_drive()`. That thread is
+    # abandoned to run to completion (or forever) in the background. This is
+    # an accepted limitation: the goal here is unwedging the *execution*
+    # (returning control to the processor so it can fail/retry the phase),
+    # not killing the stuck thread.
+    overall_timeout_s = float(timeout_seconds) + _INTERACTIVE_TIMEOUT_MARGIN_SECONDS
+    try:
+        cancel_signal_obj = await asyncio.wait_for(
+            _race_completion_against_cancel(
+                completion_future=completion_future,
+                controller=controller,
+                execution_id=todo.execution_id,
+                driver=driver,
+            ),
+            timeout=overall_timeout_s,
+        )
+    except TimeoutError:
+        error_msg = (
+            f"interactive driver did not return within {overall_timeout_s:g}s "
+            f"(transport hang?) (phase={todo.phase_id})"
+        )
+        logger.error(error_msg)
+        return _build_failed_result(
+            todo=todo,
+            session_id=session_id,
+            tokens=tokens,
+            subagents=subagents,
+            error_reason=(
+                f"interactive driver did not return within {timeout_seconds}s (transport hang?)"
+            ),
+        )
 
     if cancel_signal_obj is not None:
         return _build_cancelled_result(
@@ -437,6 +480,8 @@ async def _run_interactive_driver(
             error_reason=str(exc),
         )
 
+    round_trip_duration_ms = int((time.monotonic() - round_trip_started_at) * 1000)
+
     if collector is not None:
         await collector.record_session_summary(
             total_cost_usd=0.0,
@@ -445,7 +490,7 @@ async def _run_interactive_driver(
             cache_creation=0,
             cache_read=0,
             num_turns=1,
-            duration_ms=0,
+            duration_ms=round_trip_duration_ms,
             agent_id=agent_id,
         )
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/WorkspaceProvisionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/WorkspaceProvisionHandler.py
@@ -22,6 +22,9 @@ from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects 
 from syn_domain.contexts.orchestration.domain.aggregate_execution.WorkflowExecutionAggregate import (
     ProvisionWorkspaceCompletedCommand,
 )
+from syn_domain.contexts.orchestration.slices.execute_workflow.errors import (
+    WorkspaceMisconfiguredError,
+)
 from syn_shared.env_constants import (
     ENV_ANTHROPIC_API_KEY,
     ENV_ANTHROPIC_BASE_URL,
@@ -71,9 +74,35 @@ CommandBuilder = Callable[[ExecutablePhase, str], list[str]]
 
 
 def _is_interactive_phase(workspace: ManagedWorkspace, phase: ExecutablePhase) -> bool:
+    """Return whether this phase should dispatch via the interactive-tmux path.
+
+    Explicit signal only: ``phase.agent_config.provider ==
+    "claude-interactive"``. The YAML schema has carried an `agent.provider`
+    field since PR #765, so `workspace.isolation_handle.isolation_type` is
+    no longer consulted as an implicit fallback (issue #771 item 5).
+
+    Raises WorkspaceMisconfiguredError if the phase's declared provider
+    and the workspace's actual isolation backend disagree.
+    `WorkflowExecutionProcessor._workspace_service_for` is responsible for
+    routing `claude-interactive` phases to the interactive-tmux
+    WorkspaceService and every other phase to the default one — if that
+    routing broke, proceeding here would silently flip which path runs
+    (previously masked by the implicit OR) instead of failing loudly.
+    """
     explicit_interactive = phase.agent_config.provider == "claude-interactive"
-    implicit_interactive = workspace.isolation_handle.isolation_type == "interactive-tmux"
-    return explicit_interactive or implicit_interactive
+    workspace_is_interactive_tmux = workspace.isolation_handle.isolation_type == "interactive-tmux"
+    if explicit_interactive != workspace_is_interactive_tmux:
+        msg = (
+            f"Phase '{phase.phase_id}' agent_config.provider="
+            f"{phase.agent_config.provider!r} but its workspace was provisioned "
+            f"with isolation_type={workspace.isolation_handle.isolation_type!r}. "
+            "WorkflowExecutionProcessor._workspace_service_for must route "
+            "claude-interactive phases to the interactive-tmux WorkspaceService "
+            "and all other phases to the default one - this mismatch means that "
+            "routing picked the wrong backend for this phase."
+        )
+        raise WorkspaceMisconfiguredError(msg)
+    return explicit_interactive
 
 
 def _append_claude_plugin_dirs(
@@ -410,14 +439,9 @@ class WorkspaceProvisionHandler:
         # tmux pane instead of running claude -p. Skip the CLI command
         # builder (it would produce a noisy claude_cmd we never run) and
         # carry the prompt out-of-band on the ProvisionResult.
-        # Interactive detection: explicit per-phase (`provider:
-        # claude-interactive`) OR implicit (the workspace itself was
-        # provisioned through the interactive-tmux backend, e.g. when the
-        # API is wired with provider_kind="interactive-tmux" service-wide).
-        # The YAML schema currently has no `agent.provider` field, so the
-        # implicit signal is what carries the e2e today. Per-phase
-        # override is the future path once the YAML schema gains an
-        # `agent` block — handler logic doesn't need to change for that.
+        # Interactive detection is explicit-only (issue #771 item 5); see
+        # `_is_interactive_phase` for the mismatch guard against the
+        # workspace's actual isolation backend.
         is_interactive = _is_interactive_phase(workspace, phase)
         claude_cmd = [] if is_interactive else self._command_builder(phase, prompt)
         interactive_prompt = prompt if is_interactive else None

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/WorkspaceProvisionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/WorkspaceProvisionHandler.py
@@ -105,6 +105,21 @@ def _is_interactive_phase(workspace: ManagedWorkspace, phase: ExecutablePhase) -
     return explicit_interactive
 
 
+def _provisioned_agents(phase: ExecutablePhase) -> tuple[str, ...]:
+    """Interactive agent name(s) to stage for this phase's workspace.
+
+    For an interactive-tmux phase (`provider == "claude-interactive"`) return
+    just the agent the phase drives - `agent_config.agent_id` is the canonical
+    claude/codex/gemini name the driver stages auth and launches a pane for.
+    Staging only the needed agent avoids the multi-minute cost of copying the
+    other two agents' credentials. Returns () for the default docker path
+    (which ignores agent selection entirely).
+    """
+    if phase.agent_config.provider == "claude-interactive":
+        return (phase.agent_config.agent_id,)
+    return ()
+
+
 def _append_claude_plugin_dirs(
     claude_cmd: list[str],
     phase: ExecutablePhase,
@@ -306,6 +321,7 @@ class WorkspaceProvisionHandler:
             phase_id=todo.phase_id,
             with_sidecar=True,
             inject_tokens=True,
+            agents=_provisioned_agents(phase),
         )
 
         # Enter the async context manager; clean up on any exception (P0: container leak fix)

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_workflow_execution_processor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_workflow_execution_processor.py
@@ -93,9 +93,17 @@ class TestWorkspaceServiceSelection:
         assert selected is interactive
 
     def test_interactive_phase_without_service_fails_loudly(self) -> None:
+        """Also asserts the typed error (issue #771 item 7): a bare RuntimeError
+        gives error-mapping layers nothing to match against."""
+        from syn_domain.contexts.orchestration.slices.execute_workflow.errors import (
+            WorkspaceMisconfiguredError,
+        )
+
         processor = _make_processor(interactive_workspace_service=None)
 
-        with pytest.raises(RuntimeError, match="SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED"):
+        with pytest.raises(
+            WorkspaceMisconfiguredError, match="SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED"
+        ):
             processor._workspace_service_for(self._phase("claude-interactive"))
 
 

--- a/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_agent_execution_handler_interactive.py
+++ b/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_agent_execution_handler_interactive.py
@@ -187,7 +187,9 @@ async def test_interactive_driver_hang_fails_within_bounded_timeout(
     assert result.command.exit_code != 0
     assert result.stream_result.error_reason is not None
     assert "did not return within" in result.stream_result.error_reason
-    assert "0s" in result.stream_result.error_reason
+    # error_reason reports the bounded timeout (timeout_seconds + margin),
+    # matching what was actually enforced.
+    assert "transport hang" in result.stream_result.error_reason
 
 
 @pytest.mark.asyncio

--- a/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_agent_execution_handler_interactive.py
+++ b/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_agent_execution_handler_interactive.py
@@ -1,0 +1,217 @@
+"""Tests for AgentExecutionHandler's interactive-tmux drive path (issue #771).
+
+Covers:
+  * item 1 - a stalled driver round-trip (e.g. a wedged `docker exec`) must
+    not hang the execution forever; the wait is bounded by the phase's
+    `timeout_seconds` plus a small margin, after which we return a failed
+    result with a clear error_reason.
+  * item 6 - a successful round-trip records the actual wall-clock duration
+    in the session summary instead of a hardcoded `duration_ms=0`.
+"""
+
+from __future__ import annotations
+
+import importlib
+import threading
+import time
+from dataclasses import dataclass
+
+import pytest
+
+from syn_domain.contexts.orchestration._shared.TodoValueObjects import (
+    TodoAction,
+    TodoItem,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler import (
+    AgentExecutionHandler,
+)
+
+# NOTE: `handlers/__init__.py` re-exports the *class* `AgentExecutionHandler`,
+# shadowing the submodule of the same name on the `handlers` package object.
+# `importlib.import_module` reaches into `sys.modules` directly so we get the
+# actual module (needed to monkeypatch `_INTERACTIVE_TIMEOUT_MARGIN_SECONDS`)
+# rather than the re-exported class.
+handler_module = importlib.import_module(
+    "syn_domain.contexts.orchestration.slices.execute_workflow.handlers.AgentExecutionHandler"
+)
+
+
+@dataclass
+class _FakeAwaitResult:
+    ready: bool
+    reason: str
+
+
+class _FakeDriver:
+    """Duck-typed stand-in for InteractiveTmuxDriver.
+
+    `hang_seconds` models a transport hang: the underlying `await_completion`
+    ignores the `timeout` argument it was given (as a real stalled `docker
+    exec` would) and blocks for `hang_seconds` before ever returning. Kept
+    small (not infinite) so a leaked background thread does not stall
+    process/interpreter shutdown after the test moves on.
+    """
+
+    def __init__(self, *, hang_seconds: float = 0.0, delay_seconds: float = 0.0) -> None:
+        self.hang_seconds = hang_seconds
+        self.delay_seconds = delay_seconds
+        self.stopped = False
+
+    def send_message(self, agent: str, text: str) -> None:
+        pass
+
+    def await_completion(self, agent: str, timeout: float = 0.0) -> _FakeAwaitResult:
+        if self.hang_seconds:
+            threading.Event().wait(self.hang_seconds)
+        elif self.delay_seconds:
+            time.sleep(self.delay_seconds)
+        return _FakeAwaitResult(ready=True, reason="ready")
+
+    def capture_response(self, agent: str) -> str:
+        return "hello from pane"
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+class _FakeIsolationAdapter:
+    def __init__(self, driver: _FakeDriver) -> None:
+        self._driver = driver
+
+    def provider_handle(self, handle: object) -> _FakeDriver:
+        return self._driver
+
+
+class _FakeService:
+    def __init__(self, driver: _FakeDriver) -> None:
+        self._isolation = _FakeIsolationAdapter(driver)
+
+
+class _FakeWorkspace:
+    """Minimal duck-typed ManagedWorkspace stand-in for the interactive path."""
+
+    def __init__(self, driver: _FakeDriver) -> None:
+        self._service = _FakeService(driver)
+        self.isolation_handle = object()
+        self.id = "workspace-1"
+
+
+@dataclass(frozen=True)
+class _SummaryCall:
+    """Typed capture of one record_session_summary invocation."""
+
+    total_cost_usd: float | None
+    input_tokens: int
+    output_tokens: int
+    cache_creation: int
+    cache_read: int
+    num_turns: int | None
+    duration_ms: int | None
+    agent_id: str | None
+
+
+class _FakeCollector:
+    """Captures record_session_summary calls without touching real observability."""
+
+    def __init__(self) -> None:
+        self.summary_calls: list[_SummaryCall] = []
+
+    async def record_session_summary(
+        self,
+        total_cost_usd: float | None,
+        input_tokens: int,
+        output_tokens: int,
+        cache_creation: int,
+        cache_read: int,
+        num_turns: int | None,
+        duration_ms: int | None,
+        agent_id: str | None = None,
+    ) -> None:
+        self.summary_calls.append(
+            _SummaryCall(
+                total_cost_usd=total_cost_usd,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_creation=cache_creation,
+                cache_read=cache_read,
+                num_turns=num_turns,
+                duration_ms=duration_ms,
+                agent_id=agent_id,
+            )
+        )
+
+
+def _make_todo() -> TodoItem:
+    return TodoItem(
+        execution_id="exec-1",
+        action=TodoAction.RUN_AGENT,
+        phase_id="phase-1",
+        workspace_id="workspace-1",
+        session_id="session-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_interactive_driver_hang_fails_within_bounded_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stalled driver round-trip must not wedge the execution forever.
+
+    The driver ignores its `timeout` argument and blocks for longer than
+    the bound; the handler must return a failed result well inside
+    timeout_seconds + margin, with an error_reason describing the hang.
+    """
+    monkeypatch.setattr(handler_module, "_INTERACTIVE_TIMEOUT_MARGIN_SECONDS", 0.05)
+
+    driver = _FakeDriver(hang_seconds=1.0)
+    workspace = _FakeWorkspace(driver)
+    handler = AgentExecutionHandler(controller=None)
+
+    started = time.monotonic()
+    result = await handler.handle(
+        todo=_make_todo(),
+        workspace=workspace,  # type: ignore[arg-type]
+        agent_env={},
+        claude_cmd=[],
+        session_id="session-1",
+        agent_model="claude-x",
+        timeout_seconds=0,
+        collector=None,
+        interactive_prompt="do the thing",
+        agent_id="claude",
+    )
+    elapsed = time.monotonic() - started
+
+    # Bounded well under the driver's 1s hang (timeout_seconds=0 + margin=0.05s).
+    assert elapsed < 0.5
+    assert result.command.exit_code != 0
+    assert result.stream_result.error_reason is not None
+    assert "did not return within" in result.stream_result.error_reason
+    assert "0s" in result.stream_result.error_reason
+
+
+@pytest.mark.asyncio
+async def test_interactive_round_trip_records_positive_duration() -> None:
+    """A successful round-trip must record real wall-clock duration_ms, not 0."""
+    driver = _FakeDriver(delay_seconds=0.05)
+    workspace = _FakeWorkspace(driver)
+    collector = _FakeCollector()
+    handler = AgentExecutionHandler(controller=None)
+
+    result = await handler.handle(
+        todo=_make_todo(),
+        workspace=workspace,  # type: ignore[arg-type]
+        agent_env={},
+        claude_cmd=[],
+        session_id="session-1",
+        agent_model="claude-x",
+        timeout_seconds=5,
+        collector=collector,  # type: ignore[arg-type]
+        interactive_prompt="do the thing",
+        agent_id="claude",
+    )
+
+    assert result.command.exit_code == 0
+    assert len(collector.summary_calls) == 1
+    assert collector.summary_calls[0].duration_ms is not None
+    assert collector.summary_calls[0].duration_ms > 0

--- a/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_workspace_provision_handler_interactive.py
+++ b/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_workspace_provision_handler_interactive.py
@@ -24,15 +24,16 @@ from syn_domain.contexts.orchestration.slices.execute_workflow.errors import (
 )
 from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.WorkspaceProvisionHandler import (
     _is_interactive_phase,
+    _provisioned_agents,
 )
 
 
-def _phase(provider: str) -> ExecutablePhase:
+def _phase(provider: str, agent_id: str = "claude") -> ExecutablePhase:
     return ExecutablePhase(
         phase_id="p1",
         name="Phase 1",
         order=1,
-        agent_config=AgentConfiguration(provider=provider),
+        agent_config=AgentConfiguration(provider=provider, agent_id=agent_id),
         prompt_template="do it",
     )
 
@@ -87,3 +88,19 @@ class TestIsInteractivePhaseMismatchGuard:
         workspace = _workspace("interactive-tmux")
         with pytest.raises(WorkspaceMisconfiguredError, match="interactive-tmux"):
             _is_interactive_phase(workspace, _phase("claude"))
+
+
+class TestProvisionedAgents:
+    """Interactive phases provision only the agent they drive."""
+
+    def test_interactive_phase_provisions_only_its_agent(self) -> None:
+        assert _provisioned_agents(_phase("claude-interactive", "claude")) == ("claude",)
+
+    def test_interactive_phase_honors_non_claude_agent(self) -> None:
+        # Forward-compatible: a codex/gemini interactive phase stages that agent.
+        assert _provisioned_agents(_phase("claude-interactive", "codex")) == ("codex",)
+
+    def test_docker_phase_provisions_no_specific_agent(self) -> None:
+        # Empty -> the docker backend ignores it and the interactive provider
+        # would fall back to all agents (not reachable on the docker path).
+        assert _provisioned_agents(_phase("claude", "claude")) == ()

--- a/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_workspace_provision_handler_interactive.py
+++ b/packages/syn-domain/tests/contexts/workflows/execute_workflow/test_workspace_provision_handler_interactive.py
@@ -1,0 +1,89 @@
+"""Unit tests for `_is_interactive_phase` (issue #771 item 5).
+
+`WorkspaceProvisionHandler._is_interactive_phase` used to OR together an
+explicit signal (`phase.agent_config.provider == "claude-interactive"`)
+with an implicit one (`workspace.isolation_handle.isolation_type ==
+"interactive-tmux"`) on the theory that the YAML schema had no
+`agent.provider` field. That has been false since PR #765. These tests
+pin the collapsed, explicit-only behaviour and the new mismatch guard
+that replaces the silent implicit fallback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from syn_domain.contexts.orchestration.domain.aggregate_execution.value_objects import (
+    AgentConfiguration,
+    ExecutablePhase,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.errors import (
+    WorkspaceMisconfiguredError,
+)
+from syn_domain.contexts.orchestration.slices.execute_workflow.handlers.WorkspaceProvisionHandler import (
+    _is_interactive_phase,
+)
+
+
+def _phase(provider: str) -> ExecutablePhase:
+    return ExecutablePhase(
+        phase_id="p1",
+        name="Phase 1",
+        order=1,
+        agent_config=AgentConfiguration(provider=provider),
+        prompt_template="do it",
+    )
+
+
+def _workspace(isolation_type: str) -> MagicMock:
+    workspace = MagicMock()
+    workspace.isolation_handle.isolation_type = isolation_type
+    return workspace
+
+
+class TestIsInteractivePhaseExplicitOnly:
+    """Explicit `provider="claude-interactive"` is the only interactive signal."""
+
+    def test_explicit_interactive_on_interactive_workspace(self) -> None:
+        workspace = _workspace("interactive-tmux")
+        assert _is_interactive_phase(workspace, _phase("claude-interactive")) is True
+
+    def test_default_provider_on_docker_workspace(self) -> None:
+        workspace = _workspace("docker")
+        assert _is_interactive_phase(workspace, _phase("claude")) is False
+
+    def test_implicit_isolation_type_no_longer_flips_result(self) -> None:
+        """A `claude` phase landing on a docker workspace is unambiguous.
+
+        This is the base case the old implicit-detection comment claimed
+        was unreachable; it is exercised directly here for clarity, and by
+        the docker-workspace fixture in every other test in this class.
+        """
+        workspace = _workspace("docker")
+        assert _is_interactive_phase(workspace, _phase("claude")) is False
+
+
+class TestIsInteractivePhaseMismatchGuard:
+    """Explicit signal disagreeing with the workspace's backend fails loudly."""
+
+    def test_interactive_phase_on_non_interactive_workspace_raises(self) -> None:
+        """An interactive phase must never silently run on a docker workspace.
+
+        Previously the implicit OR made this combination resolve to
+        ``False`` (docker path) with no signal that anything was wrong.
+        """
+        workspace = _workspace("docker")
+        with pytest.raises(WorkspaceMisconfiguredError, match="claude-interactive"):
+            _is_interactive_phase(workspace, _phase("claude-interactive"))
+
+    def test_non_interactive_phase_on_interactive_workspace_raises(self) -> None:
+        """A plain `claude` phase must never silently run against a tmux workspace.
+
+        Previously the implicit OR flipped this to ``True`` (interactive
+        path) even though the phase never asked for it.
+        """
+        workspace = _workspace("interactive-tmux")
+        with pytest.raises(WorkspaceMisconfiguredError, match="interactive-tmux"):
+            _is_interactive_phase(workspace, _phase("claude"))

--- a/packages/syn-shared/src/syn_shared/settings/__init__.py
+++ b/packages/syn-shared/src/syn_shared/settings/__init__.py
@@ -68,6 +68,7 @@ from syn_shared.settings.workspace import (
 )
 from syn_shared.settings.workspace_images import (
     DEFAULT_WORKSPACE_IMAGE,
+    INTERACTIVE_TMUX_WORKSPACE_IMAGE,
     WorkspaceImageProvider,
     workspace_image_ref,
 )
@@ -78,6 +79,7 @@ from syn_shared.settings.workspace_security import (
 
 __all__ = [
     "DEFAULT_WORKSPACE_IMAGE",
+    "INTERACTIVE_TMUX_WORKSPACE_IMAGE",
     "AppEnvironment",
     "CloudProvider",
     "ContainerLoggingSettings",

--- a/packages/syn-shared/src/syn_shared/settings/workspace.py
+++ b/packages/syn-shared/src/syn_shared/settings/workspace.py
@@ -28,7 +28,10 @@ from syn_shared.settings.git_identity import (  # noqa: F401
 from syn_shared.settings.git_identity_resolver import (
     GitIdentityResolver as GitIdentityResolver,
 )
-from syn_shared.settings.workspace_images import DEFAULT_WORKSPACE_IMAGE
+from syn_shared.settings.workspace_images import (
+    DEFAULT_WORKSPACE_IMAGE,
+    INTERACTIVE_TMUX_WORKSPACE_IMAGE,
+)
 from syn_shared.settings.workspace_security import (  # noqa: F401
     ContainerLoggingSettings,
     WorkspaceSecuritySettings,
@@ -138,7 +141,7 @@ class WorkspaceSettings(BaseSettings):
     )
 
     interactive_tmux_image: str = Field(
-        default="agentic-workspace-interactive-tmux:latest",
+        default=INTERACTIVE_TMUX_WORKSPACE_IMAGE,
         description=(
             "Docker image for the interactive-tmux workspace provider. "
             "Bundles tmux + interactive claude/codex/gemini CLIs."

--- a/packages/syn-shared/src/syn_shared/settings/workspace_images.py
+++ b/packages/syn-shared/src/syn_shared/settings/workspace_images.py
@@ -29,6 +29,7 @@ class WorkspaceImageProvider(StrEnum):
     """
 
     CLAUDE_CLI = "claude-cli"
+    INTERACTIVE_TMUX = "interactive-tmux"
 
 
 # ---------------------------------------------------------------------------
@@ -62,4 +63,15 @@ def workspace_image_ref(
 # ---------------------------------------------------------------------------
 
 DEFAULT_WORKSPACE_IMAGE: str = workspace_image_ref()
-"""Default workspace image — Claude CLI provider, latest tag, from GHCR."""
+"""Default workspace image - Claude CLI provider, latest tag, from GHCR."""
+
+INTERACTIVE_TMUX_WORKSPACE_IMAGE: str = (
+    f"{IMAGE_PREFIX}-{WorkspaceImageProvider.INTERACTIVE_TMUX.value}:{DEFAULT_TAG}"
+)
+"""Default interactive-tmux workspace image - bare local tag, not yet published to GHCR.
+
+Unlike DEFAULT_WORKSPACE_IMAGE, this is built and run locally by agentic-primitives
+(EXP-05) and has not been published to a registry. Once it is published, switch this
+to `workspace_image_ref(WorkspaceImageProvider.INTERACTIVE_TMUX)` to become
+GHCR-qualified like the default image.
+"""

--- a/packages/syn-shared/tests/test_workspace_settings.py
+++ b/packages/syn-shared/tests/test_workspace_settings.py
@@ -13,6 +13,7 @@ import pytest
 
 from syn_shared.settings import (
     DEFAULT_WORKSPACE_IMAGE,
+    INTERACTIVE_TMUX_WORKSPACE_IMAGE,
     CloudProvider,
     ContainerLoggingSettings,
     GitCredentialType,
@@ -257,6 +258,34 @@ class TestWorkspaceImages:
         with patch.dict(os.environ, env, clear=True):
             settings = WorkspaceSettings(_env_file=None)
             assert settings.docker_image == "my-registry/custom-image:v1"
+
+    def test_interactive_tmux_image_is_bare_local_tag(self) -> None:
+        """Interactive-tmux image is a bare local tag, not yet GHCR-qualified."""
+        assert not INTERACTIVE_TMUX_WORKSPACE_IMAGE.startswith("ghcr.io/")
+        assert INTERACTIVE_TMUX_WORKSPACE_IMAGE == "agentic-workspace-interactive-tmux:latest"
+
+    def test_interactive_tmux_image_ref_when_published(self) -> None:
+        """workspace_image_ref should build the GHCR-qualified form once published."""
+        from syn_shared.settings.workspace_images import (
+            WorkspaceImageProvider,
+            workspace_image_ref,
+        )
+
+        ref = workspace_image_ref(WorkspaceImageProvider.INTERACTIVE_TMUX)
+        assert ref == "ghcr.io/agentparadise/agentic-workspace-interactive-tmux:latest"
+
+    def test_interactive_tmux_image_matches_settings(self) -> None:
+        """WorkspaceSettings.interactive_tmux_image default should match the registry constant."""
+        with patch.dict(os.environ, {}, clear=True):
+            settings = WorkspaceSettings(_env_file=None)
+            assert settings.interactive_tmux_image == INTERACTIVE_TMUX_WORKSPACE_IMAGE
+
+    def test_interactive_tmux_image_overridable_via_env(self) -> None:
+        """interactive_tmux_image should be overridable via SYN_WORKSPACE_INTERACTIVE_TMUX_IMAGE."""
+        env = {"SYN_WORKSPACE_INTERACTIVE_TMUX_IMAGE": "my-registry/custom-tmux-image:v1"}
+        with patch.dict(os.environ, env, clear=True):
+            settings = WorkspaceSettings(_env_file=None)
+            assert settings.interactive_tmux_image == "my-registry/custom-tmux-image:v1"
 
 
 class TestSettingsWorkspaceIntegration:

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.1" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "python-json-logger", specifier = ">=2.0.7" },


### PR DESCRIPTION
## Summary

Closes all seven "Independent (can do now)" items from #771 (the interactive-tmux gap tracker). The "Blocked on agentic-primitives#225" items are untouched and stay open on #771.

- **Timeout guard (hung transport wedges execution):** the interactive drive is now bounded by `asyncio.wait_for(timeout_seconds + 30s margin)` around the existing cancel-race; on expiry the phase fails cleanly with an explicit transport-hang error_reason instead of staying RUNNING until process restart. A comment documents that the executor thread itself cannot be cancelled - the goal is unwedging the execution. The blocking drive round-trip was extracted to a module-level `_drive_round_trip` (keeps `_run_interactive_driver` under the cognitive-complexity gate; the now-stale #768 fitness exception is removed).
- **Real duration telemetry:** interactive session summaries record measured wall-clock `duration_ms` (monotonic around the driver round-trip) instead of hardcoded 0. Cost/tokens stay 0 - accounting is genuinely unavailable on this path until upstream capture lands.
- **Event loop no longer blocked on provision:** `InteractiveTmuxIsolationAdapter.create()/destroy()` offload the provider's blocking-in-async coroutine to a worker thread (`asyncio.to_thread`), so container startup (~45s worst case) no longer freezes syn-api's HTTP routes, pollers, and SSE.
- **Typed misconfiguration errors:** `WorkspaceProvisionError` moved to shared `workspace_backends/errors.py` (re-exported from the old location for compat) and used for flag-off / provider-unavailable; new domain-layer `WorkspaceMisconfiguredError` for the processor's unwired-service raise (syn-domain does not depend on syn-adapters, so the domain gets its own typed error). Both subclass RuntimeError so existing call sites keep working.
- **Explicit-only interactive detection:** the implicit `isolation_type == "interactive-tmux"` fallback (and its stale "YAML schema has no agent.provider field" comment) is gone; detection is the explicit `agent.provider` signal only, with a loud `WorkspaceMisconfiguredError` if phase and workspace backends disagree instead of a silent flip.
- **Streaming trap closed:** interactive workspaces get a `NoStreamEventStreamAdapter` that raises a clear streaming-unsupported error instead of the accidental `RuntimeError("Provider not set")` from the never-wired stream adapter.
- **ADR-056 image registry:** `interactive_tmux_image` default now comes from `workspace_images.py` (`WorkspaceImageProvider.INTERACTIVE_TMUX`); value unchanged (bare local tag, documented switch-over path for when the image is GHCR-published).
- **ADR-004 env drift:** `.env.example` regenerated via `just gen-env`; `SYN_WORKSPACE_INTERACTIVE_TMUX_ENABLED` and `SYN_WORKSPACE_INTERACTIVE_TMUX_IMAGE` now discoverable.

## Test plan

- [x] New tests: driver-hang fails within bounded window; successful round-trip records duration_ms > 0; create/destroy keep the event loop responsive (concurrent ticker); explicit-only detection + mismatch guard; typed errors asserted for flag-off / unavailable / unwired-service; NoStream adapter rejects stream(); image constant + settings default + env override
- [x] `APP_ENVIRONMENT=test uv run pytest packages/syn-adapters/tests/ packages/syn-domain/ packages/syn-shared/tests/` - green (1 pre-existing docker-image skip, 2 pre-existing #444 xfails)
- [x] `just fitness-check` - 0 failed, 0 stale exceptions (untyped-dict ratchet at 391/391)
- [x] `just codegen` - no drift
- [x] `uv run ruff check .` / `uv run ruff format --check .` - clean
- [x] Pre-push hook - all gates green

Refs #771