### PR TITLE
fix(dashboard): render codex transcripts + clear agent badge

### DIFF
--- a/apps/syn-api/src/syn_api/routes/conversations.py
+++ b/apps/syn-api/src/syn_api/routes/conversations.py
@@ -134,7 +134,7 @@ class TranscriptEventType(StrEnum):
     / ``system`` as its top-level ``type``; the codex path is normalized ONTO
     the same vocabulary so the dashboard's single color map styles both. These
     strings are mirrored by ``conversationEventColors`` in the frontend
-    (``sessionConstants.ts``) — keep them in sync.
+    (``sessionConstants.ts``) - keep them in sync.
     """
 
     ASSISTANT = "assistant"
@@ -268,7 +268,7 @@ def _extract_line_fields(
         return TranscriptEventType.LOG, None, _log_line_preview(raw)
 
     # Valid JSON but not an object (a bare scalar/array). Both the codex and
-    # claude extractors call ``.get()``, so guard here — otherwise one odd line
+    # claude extractors call ``.get()``, so guard here - otherwise one odd line
     # (``null``, ``[]``, ``"diagnostic"``) would raise and fail the WHOLE
     # transcript request with QUERY_FAILED.
     if not isinstance(data, dict):

--- a/apps/syn-api/src/syn_api/routes/conversations.py
+++ b/apps/syn-api/src/syn_api/routes/conversations.py
@@ -184,40 +184,47 @@ def _codex_file_change_preview(item: Mapping[str, object]) -> str | None:
     return joined[:_PREVIEW_LEN] if joined else None
 
 
-def _codex_command_execution_preview(
-    item: Mapping[str, object], stream_type: CodexStreamType
-) -> str | None:
-    """Preview for a codex ``command_execution`` item.
+def _codex_command_execution_preview(item: Mapping[str, object]) -> str | None:
+    """Preview for a completed codex ``command_execution`` item.
 
-    Codex emits both ``item.started`` and ``item.completed`` for the same
-    command. ``item.started`` carries the invocation (the ``command``);
-    ``item.completed`` carries the result (``aggregated_output``). Without
-    this split, both rows show the same command string, so the same tool
-    call renders twice in the transcript with no new information on the
-    second line. Falls back to the command when the output is empty (e.g.
-    a command that produced no stdout).
+    Prefers the result (``aggregated_output``); falls back to the invocation
+    (``command``) when the output is empty (e.g. a command that produced no
+    stdout), so the row is never blank.
     """
+    output = item.get("aggregated_output")
+    if isinstance(output, str) and output:
+        return output[:_PREVIEW_LEN]
     command = item.get("command")
-    command_preview = command[:_PREVIEW_LEN] if isinstance(command, str) and command else None
-    if stream_type == CodexStreamType.ITEM_COMPLETED:
-        output = item.get("aggregated_output")
-        if isinstance(output, str) and output:
-            return output[:_PREVIEW_LEN]
-    return command_preview
+    return command[:_PREVIEW_LEN] if isinstance(command, str) and command else None
+
+
+_CODEX_TOOL_ITEM_TYPES = frozenset((CodexItemType.COMMAND_EXECUTION, CodexItemType.FILE_CHANGE))
 
 
 def _codex_item_fields(
     item: Mapping[str, object], stream_type: CodexStreamType
 ) -> tuple[str, str | None, str | None]:
-    """Map a codex stream ``item`` to (event_type, tool_name, preview)."""
+    """Map a codex stream ``item`` to (event_type, tool_name, preview).
+
+    Codex emits both ``item.started`` and ``item.completed`` for the same
+    tool call. Only ``item.completed`` renders a tool row - ``item.started``
+    is normalized to a plain ``system`` line with no tool_name/preview, so
+    the raw line still appears (expandable) but never duplicates the
+    completed row, whether or not the completed side has output.
+    """
     item_type = item.get("type")
     if item_type == CodexItemType.AGENT_MESSAGE:
         text = item.get("text")
         preview = text[:_PREVIEW_LEN] if isinstance(text, str) and text else None
         return TranscriptEventType.ASSISTANT, None, preview
+    if item_type in _CODEX_TOOL_ITEM_TYPES and stream_type == CodexStreamType.ITEM_STARTED:
+        return TranscriptEventType.SYSTEM, None, None
     if item_type == CodexItemType.COMMAND_EXECUTION:
-        preview = _codex_command_execution_preview(item, stream_type)
-        return TranscriptEventType.TOOL_USE, CODEX_TOOL_NAME_COMMAND, preview
+        return (
+            TranscriptEventType.TOOL_USE,
+            CODEX_TOOL_NAME_COMMAND,
+            _codex_command_execution_preview(item),
+        )
     if item_type == CodexItemType.FILE_CHANGE:
         return (
             TranscriptEventType.TOOL_USE,

--- a/apps/syn-api/src/syn_api/routes/conversations.py
+++ b/apps/syn-api/src/syn_api/routes/conversations.py
@@ -7,10 +7,14 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 from syn_api._wiring import ensure_connected, get_conversation_store
 from syn_api.types import (
@@ -21,6 +25,12 @@ from syn_api.types import (
     ObservabilityError,
     Ok,
     Result,
+)
+from syn_shared.codex_stream import (
+    CODEX_TOOL_NAME_COMMAND,
+    CODEX_TOOL_NAME_FILE_CHANGE,
+    CodexItemType,
+    CodexStreamType,
 )
 
 logger = logging.getLogger(__name__)
@@ -117,23 +127,127 @@ def _extract_content_preview(data: dict[str, Any]) -> str:
     return _get_top_level_content(data) or _get_message_content(data) or _get_result_content(data)
 
 
+class TranscriptEventType(StrEnum):
+    """Normalized display event-type a transcript line renders as.
+
+    Claude's ``stream-json`` already emits ``assistant`` / ``user`` / ``result``
+    / ``system`` as its top-level ``type``; the codex path is normalized ONTO
+    the same vocabulary so the dashboard's single color map styles both. These
+    strings are mirrored by ``conversationEventColors`` in the frontend
+    (``sessionConstants.ts``) — keep them in sync.
+    """
+
+    ASSISTANT = "assistant"
+    TOOL_USE = "tool_use"
+    SYSTEM = "system"
+    RESULT = "result"
+    ERROR = "error"
+    LOG = "log"
+    """A non-JSON CLI diagnostic line (codex writes these to stdout)."""
+
+
+_PREVIEW_LEN = 200
+
+# Codex writes plain-text banners to stdout alongside its JSONL events. These
+# are pure CLI chrome (not conversation, not diagnostics) and are dropped from
+# the transcript entirely. Matched by prefix on non-JSON lines only.
+# Source: CodexStreamProcessor golden-fixture note (2026-07-23).
+_CODEX_CLI_NOISE_PREFIXES = (
+    "Reading additional input from stdin",
+    "warning: --full-auto is deprecated",
+)
+
+_CODEX_STREAM_TYPES = frozenset(t.value for t in CodexStreamType)
+
+
+def _is_codex_cli_noise(raw: str) -> bool:
+    """True for a codex plain-text banner line that should not appear at all."""
+    stripped = raw.strip()
+    if not stripped or stripped.startswith("{"):
+        return False
+    return any(stripped.startswith(prefix) for prefix in _CODEX_CLI_NOISE_PREFIXES)
+
+
+def _codex_file_change_preview(item: Mapping[str, object]) -> str | None:
+    """Join the changed paths in a codex ``file_change`` item into a preview."""
+    changes = item.get("changes")
+    if not isinstance(changes, list):
+        return None
+    paths = [str(c.get("path", "")) for c in changes if isinstance(c, dict) and c.get("path")]
+    joined = ", ".join(paths)
+    return joined[:_PREVIEW_LEN] if joined else None
+
+
+def _codex_item_fields(item: Mapping[str, object]) -> tuple[str, str | None, str | None]:
+    """Map a codex stream ``item`` to (event_type, tool_name, preview)."""
+    item_type = item.get("type")
+    if item_type == CodexItemType.AGENT_MESSAGE:
+        text = item.get("text")
+        preview = text[:_PREVIEW_LEN] if isinstance(text, str) and text else None
+        return TranscriptEventType.ASSISTANT, None, preview
+    if item_type == CodexItemType.COMMAND_EXECUTION:
+        command = item.get("command")
+        preview = command[:_PREVIEW_LEN] if isinstance(command, str) and command else None
+        return TranscriptEventType.TOOL_USE, CODEX_TOOL_NAME_COMMAND, preview
+    if item_type == CodexItemType.FILE_CHANGE:
+        return (
+            TranscriptEventType.TOOL_USE,
+            CODEX_TOOL_NAME_FILE_CHANGE,
+            _codex_file_change_preview(item),
+        )
+    return TranscriptEventType.SYSTEM, None, None
+
+
+def _extract_codex_fields(
+    data: Mapping[str, object],
+) -> tuple[str, str | None, str | None] | None:
+    """Normalize a codex stream event, or None if the line is not codex-shaped.
+
+    Codex's ``--json`` events use a closed set of top-level ``type`` values
+    (``item.completed`` etc.) unrelated to claude's ``stream-json`` types, so a
+    ``type`` in that set unambiguously identifies a codex line. Returning None
+    lets the caller fall back to claude parsing.
+    """
+    raw_type = data.get("type")
+    if raw_type not in _CODEX_STREAM_TYPES:
+        return None
+    if raw_type == CodexStreamType.TURN_COMPLETED:
+        return TranscriptEventType.RESULT, None, None
+    if raw_type == CodexStreamType.TURN_FAILED:
+        error = data.get("error")
+        preview = str(error)[:_PREVIEW_LEN] if error else None
+        return TranscriptEventType.ERROR, None, preview
+    item = data.get("item")
+    if not isinstance(item, dict):
+        return TranscriptEventType.SYSTEM, None, None
+    return _codex_item_fields(item)
+
+
 def _extract_line_fields(
     raw: str,
 ) -> tuple[str | None, str | None, str | None]:
     """Extract event_type, tool_name, and content preview from a JSONL line.
 
+    Handles both claude ``stream-json`` and codex ``--json`` line shapes.
     Returns (event_type, tool_name, preview) — all None-able.
     """
     try:
         data = json.loads(raw)
     except (json.JSONDecodeError, AttributeError):
-        preview = raw[:200] if raw else None
-        return None, None, preview
+        # Non-JSON line: a codex CLI diagnostic (e.g. an ERROR trace) on stdout.
+        # Label it ``log`` rather than leaving it to render as "unknown".
+        stripped = raw.strip() if raw else ""
+        preview = stripped[:_PREVIEW_LEN] if stripped else None
+        return TranscriptEventType.LOG, None, preview
+
+    codex = _extract_codex_fields(data)
+    if codex is not None:
+        return codex
 
     event_type = data.get("type") or data.get("event_type")
     tool_name = data.get("tool_name") or data.get("name")
     content = _extract_content_preview(data)
-    preview = content[:200] if content else None
+    preview = content[:_PREVIEW_LEN] if content else None
     return event_type, tool_name, preview
 
 
@@ -174,6 +288,10 @@ async def get_conversation_log(
                 ObservabilityError.NOT_FOUND,
                 message=f"Conversation log not found for session {session_id}",
             )
+
+        # Drop codex CLI banner noise before numbering so line numbers and
+        # total_lines reflect only real transcript content.
+        raw_lines = [line for line in raw_lines if not _is_codex_cli_noise(line)]
 
         total = len(raw_lines)
         page = raw_lines[offset : offset + limit]

--- a/apps/syn-api/src/syn_api/routes/conversations.py
+++ b/apps/syn-api/src/syn_api/routes/conversations.py
@@ -184,7 +184,31 @@ def _codex_file_change_preview(item: Mapping[str, object]) -> str | None:
     return joined[:_PREVIEW_LEN] if joined else None
 
 
-def _codex_item_fields(item: Mapping[str, object]) -> tuple[str, str | None, str | None]:
+def _codex_command_execution_preview(
+    item: Mapping[str, object], stream_type: CodexStreamType
+) -> str | None:
+    """Preview for a codex ``command_execution`` item.
+
+    Codex emits both ``item.started`` and ``item.completed`` for the same
+    command. ``item.started`` carries the invocation (the ``command``);
+    ``item.completed`` carries the result (``aggregated_output``). Without
+    this split, both rows show the same command string, so the same tool
+    call renders twice in the transcript with no new information on the
+    second line. Falls back to the command when the output is empty (e.g.
+    a command that produced no stdout).
+    """
+    command = item.get("command")
+    command_preview = command[:_PREVIEW_LEN] if isinstance(command, str) and command else None
+    if stream_type == CodexStreamType.ITEM_COMPLETED:
+        output = item.get("aggregated_output")
+        if isinstance(output, str) and output:
+            return output[:_PREVIEW_LEN]
+    return command_preview
+
+
+def _codex_item_fields(
+    item: Mapping[str, object], stream_type: CodexStreamType
+) -> tuple[str, str | None, str | None]:
     """Map a codex stream ``item`` to (event_type, tool_name, preview)."""
     item_type = item.get("type")
     if item_type == CodexItemType.AGENT_MESSAGE:
@@ -192,8 +216,7 @@ def _codex_item_fields(item: Mapping[str, object]) -> tuple[str, str | None, str
         preview = text[:_PREVIEW_LEN] if isinstance(text, str) and text else None
         return TranscriptEventType.ASSISTANT, None, preview
     if item_type == CodexItemType.COMMAND_EXECUTION:
-        command = item.get("command")
-        preview = command[:_PREVIEW_LEN] if isinstance(command, str) and command else None
+        preview = _codex_command_execution_preview(item, stream_type)
         return TranscriptEventType.TOOL_USE, CODEX_TOOL_NAME_COMMAND, preview
     if item_type == CodexItemType.FILE_CHANGE:
         return (
@@ -226,7 +249,7 @@ def _extract_codex_fields(
     item = data.get("item")
     if not isinstance(item, dict):
         return TranscriptEventType.SYSTEM, None, None
-    return _codex_item_fields(item)
+    return _codex_item_fields(item, CodexStreamType(raw_type))
 
 
 def _extract_line_fields(

--- a/apps/syn-api/src/syn_api/routes/conversations.py
+++ b/apps/syn-api/src/syn_api/routes/conversations.py
@@ -160,6 +160,12 @@ _CODEX_CLI_NOISE_PREFIXES = (
 _CODEX_STREAM_TYPES = frozenset(t.value for t in CodexStreamType)
 
 
+def _log_line_preview(raw: str) -> str | None:
+    """Preview for a non-object transcript line (CLI diagnostic or JSON scalar)."""
+    stripped = raw.strip() if raw else ""
+    return stripped[:_PREVIEW_LEN] if stripped else None
+
+
 def _is_codex_cli_noise(raw: str) -> bool:
     """True for a codex plain-text banner line that should not appear at all."""
     stripped = raw.strip()
@@ -236,9 +242,14 @@ def _extract_line_fields(
     except (json.JSONDecodeError, AttributeError):
         # Non-JSON line: a codex CLI diagnostic (e.g. an ERROR trace) on stdout.
         # Label it ``log`` rather than leaving it to render as "unknown".
-        stripped = raw.strip() if raw else ""
-        preview = stripped[:_PREVIEW_LEN] if stripped else None
-        return TranscriptEventType.LOG, None, preview
+        return TranscriptEventType.LOG, None, _log_line_preview(raw)
+
+    # Valid JSON but not an object (a bare scalar/array). Both the codex and
+    # claude extractors call ``.get()``, so guard here — otherwise one odd line
+    # (``null``, ``[]``, ``"diagnostic"``) would raise and fail the WHOLE
+    # transcript request with QUERY_FAILED.
+    if not isinstance(data, dict):
+        return TranscriptEventType.LOG, None, _log_line_preview(raw)
 
     codex = _extract_codex_fields(data)
     if codex is not None:

--- a/apps/syn-api/tests/test_api_conversations.py
+++ b/apps/syn-api/tests/test_api_conversations.py
@@ -215,6 +215,45 @@ async def test_codex_diagnostic_line_labelled_log_not_unknown(mock_conversation_
     assert line.content_preview is not None
 
 
+async def test_non_object_json_line_does_not_fail_whole_transcript(mock_conversation_store):
+    """A bare JSON scalar/array line is labelled ``log``, not crash the request."""
+    mock_conversation_store.retrieve_session.return_value = [
+        "null",
+        '["not", "an", "object"]',
+        '{"type": "assistant", "content": "still here"}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    lines = result.value.lines
+    assert lines[0].event_type == "log"
+    assert lines[1].event_type == "log"
+    assert lines[2].event_type == "assistant"
+    assert lines[2].content_preview == "still here"
+
+
+async def test_claude_jsonl_lines_survive_noise_filter(mock_conversation_store):
+    """Claude transcripts are pure JSONL, so the codex noise filter never drops them."""
+    mock_conversation_store.retrieve_session.return_value = [
+        # A claude assistant message whose text happens to mention a codex banner.
+        '{"type": "assistant", "content": "Reading additional input from stdin is a codex banner"}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("claude-1")
+
+    assert isinstance(result, Ok)
+    log = result.value
+    assert log.total_lines == 1
+    assert log.lines[0].event_type == "assistant"
+
+
 async def test_get_conversation_metadata(mock_conversation_store):
     """Retrieve conversation metadata from store."""
     mock_conversation_store.get_session_metadata.return_value = {

--- a/apps/syn-api/tests/test_api_conversations.py
+++ b/apps/syn-api/tests/test_api_conversations.py
@@ -162,8 +162,12 @@ async def test_codex_command_execution_maps_to_bash_tool(mock_conversation_store
     assert line.content_preview == "alpha"
 
 
-async def test_codex_command_execution_started_shows_invocation(mock_conversation_store):
-    """An ``item.started`` command_execution shows the command being invoked."""
+async def test_codex_command_execution_started_is_system_no_tool_row(mock_conversation_store):
+    """An ``item.started`` command_execution renders as a plain system line.
+
+    It must NOT produce a tool_use row - only ``item.completed`` does, so
+    the same tool call never renders twice regardless of output emptiness.
+    """
     mock_conversation_store.retrieve_session.return_value = [
         '{"type":"item.started","item":{"id":"item_2","type":"command_execution",'
         '"command":"cat one.txt","status":"in_progress"}}',
@@ -176,16 +180,36 @@ async def test_codex_command_execution_started_shows_invocation(mock_conversatio
 
     assert isinstance(result, Ok)
     line = result.value.lines[0]
-    assert line.event_type == "tool_use"
-    assert line.tool_name == "Bash"
-    assert line.content_preview == "cat one.txt"
+    assert line.event_type == "system"
+    assert line.tool_name is None
+    assert line.content_preview is None
 
 
-async def test_codex_command_execution_started_and_completed_differ(mock_conversation_store):
-    """The started/completed pair for the SAME command carry different content.
+async def test_codex_file_change_started_is_system_no_tool_row(mock_conversation_store):
+    """An ``item.started`` file_change renders as a plain system line, not a tool row."""
+    mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.started","item":{"id":"item_1","type":"file_change",'
+        '"status":"in_progress","changes":[{"path":"src/a.py","kind":"modify"}]}}',
+    ]
 
-    Regression guard: before the fix, both rows normalized to the command
-    string and rendered as byte-identical duplicates.
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    line = result.value.lines[0]
+    assert line.event_type == "system"
+    assert line.tool_name is None
+    assert line.content_preview is None
+
+
+async def test_codex_command_execution_started_and_completed_no_duplicate(mock_conversation_store):
+    """The started/completed pair for the SAME command renders exactly ONE tool row.
+
+    Regression guard: before this fix, both rows normalized to the same
+    (event_type, tool_name, preview) triple and rendered as byte-identical
+    duplicates in the transcript.
     """
     mock_conversation_store.retrieve_session.return_value = [
         '{"type":"item.started","item":{"id":"item_2","type":"command_execution",'
@@ -202,14 +226,23 @@ async def test_codex_command_execution_started_and_completed_differ(mock_convers
 
     assert isinstance(result, Ok)
     started, completed = result.value.lines
-    assert started.content_preview == "cat one.txt"
+    assert started.event_type == "system"
+    assert started.tool_name is None
+    assert completed.event_type == "tool_use"
+    assert completed.tool_name == "Bash"
     assert completed.content_preview == "alpha"
-    assert started.content_preview != completed.content_preview
 
 
 async def test_codex_command_execution_completed_falls_back_to_command(mock_conversation_store):
-    """An ``item.completed`` with empty aggregated_output falls back to the command."""
+    """An ``item.completed`` with empty aggregated_output falls back to the command.
+
+    This is the case that used to produce a duplicate row: started and
+    completed both showed the bare command with no distinguishing preview.
+    Now started is suppressed entirely, so there is exactly one row.
+    """
     mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.started","item":{"id":"item_2","type":"command_execution",'
+        '"command":"cat one.txt","status":"in_progress"}}',
         '{"type":"item.completed","item":{"id":"item_2","type":"command_execution",'
         '"command":"cat one.txt","aggregated_output":"","exit_code":0,'
         '"status":"completed"}}',
@@ -221,12 +254,16 @@ async def test_codex_command_execution_completed_falls_back_to_command(mock_conv
         result = await get_conversation_log("codex-1")
 
     assert isinstance(result, Ok)
-    line = result.value.lines[0]
-    assert line.content_preview == "cat one.txt"
+    started, completed = result.value.lines
+    assert started.event_type == "system"
+    assert started.tool_name is None
+    assert completed.event_type == "tool_use"
+    assert completed.tool_name == "Bash"
+    assert completed.content_preview == "cat one.txt"
 
 
 async def test_codex_file_change_maps_to_edit_tool(mock_conversation_store):
-    """A codex ``file_change`` item maps to the Edit tool with the changed paths."""
+    """A codex ``file_change`` item.completed maps to the Edit tool with the changed paths."""
     mock_conversation_store.retrieve_session.return_value = [
         '{"type":"item.completed","item":{"id":"item_3","type":"file_change",'
         '"status":"completed","changes":[{"path":"src/a.py","kind":"modify"},'
@@ -243,6 +280,74 @@ async def test_codex_file_change_maps_to_edit_tool(mock_conversation_store):
     assert line.event_type == "tool_use"
     assert line.tool_name == "Edit"
     assert line.content_preview == "src/a.py, src/b.py"
+
+
+async def test_codex_file_change_started_and_completed_no_duplicate(mock_conversation_store):
+    """The started/completed pair for the SAME file_change renders exactly ONE tool row.
+
+    Regression guard for the fixture case where ``changes`` is present on
+    BOTH started and completed with identical paths.
+    """
+    mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.started","item":{"id":"item_1","type":"file_change",'
+        '"status":"in_progress","changes":[{"path":"src/a.py","kind":"modify"}]}}',
+        '{"type":"item.completed","item":{"id":"item_1","type":"file_change",'
+        '"status":"completed","changes":[{"path":"src/a.py","kind":"modify"}]}}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    started, completed = result.value.lines
+    assert started.event_type == "system"
+    assert started.tool_name is None
+    assert completed.event_type == "tool_use"
+    assert completed.tool_name == "Edit"
+    assert completed.content_preview == "src/a.py"
+
+
+async def test_codex_real_fixture_has_no_duplicate_tool_rows(mock_conversation_store):
+    """Strong regression guard: run the real recorded codex fixture through the
+
+    full pipeline and assert no two rows share the same
+    (event_type, tool_name, content_preview) triple where tool_name is set.
+    This proves duplication is gone against real recorded data, not just
+    hand-crafted fixtures.
+    """
+    import pathlib
+
+    fixture_path = (
+        pathlib.Path(__file__).parents[3]
+        / "packages"
+        / "syn-domain"
+        / "tests"
+        / "fixtures"
+        / "codex"
+        / "codex_exec_recording.jsonl"
+    )
+    raw_lines = fixture_path.read_text().splitlines()
+    mock_conversation_store.retrieve_session.return_value = raw_lines
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    lines = result.value.lines
+    assert len(lines) > 0
+
+    tool_triples = [
+        (line.event_type, line.tool_name, line.content_preview)
+        for line in lines
+        if line.tool_name is not None
+    ]
+    assert len(tool_triples) == len(set(tool_triples)), (
+        f"Duplicate tool rows found in real fixture: {tool_triples}"
+    )
 
 
 async def test_codex_cli_stdin_banner_is_filtered(mock_conversation_store):

--- a/apps/syn-api/tests/test_api_conversations.py
+++ b/apps/syn-api/tests/test_api_conversations.py
@@ -120,6 +120,101 @@ async def test_get_conversation_log_parses_json(mock_conversation_store):
     assert lines[1].tool_name is None
 
 
+async def test_codex_agent_message_renders_as_talking(mock_conversation_store):
+    """A codex ``agent_message`` item surfaces its text as readable conversation."""
+    mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.completed","item":{"id":"item_0","type":"agent_message",'
+        '"text":"I will read the plan and implement it."}}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    line = result.value.lines[0]
+    assert line.event_type == "assistant"
+    assert line.tool_name is None
+    assert line.content_preview == "I will read the plan and implement it."
+
+
+async def test_codex_command_execution_maps_to_bash_tool(mock_conversation_store):
+    """A codex ``command_execution`` item maps to the Bash tool with its command."""
+    mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.completed","item":{"id":"item_2","type":"command_execution",'
+        '"command":"cat one.txt","aggregated_output":"alpha","exit_code":0,'
+        '"status":"completed"}}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    line = result.value.lines[0]
+    assert line.event_type == "tool_use"
+    assert line.tool_name == "Bash"
+    assert line.content_preview == "cat one.txt"
+
+
+async def test_codex_file_change_maps_to_edit_tool(mock_conversation_store):
+    """A codex ``file_change`` item maps to the Edit tool with the changed paths."""
+    mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.completed","item":{"id":"item_3","type":"file_change",'
+        '"status":"completed","changes":[{"path":"src/a.py","kind":"modify"},'
+        '{"path":"src/b.py","kind":"add"}]}}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    line = result.value.lines[0]
+    assert line.event_type == "tool_use"
+    assert line.tool_name == "Edit"
+    assert line.content_preview == "src/a.py, src/b.py"
+
+
+async def test_codex_cli_stdin_banner_is_filtered(mock_conversation_store):
+    """The codex ``Reading additional input from stdin`` banner is dropped entirely."""
+    mock_conversation_store.retrieve_session.return_value = [
+        "Reading additional input from stdin...",
+        '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"hello"}}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    log = result.value
+    assert log.total_lines == 1
+    assert len(log.lines) == 1
+    assert log.lines[0].content_preview == "hello"
+
+
+async def test_codex_diagnostic_line_labelled_log_not_unknown(mock_conversation_store):
+    """A non-JSON codex diagnostic line is labelled ``log``, never ``unknown``."""
+    mock_conversation_store.retrieve_session.return_value = [
+        "ERROR codex_models_manager::manager: transient upstream hiccup",
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    line = result.value.lines[0]
+    assert line.event_type == "log"
+    assert line.content_preview is not None
+
+
 async def test_get_conversation_metadata(mock_conversation_store):
     """Retrieve conversation metadata from store."""
     mock_conversation_store.get_session_metadata.return_value = {

--- a/apps/syn-api/tests/test_api_conversations.py
+++ b/apps/syn-api/tests/test_api_conversations.py
@@ -156,6 +156,72 @@ async def test_codex_command_execution_maps_to_bash_tool(mock_conversation_store
     line = result.value.lines[0]
     assert line.event_type == "tool_use"
     assert line.tool_name == "Bash"
+    # item.completed shows the result (aggregated_output), not the invocation -
+    # see test_codex_command_execution_started_shows_invocation for the
+    # started-side preview.
+    assert line.content_preview == "alpha"
+
+
+async def test_codex_command_execution_started_shows_invocation(mock_conversation_store):
+    """An ``item.started`` command_execution shows the command being invoked."""
+    mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.started","item":{"id":"item_2","type":"command_execution",'
+        '"command":"cat one.txt","status":"in_progress"}}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    line = result.value.lines[0]
+    assert line.event_type == "tool_use"
+    assert line.tool_name == "Bash"
+    assert line.content_preview == "cat one.txt"
+
+
+async def test_codex_command_execution_started_and_completed_differ(mock_conversation_store):
+    """The started/completed pair for the SAME command carry different content.
+
+    Regression guard: before the fix, both rows normalized to the command
+    string and rendered as byte-identical duplicates.
+    """
+    mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.started","item":{"id":"item_2","type":"command_execution",'
+        '"command":"cat one.txt","status":"in_progress"}}',
+        '{"type":"item.completed","item":{"id":"item_2","type":"command_execution",'
+        '"command":"cat one.txt","aggregated_output":"alpha","exit_code":0,'
+        '"status":"completed"}}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    started, completed = result.value.lines
+    assert started.content_preview == "cat one.txt"
+    assert completed.content_preview == "alpha"
+    assert started.content_preview != completed.content_preview
+
+
+async def test_codex_command_execution_completed_falls_back_to_command(mock_conversation_store):
+    """An ``item.completed`` with empty aggregated_output falls back to the command."""
+    mock_conversation_store.retrieve_session.return_value = [
+        '{"type":"item.completed","item":{"id":"item_2","type":"command_execution",'
+        '"command":"cat one.txt","aggregated_output":"","exit_code":0,'
+        '"status":"completed"}}',
+    ]
+
+    with _patch_store(mock_conversation_store):
+        from syn_api.routes.conversations import get_conversation_log
+
+        result = await get_conversation_log("codex-1")
+
+    assert isinstance(result, Ok)
+    line = result.value.lines[0]
     assert line.content_preview == "cat one.txt"
 
 

--- a/apps/syn-dashboard-ui/src/components/AgentBadge.tsx
+++ b/apps/syn-dashboard-ui/src/components/AgentBadge.tsx
@@ -1,0 +1,31 @@
+/**
+ * Compact badge naming the agent that ran a session/phase.
+ *
+ * Answers "which agent" (Claude vs Codex), distinct from the workspace image.
+ * Sourced from the domain `agent_provider` value. Shared by the session detail
+ * header, the sessions table, and the mobile session card. Label vocabulary
+ * lives in ./agentProvider.
+ */
+
+import { Bot } from 'lucide-react'
+
+import { agentProviderLabel } from './agentProvider'
+
+export function AgentBadge({
+  provider,
+  className = '',
+}: {
+  provider: string | null
+  className?: string
+}) {
+  const label = agentProviderLabel(provider)
+  if (!label) return null
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full bg-[var(--color-accent)]/15 px-2 py-0.5 text-xs font-medium text-[var(--color-accent)] ${className}`}
+    >
+      <Bot className="h-3 w-3" />
+      {label}
+    </span>
+  )
+}

--- a/apps/syn-dashboard-ui/src/components/agentProvider.ts
+++ b/apps/syn-dashboard-ui/src/components/agentProvider.ts
@@ -1,5 +1,5 @@
 /**
- * Agent-provider label vocabulary — the single source for "which agent" names.
+ * Agent-provider label vocabulary - the single source for "which agent" names.
  *
  * Keyed by the domain provider value (syn_shared/agents.py AgentProvider).
  * Kept separate from AgentBadge.tsx so the component file exports only a

--- a/apps/syn-dashboard-ui/src/components/agentProvider.ts
+++ b/apps/syn-dashboard-ui/src/components/agentProvider.ts
@@ -1,0 +1,19 @@
+/**
+ * Agent-provider label vocabulary — the single source for "which agent" names.
+ *
+ * Keyed by the domain provider value (syn_shared/agents.py AgentProvider).
+ * Kept separate from AgentBadge.tsx so the component file exports only a
+ * component (react-refresh/only-export-components).
+ */
+
+// Keep in sync with AgentProvider in packages/syn-shared/src/syn_shared/agents.py.
+export const AGENT_PROVIDER_LABELS: Record<string, string> = {
+  claude: 'Claude',
+  'claude-interactive': 'Claude (interactive)',
+  codex: 'Codex',
+}
+
+export function agentProviderLabel(provider: string | null): string | null {
+  if (!provider) return null
+  return AGENT_PROVIDER_LABELS[provider.toLowerCase()] ?? provider
+}

--- a/apps/syn-dashboard-ui/src/components/index.ts
+++ b/apps/syn-dashboard-ui/src/components/index.ts
@@ -1,3 +1,5 @@
+export { AgentBadge } from './AgentBadge'
+export { AGENT_PROVIDER_LABELS, agentProviderLabel } from './agentProvider'
 export { Breadcrumbs } from './Breadcrumbs'
 export { ChartTooltip } from './ChartTooltip'
 export { Card, CardContent, CardHeader } from './Card'

--- a/apps/syn-dashboard-ui/src/pages/SessionDetail/ConversationLogLine.tsx
+++ b/apps/syn-dashboard-ui/src/pages/SessionDetail/ConversationLogLine.tsx
@@ -75,7 +75,7 @@ export function ConversationLogLine({
         className="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-[var(--color-surface)]"
       >
         <span className="font-mono text-xs text-[var(--color-text-muted)] w-8">
-          {line.line_number + 1}
+          {line.line_number}
         </span>
         <span className={clsx('rounded px-2 py-0.5 text-xs font-medium', bgColor, textColor)}>
           {line.event_type || 'unknown'}

--- a/apps/syn-dashboard-ui/src/pages/SessionDetail/SessionHeader.tsx
+++ b/apps/syn-dashboard-ui/src/pages/SessionDetail/SessionHeader.tsx
@@ -1,17 +1,30 @@
-import { Activity, Container, FileText } from 'lucide-react'
+import { Activity, Bot, Container, FileText } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import { StatusBadge } from '../../components'
 import type { SessionResponse } from '../../types'
-import { PROVIDER_ENVIRONMENTS } from './sessionConstants'
+import { AGENT_PROVIDER_LABELS, PROVIDER_ENVIRONMENTS } from './sessionConstants'
+
+function AgentProviderBadge({ provider }: { provider: string | null }) {
+  if (!provider) return null
+  const label = AGENT_PROVIDER_LABELS[provider.toLowerCase()] ?? provider
+  return (
+    <span className="flex items-center gap-1.5 rounded-full bg-[var(--color-accent)]/15 px-2.5 py-0.5 font-medium text-[var(--color-accent)]">
+      <Bot className="h-3.5 w-3.5" />
+      Agent: {label}
+    </span>
+  )
+}
 
 function WorkspaceEnvironmentBadge({ provider }: { provider: string | null }) {
   if (!provider) return null
+  // Only render when there is a real image mapping; never show the bare
+  // provider string as if it were a container image.
   const env = PROVIDER_ENVIRONMENTS[provider.toLowerCase()]
-  const label = env ? `${env.backend}:${env.image}` : provider
+  if (!env) return null
   return (
     <span className="flex items-center gap-1.5">
       <Container className="h-3.5 w-3.5" />
-      <code className="font-mono">{label}</code>
+      <code className="font-mono">{`${env.backend}:${env.image}`}</code>
     </span>
   )
 }
@@ -50,7 +63,8 @@ export function SessionHeader({
               )}
               {session.phase_id && <span>Phase: {session.phase_id}</span>}
             </div>
-            <div className="mt-1 flex items-center gap-4 text-xs text-[var(--color-text-muted)]">
+            <div className="mt-1 flex items-center gap-3 text-xs text-[var(--color-text-muted)]">
+              <AgentProviderBadge provider={session.agent_provider} />
               <WorkspaceEnvironmentBadge provider={session.agent_provider} />
             </div>
           </div>

--- a/apps/syn-dashboard-ui/src/pages/SessionDetail/SessionHeader.tsx
+++ b/apps/syn-dashboard-ui/src/pages/SessionDetail/SessionHeader.tsx
@@ -1,8 +1,8 @@
 import { Activity, Bot, Container, FileText } from 'lucide-react'
 import { Link } from 'react-router-dom'
-import { StatusBadge } from '../../components'
+import { AGENT_PROVIDER_LABELS, StatusBadge } from '../../components'
 import type { SessionResponse } from '../../types'
-import { AGENT_PROVIDER_LABELS, PROVIDER_ENVIRONMENTS } from './sessionConstants'
+import { PROVIDER_ENVIRONMENTS } from './sessionConstants'
 
 function AgentProviderBadge({ provider }: { provider: string | null }) {
   if (!provider) return null

--- a/apps/syn-dashboard-ui/src/pages/SessionDetail/sessionConstants.ts
+++ b/apps/syn-dashboard-ui/src/pages/SessionDetail/sessionConstants.ts
@@ -94,11 +94,5 @@ export const PROVIDER_ENVIRONMENTS: Record<string, { backend: string; image: str
   claude: { backend: 'docker', image: 'agentic-workspace-claude-cli' },
 }
 
-// Human-readable name for the agent that ran a session/phase, keyed by the
-// domain provider value (syn_shared/agents.py AgentProvider). Distinct from the
-// workspace image: the badge answers "which agent", not "which container".
-export const AGENT_PROVIDER_LABELS: Record<string, string> = {
-  claude: 'Claude',
-  'claude-interactive': 'Claude (interactive)',
-  codex: 'Codex',
-}
+// Agent name labels (AGENT_PROVIDER_LABELS) live in the shared AgentBadge
+// component — the single source reused by the detail header and sessions list.

--- a/apps/syn-dashboard-ui/src/pages/SessionDetail/sessionConstants.ts
+++ b/apps/syn-dashboard-ui/src/pages/SessionDetail/sessionConstants.ts
@@ -87,12 +87,12 @@ export const conversationEventColors: Record<string, string> = {
   log: 'text-gray-500 bg-gray-500/10',
 }
 
-// Workspace container image per provider. Codex has no distinct image — it runs
-// the codex CLI inside the shared claude-cli workspace image — so it is
+// Workspace container image per provider. Codex has no distinct image - it runs
+// the codex CLI inside the shared claude-cli workspace image - so it is
 // deliberately absent here; the agent identity is carried by AGENT_PROVIDER_LABELS.
 export const PROVIDER_ENVIRONMENTS: Record<string, { backend: string; image: string }> = {
   claude: { backend: 'docker', image: 'agentic-workspace-claude-cli' },
 }
 
 // Agent name labels (AGENT_PROVIDER_LABELS) live in the shared AgentBadge
-// component — the single source reused by the detail header and sessions list.
+// component - the single source reused by the detail header and sessions list.

--- a/apps/syn-dashboard-ui/src/pages/SessionDetail/sessionConstants.ts
+++ b/apps/syn-dashboard-ui/src/pages/SessionDetail/sessionConstants.ts
@@ -75,13 +75,30 @@ export const operationColors: Record<string, string> = {
   validation: 'text-green-400 bg-green-500/10',
 }
 
+// Keep the keys in sync with TranscriptEventType in the API
+// (apps/syn-api/src/syn_api/routes/conversations.py).
 export const conversationEventColors: Record<string, string> = {
   system: 'text-gray-400 bg-gray-500/10',
   assistant: 'text-blue-400 bg-blue-500/10',
   user: 'text-green-400 bg-green-500/10',
   result: 'text-purple-400 bg-purple-500/10',
+  tool_use: 'text-amber-400 bg-amber-500/10',
+  error: 'text-red-400 bg-red-500/10',
+  log: 'text-gray-500 bg-gray-500/10',
 }
 
+// Workspace container image per provider. Codex has no distinct image — it runs
+// the codex CLI inside the shared claude-cli workspace image — so it is
+// deliberately absent here; the agent identity is carried by AGENT_PROVIDER_LABELS.
 export const PROVIDER_ENVIRONMENTS: Record<string, { backend: string; image: string }> = {
   claude: { backend: 'docker', image: 'agentic-workspace-claude-cli' },
+}
+
+// Human-readable name for the agent that ran a session/phase, keyed by the
+// domain provider value (syn_shared/agents.py AgentProvider). Distinct from the
+// workspace image: the badge answers "which agent", not "which container".
+export const AGENT_PROVIDER_LABELS: Record<string, string> = {
+  claude: 'Claude',
+  'claude-interactive': 'Claude (interactive)',
+  codex: 'Codex',
 }

--- a/apps/syn-dashboard-ui/src/pages/SessionList/SessionCard.tsx
+++ b/apps/syn-dashboard-ui/src/pages/SessionList/SessionCard.tsx
@@ -8,7 +8,7 @@
  * See: docs/adrs/ADR-064-observability-monitor-ui.md
  */
 
-import { StatusBadge } from '../../components'
+import { AgentBadge, StatusBadge } from '../../components'
 import type { SessionSummary } from '../../types'
 import { formatRelativeTime, formatTimestampLocale } from '../../utils/formatters'
 
@@ -33,6 +33,7 @@ export function SessionCard({ session }: { session: SessionSummary }) {
       <div className="flex min-w-0 flex-col gap-1">
         <div className="flex items-center gap-2">
           <StatusBadge status={session.status} size="sm" />
+          <AgentBadge provider={session.agent_provider} />
           <span
             className="truncate text-sm font-medium text-[var(--color-text-primary)]"
             title={workflowLabel}

--- a/apps/syn-dashboard-ui/src/pages/SessionList/sessionColumns.tsx
+++ b/apps/syn-dashboard-ui/src/pages/SessionList/sessionColumns.tsx
@@ -11,7 +11,7 @@
 import type { ColumnDef } from '../../components'
 import type { SortKey } from '../../hooks/useSortUrlState'
 import type { SessionSummary } from '../../types'
-import { StatusBadge } from '../../components'
+import { AgentBadge, StatusBadge } from '../../components'
 import { formatRelativeTime, formatTimestampLocale } from '../../utils/formatters'
 
 const EM_DASH = '—'
@@ -22,6 +22,14 @@ const STATUS: ColumnDef<SessionSummary, SortKey> = {
   align: 'left',
   sortKey: 'status',
   render: (s) => <StatusBadge status={s.status} size="sm" />,
+}
+
+const AGENT: ColumnDef<SessionSummary, SortKey> = {
+  key: 'agent',
+  label: 'Agent',
+  align: 'left',
+  cellTitle: (s) => s.agent_provider ?? undefined,
+  render: (s) => (s.agent_provider ? <AgentBadge provider={s.agent_provider} /> : EM_DASH),
 }
 
 const WORKFLOW: ColumnDef<SessionSummary, SortKey> = {
@@ -93,6 +101,7 @@ const STARTED: ColumnDef<SessionSummary, SortKey> = {
 export const SESSION_COLUMNS: ColumnDef<SessionSummary, SortKey>[] = [
   STATUS,
   WORKFLOW,
+  AGENT,
   PHASE,
   REPOS,
   TOKENS,

--- a/packages/syn-shared/src/syn_shared/codex_stream.py
+++ b/packages/syn-shared/src/syn_shared/codex_stream.py
@@ -1,0 +1,48 @@
+"""Shared, type-safe identifiers for the ``codex exec --json`` stream shape.
+
+The codex CLI emits a JSONL event stream whose top-level ``type`` is one of a
+small closed set (``thread.started`` / ``turn.started`` / ``item.started`` /
+``item.completed`` / ``turn.completed`` / ``turn.failed``), and whose ``item``
+payloads carry their own ``item.type`` (``agent_message`` / ``command_execution``
+/ ``file_change``).
+
+These StrEnums replace bare string literals so every reader of a codex stream
+(the live ``CodexStreamProcessor`` and the after-the-fact conversation-log
+renderer) compares against ONE source of truth. ``StrEnum`` members compare
+equal to their string value, so a raw ``data.get("type")`` (a plain ``str``)
+can still be compared against a member without changing the field type.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class CodexStreamType(StrEnum):
+    """A codex stream event's top-level ``type`` value."""
+
+    THREAD_STARTED = "thread.started"
+    TURN_STARTED = "turn.started"
+    ITEM_STARTED = "item.started"
+    ITEM_COMPLETED = "item.completed"
+    TURN_COMPLETED = "turn.completed"
+    TURN_FAILED = "turn.failed"
+
+
+class CodexItemType(StrEnum):
+    """A codex ``item`` payload's ``type`` value."""
+
+    AGENT_MESSAGE = "agent_message"
+    """Conversational text the model produced (the "talking")."""
+
+    COMMAND_EXECUTION = "command_execution"
+    """A shell command the model ran."""
+
+    FILE_CHANGE = "file_change"
+    """One or more file edits the model made."""
+
+
+# Tool-name labels a codex item maps onto in the observability timeline.
+# Mirrors CodexStreamProcessor so the transcript and the timeline agree.
+CODEX_TOOL_NAME_COMMAND = "Bash"
+CODEX_TOOL_NAME_FILE_CHANGE = "Edit"


### PR DESCRIPTION
## What & why

Testing the codex bridge live surfaced four transcript/UI regressions for **codex** sessions (claude sessions were fine). Root cause: the session-transcript renderer only understood claude `stream-json`, so codex `--json` events fell through unhandled.

### Fixes
1. **Codex "talking" now renders.** `_extract_line_fields` was claude-only, so a codex `agent_message` item never produced a `content_preview` — the transcript showed only tool uses, never the model's reasoning text. Normalized the codex shape (`agent_message` / `command_execution` / `file_change`) onto the same display vocabulary claude uses (`assistant` / `tool_use`), so conversation text, Bash commands, and file edits all render.
2. **CLI noise gone.** Drop codex stdout banners (`Reading additional input from stdin`, `--full-auto deprecated`) entirely, and label any other non-JSON diagnostic line `log` instead of the bare `unknown`.
3. **Line numbering.** Transcript started at line 2 — the frontend added `+1` to an already 1-based backend `line_number`. Removed the double-increment.
4. **Agent badge (#787).** Added a distinct `Agent: Claude/Codex` badge sourced from the phase provider. The workspace-environment badge no longer renders the bare provider string as if it were a container image (codex has no distinct image — it runs the codex CLI inside the shared claude-cli workspace image).

### Type-safety
Codex stream/item type literals move to a shared `StrEnum` (`syn_shared.codex_stream`) so the transcript reader and `CodexStreamProcessor` share one source of truth (no magic strings). New helpers use `Mapping[str, object]`, not `dict[str, Any]`.

## Out of scope (filed separately)
- **#788** codex phase mis-attributes model as `haiku` in Cost-by-Model — a distinct backend pricing/model-recording bug, kept out to keep this PR clean.

## Testing
- 5 new unit tests over the real codex golden-fixture event shapes (agent_message, command_execution, file_change, banner filtering, diagnostic labelling); 11/11 pass.
- pyright 0 errors, ruff clean, untyped-dict ratchet back to threshold, tsc + eslint clean, codegen no drift.

Closes #789
Refs #787, #790