### PR TITLE
fix(observability): codex phases priced as haiku (#788) + shared codex constants (#793)

### DIFF
--- a/apps/syn-api/src/syn_api/_wiring.py
+++ b/apps/syn-api/src/syn_api/_wiring.py
@@ -218,7 +218,20 @@ def _build_claude_command(
     prompt: str,
 ) -> list[str]:
     """Build the Claude CLI command for agent execution."""
+    # `AgentConfiguration.model` is `str | None` because a codex phase can
+    # leave it unset (see ExecuteWorkflowHandler._default_model_for_provider).
+    # A claude-provider phase always resolves a concrete model (the domain
+    # default "haiku" when the YAML omits `model:`), so `None` here would
+    # indicate a construction bug elsewhere, not a real "unset" case worth
+    # silently tolerating - fail loudly instead of forwarding `--model None`.
     model = phase.agent_config.model
+    if model is None:
+        msg = (
+            f"Claude phase '{phase.phase_id}' resolved to a None model - "
+            "AgentConfiguration.model should always default to a claude "
+            "alias for provider='claude'."
+        )
+        raise ValueError(msg)
     cmd = [
         "claude",
         "--model",

--- a/apps/syn-api/tests/test_wiring_command_builder.py
+++ b/apps/syn-api/tests/test_wiring_command_builder.py
@@ -62,6 +62,43 @@ def test_codex_command_omits_claude_alias_model() -> None:
     assert _build_codex_command("do the thing", "o3")[-3:] == ["--model", "o3", "do the thing"]
 
 
+def test_codex_command_via_domain_default_model_omits_model_flag() -> None:
+    """Regression (#788 follow-up, PR #795): a codex phase that omits
+    `model:` must resolve to a command with NO `--model` flag - codex runs
+    model-unforced (its own account default), not `--model codex` (which
+    an earlier fix synthesized and which is not a real codex model id).
+    """
+    from syn_domain.contexts.orchestration.domain.aggregate_workflow_template.value_objects import (
+        PhaseDefinition,
+    )
+    from syn_domain.contexts.orchestration.slices.execute_workflow.ExecuteWorkflowHandler import (
+        _build_agent_config_from_phase,
+    )
+    from syn_shared.agents import AgentProvider
+
+    phase_def = PhaseDefinition(
+        phase_id="p1",
+        name="p",
+        order=1,
+        prompt_template="x",
+        provider=AgentProvider.CODEX,
+    )
+    cfg = _build_agent_config_from_phase(phase_def)
+    assert cfg.model is None
+
+    cmd = _build_codex_command("do the thing", cfg.model)
+    assert cmd == [
+        "codex",
+        "exec",
+        "--json",
+        "--sandbox",
+        "danger-full-access",
+        "--skip-git-repo-check",
+        "do the thing",
+    ]
+    assert "--model" not in cmd
+
+
 def test_agent_command_dispatches_on_provider_string() -> None:
     assert _build_agent_command(_phase("codex"), "x")[0] == "codex"
     assert _build_agent_command(_phase("claude"), "x")[0] == "claude"

--- a/packages/syn-domain/src/syn_domain/contexts/agent_sessions/domain/read_models/session_cost.py
+++ b/packages/syn-domain/src/syn_domain/contexts/agent_sessions/domain/read_models/session_cost.py
@@ -106,6 +106,14 @@ class SessionCost:
     agent_model: str | None = None
     """Primary model used for this session (from CLI result event)."""
 
+    unpriced_observation_count: int = 0
+    """Count of TOKEN_USAGE observations whose model was unknown/missing.
+
+    These contribute zero cost to ``total_cost_usd`` (never priced as a
+    default/guessed model - see issue #788). A non-zero count means the
+    total is incomplete, not confidently wrong.
+    """
+
     # Status
     is_finalized: bool = False
     """Whether the session has completed."""
@@ -146,6 +154,7 @@ class SessionCost:
             cost_by_tool_tokens=_coerce_decimal_dict(data.get("cost_by_tool_tokens")),
             is_finalized=data.get("is_finalized", False),
             agent_model=data.get("agent_model"),
+            unpriced_observation_count=data.get("unpriced_observation_count", 0),
             started_at=_coerce_datetime(data.get("started_at")),
             completed_at=_coerce_datetime(data.get("completed_at")),
         )
@@ -175,6 +184,7 @@ class SessionCost:
             "cost_by_tool_tokens": {k: str(v) for k, v in self.cost_by_tool_tokens.items()},
             "is_finalized": self.is_finalized,
             "agent_model": self.agent_model,
+            "unpriced_observation_count": self.unpriced_observation_count,
             "started_at": self.started_at.isoformat() if self.started_at else None,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
         }

--- a/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/cost_calculator.py
+++ b/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/cost_calculator.py
@@ -6,11 +6,33 @@ for model pricing across the platform.
 
 from decimal import Decimal
 
-from syn_shared.pricing import get_model_pricing
+from syn_shared.pricing import ModelPricing, resolve_model_pricing
 
 
 class CostCalculator:
-    """Calculates token costs using model-specific pricing."""
+    """Calculates token costs using model-specific pricing.
+
+    Uses the STRICT resolver (``resolve_model_pricing``), never the
+    legacy-fallback ``get_model_pricing``. An unknown or missing model
+    MUST NOT be priced as any real model - a codex phase with no
+    ``model:`` was previously priced as Claude Haiku, then Claude Sonnet
+    after a partial fix, because callers fell back through
+    ``get_model_pricing(model or "")`` (issue #788). This calculator
+    contributes zero cost instead of guessing.
+    """
+
+    def resolve_pricing(self, model: str | None) -> ModelPricing | None:
+        """Resolve pricing for a model, or ``None`` if unknown/missing.
+
+        Args:
+            model: Model name, or ``None``/empty when the model is unknown.
+
+        Returns:
+            ``ModelPricing`` for a recognized model, ``None`` otherwise.
+        """
+        if not model:
+            return None
+        return resolve_model_pricing(model)
 
     def calculate_token_cost(
         self,
@@ -30,7 +52,10 @@ class CostCalculator:
             model: Model name for model-specific pricing
 
         Returns:
-            Total cost in USD
+            Total cost in USD. ``Decimal("0")`` when the model is unknown
+            or missing - never a guessed price from a default model.
         """
-        pricing = get_model_pricing(model or "")
+        pricing = self.resolve_pricing(model)
+        if pricing is None:
+            return Decimal("0")
         return pricing.calculate_cost(input_tokens, output_tokens, cache_creation, cache_read)

--- a/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/projection.py
@@ -180,20 +180,22 @@ class SessionCostProjection:
         session_cost.cache_creation_tokens += cache_creation
         session_cost.cache_read_tokens += cache_read
 
-        # Calculate cost using CostCalculator
-        token_cost = self._cost_calculator.calculate_token_cost(
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cache_creation=cache_creation,
-            cache_read=cache_read,
-            model=data.get("model"),
-        )
+        # Resolve pricing STRICTLY: an unknown/missing model contributes
+        # zero cost, never a guessed default model's price (issue #788).
+        model = data.get("model")
+        pricing = self._cost_calculator.resolve_pricing(model)
+        if pricing is None:
+            token_cost = Decimal("0")
+            session_cost.unpriced_observation_count += 1
+        else:
+            token_cost = pricing.calculate_cost(
+                input_tokens, output_tokens, cache_creation, cache_read
+            )
         session_cost.token_cost_usd += token_cost
         session_cost.total_cost_usd += token_cost
 
-        # Update cost by model
-        model = data.get("model")
-        if model:
+        # Update cost by model (only for observations we could actually price)
+        if model and pricing is not None:
             current = session_cost.cost_by_model.get(model, Decimal("0"))
             session_cost.cost_by_model[model] = current + token_cost
 

--- a/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/query_service.py
+++ b/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/query_service.py
@@ -146,8 +146,14 @@ class SessionCostQueryService:
         rows = await conn.fetch(_STARTED_AT_BY_SESSION_QUERY, SESSION_STARTED)  # type: ignore[union-attr]
         return {row["session_id"]: row["started_at"] for row in rows}  # type: ignore[index]
 
-    def _resolve_cost(self, row: object) -> Decimal:
-        """Resolve cost from sdk_cost field or calculate from token counts."""
+    def _resolve_cost(self, row: object, model: str | None) -> Decimal:
+        """Resolve cost from sdk_cost field or calculate from token counts.
+
+        ``model`` comes from the same row (``agent_model``, a single session's
+        model - a session is one agent/phase/sandbox, see #788) and is used
+        whenever the SDK-reported cost is absent and we must price from raw
+        token counts.
+        """
         sdk_cost = row["sdk_cost"]  # type: ignore[index]
         if sdk_cost is not None:
             return Decimal(str(sdk_cost))
@@ -156,6 +162,7 @@ class SessionCostQueryService:
             output_tokens=row["total_output"] or 0,  # type: ignore[index]
             cache_creation=row["cache_creation"] or 0,  # type: ignore[index]
             cache_read=row["cache_read"] or 0,  # type: ignore[index]
+            model=model,
         )
 
     def _build_from_summary(
@@ -166,7 +173,8 @@ class SessionCostQueryService:
     ) -> SessionCost:
         """Build a SessionCost from a session_summary row."""
         sid = row["session_id"]  # type: ignore[index]
-        cost = self._resolve_cost(row)
+        agent_model = row["agent_model"]  # type: ignore[index]
+        cost = self._resolve_cost(row, agent_model)
         sc = SessionCost(session_id=sid)
         sc.input_tokens = row["total_input"] or 0  # type: ignore[index]
         sc.output_tokens = row["total_output"] or 0  # type: ignore[index]
@@ -182,9 +190,9 @@ class SessionCostQueryService:
         sc.started_at = started_map.get(sid)  # type: ignore[arg-type]
         sc.completed_at = row["completed_at"]  # type: ignore[index]
         sc.is_finalized = True
-        if row["agent_model"]:  # type: ignore[index]
-            sc.agent_model = row["agent_model"]  # type: ignore[index]
-            sc.cost_by_model = {row["agent_model"]: cost}  # type: ignore[index]
+        if agent_model:
+            sc.agent_model = agent_model
+            sc.cost_by_model = {agent_model: cost}
         return sc
 
     def _build_from_token_usage(
@@ -199,11 +207,13 @@ class SessionCostQueryService:
         total_output = row["total_output"] or 0  # type: ignore[index]
         cache_creation = row["cache_creation"] or 0  # type: ignore[index]
         cache_read = row["cache_read"] or 0  # type: ignore[index]
+        agent_model = row["agent_model"]  # type: ignore[index]
         cost = self._cost_calculator.calculate_token_cost(
             input_tokens=total_input,
             output_tokens=total_output,
             cache_creation=cache_creation,
             cache_read=cache_read,
+            model=agent_model,
         )
         sc = SessionCost(session_id=sid)
         sc.input_tokens = total_input
@@ -216,7 +226,7 @@ class SessionCostQueryService:
         sc.execution_id = row["execution_id"]  # type: ignore[index]
         sc.phase_id = row["phase_id"]  # type: ignore[index]
         sc.started_at = started_map.get(sid) or row["started_at"]  # type: ignore[index,arg-type]
-        if row["agent_model"]:  # type: ignore[index]
-            sc.agent_model = row["agent_model"]  # type: ignore[index]
-            sc.cost_by_model = {row["agent_model"]: cost}  # type: ignore[index]
+        if agent_model:
+            sc.agent_model = agent_model
+            sc.cost_by_model = {agent_model: cost}
         return sc

--- a/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/test_cost_calculator.py
+++ b/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/test_cost_calculator.py
@@ -19,8 +19,9 @@ class TestCostCalculator:
         cost = calc.calculate_token_cost(
             input_tokens=1_000_000,
             output_tokens=1_000_000,
+            model="claude-sonnet-4-20250514",
         )
-        # Default (Sonnet 4): $3 input + $15 output = $18
+        # Sonnet 4: $3 input + $15 output = $18
         assert cost == Decimal("18.00")
 
     def test_cache_token_costs(self) -> None:
@@ -30,9 +31,25 @@ class TestCostCalculator:
             output_tokens=0,
             cache_creation=1_000_000,
             cache_read=1_000_000,
+            model="claude-sonnet-4-20250514",
         )
-        # Default (Sonnet 4): $3.75 cache write + $0.30 cache read = $4.05
+        # Sonnet 4: $3.75 cache write + $0.30 cache read = $4.05
         assert cost == Decimal("4.05")
+
+    def test_unknown_model_contributes_zero_cost(self) -> None:
+        """An unknown/missing model MUST NOT be priced as any real model (#788)."""
+        calc = CostCalculator()
+        cost = calc.calculate_token_cost(
+            input_tokens=1_000_000,
+            output_tokens=1_000_000,
+        )
+        assert cost == Decimal("0")
+
+    def test_missing_model_is_not_priced(self) -> None:
+        """model=None resolves to no pricing, never a guessed default."""
+        calc = CostCalculator()
+        assert calc.resolve_pricing(None) is None
+        assert calc.resolve_pricing("totally-unknown-model") is None
 
     def test_model_specific_pricing(self) -> None:
         calc = CostCalculator()
@@ -51,7 +68,9 @@ class TestCostCalculator:
 
     def test_small_token_counts(self) -> None:
         calc = CostCalculator()
-        cost = calc.calculate_token_cost(input_tokens=1000, output_tokens=500)
+        cost = calc.calculate_token_cost(
+            input_tokens=1000, output_tokens=500, model="claude-sonnet-4-20250514"
+        )
         expected = (Decimal("1000") / 1_000_000) * Decimal("3.00") + (
             Decimal("500") / 1_000_000
         ) * Decimal("15.00")

--- a/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/test_projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/test_projection.py
@@ -106,6 +106,7 @@ class TestAgentObservationHandling:
                 "output_tokens": 1_000_000,  # 1M tokens
                 "cache_creation_tokens": 0,
                 "cache_read_tokens": 0,
+                "model": "claude-sonnet-4-20250514",
             },
             "timestamp": datetime.now().isoformat(),
         }
@@ -252,6 +253,7 @@ class TestAgentObservationHandling:
                 "output_tokens": 0,
                 "cache_creation_tokens": 1_000_000,  # 1M tokens @ $3.75/MTok
                 "cache_read_tokens": 1_000_000,  # 1M tokens @ $0.30/MTok
+                "model": "claude-sonnet-4-20250514",
             },
         }
 
@@ -286,6 +288,78 @@ class TestAgentObservationHandling:
         assert session_cost is not None
         assert "claude-sonnet-4-20250514" in session_cost.cost_by_model
         assert session_cost.cost_by_model["claude-sonnet-4-20250514"] == Decimal("18.00")
+
+    @pytest.mark.asyncio
+    async def test_unknown_model_contributes_no_cost(
+        self, projection: SessionCostProjection
+    ) -> None:
+        """A TOKEN_USAGE observation with no model MUST NOT be priced as any
+
+        real model (issue #788). Cost stays zero and the projection records
+        that the total is incomplete rather than confidently wrong.
+        """
+        await projection.on_agent_observation(
+            {
+                "session_id": "session-1",
+                "event_type": ObservationType.TOKEN_USAGE.value,
+                "data": {
+                    "input_tokens": 1_000_000,
+                    "output_tokens": 1_000_000,
+                },
+            }
+        )
+
+        session_cost = await projection.get_session_cost("session-1")
+        assert session_cost is not None
+        assert session_cost.total_cost_usd == Decimal("0")
+        assert session_cost.token_cost_usd == Decimal("0")
+        assert session_cost.cost_by_model == {}
+        assert session_cost.unpriced_observation_count == 1
+
+    @pytest.mark.asyncio
+    async def test_unrecognized_model_contributes_no_cost(
+        self, projection: SessionCostProjection
+    ) -> None:
+        """An explicit but unrecognized model id is also never priced."""
+        await projection.on_agent_observation(
+            {
+                "session_id": "session-1",
+                "event_type": ObservationType.TOKEN_USAGE.value,
+                "data": {
+                    "input_tokens": 1_000_000,
+                    "output_tokens": 1_000_000,
+                    "model": "some-future-model-id",
+                },
+            }
+        )
+
+        session_cost = await projection.get_session_cost("session-1")
+        assert session_cost is not None
+        assert session_cost.total_cost_usd == Decimal("0")
+        assert session_cost.cost_by_model == {}
+        assert session_cost.unpriced_observation_count == 1
+
+    @pytest.mark.asyncio
+    async def test_codex_phase_not_priced_as_haiku_or_sonnet(
+        self, projection: SessionCostProjection
+    ) -> None:
+        """A codex phase (no model reported) is not haiku-priced or sonnet-priced."""
+        await projection.on_agent_observation(
+            {
+                "session_id": "codex-session-1",
+                "event_type": ObservationType.TOKEN_USAGE.value,
+                "data": {
+                    "input_tokens": 1_000_000,
+                    "output_tokens": 1_000_000,
+                },
+            }
+        )
+
+        session_cost = await projection.get_session_cost("codex-session-1")
+        assert session_cost is not None
+        # Haiku would be $1 + $5 = $6.00; Sonnet would be $3 + $15 = $18.00.
+        assert session_cost.total_cost_usd not in (Decimal("6.00"), Decimal("18.00"))
+        assert session_cost.total_cost_usd == Decimal("0")
 
     @pytest.mark.asyncio
     async def test_skip_observation_without_session_id(

--- a/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/test_query_service.py
+++ b/packages/syn-domain/src/syn_domain/contexts/agent_sessions/slices/session_cost/test_query_service.py
@@ -1,0 +1,113 @@
+"""Regression tests: SessionCostQueryService prices non-Sonnet models correctly.
+
+Issue #788 found that ``_resolve_cost``/``_build_from_summary``/
+``_build_from_token_usage`` never passed ``agent_model`` (already selected in
+the row as ``agent_model``) into ``calculate_token_cost``, so every session
+priced from raw token counts (no SDK-reported ``total_cost_usd``) fell
+through to the Sonnet default. These tests pin an Opus session pricing as
+Opus - not Sonnet, not $0 - and confirm a genuinely unknown model still
+contributes $0 without guessing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+
+import pytest
+
+from syn_domain.contexts.agent_sessions.slices.session_cost.query_service import (
+    SessionCostQueryService,
+)
+
+_FakeRow = Mapping[str, object]
+
+_OPUS_MODEL = "claude-opus-4-20250514"
+_SONNET_MODEL = "claude-sonnet-4-20250514"
+
+# 1M input + 1M output tokens at Opus rates: $15.00 + $75.00 = $90.00
+_OPUS_COST_1M_1M = Decimal("90.00")
+# The same token counts at Sonnet rates would be $3.00 + $15.00 = $18.00 -
+# this is the wrong answer the pre-fix code silently produced.
+_SONNET_COST_1M_1M = Decimal("18.00")
+
+
+def _summary_row(agent_model: str | None) -> _FakeRow:
+    return {
+        "session_id": "session-1",
+        "total_input": 1_000_000,
+        "total_output": 1_000_000,
+        "cache_creation": 0,
+        "cache_read": 0,
+        "sdk_cost": None,  # no SDK-reported cost - must price from tokens
+        "duration_ms_val": 0,
+        "agent_model": agent_model,
+        "num_turns": 1,
+        "tool_count": 0,
+        "completed_at": None,
+        "execution_id": "exec-1",
+        "phase_id": "phase-1",
+    }
+
+
+def _token_usage_row(agent_model: str | None) -> _FakeRow:
+    return {
+        "session_id": "session-2",
+        "total_input": 1_000_000,
+        "total_output": 1_000_000,
+        "cache_creation": 0,
+        "cache_read": 0,
+        "started_at": None,
+        "last_observation": None,
+        "agent_model": agent_model,
+        "execution_id": "exec-2",
+        "phase_id": "phase-2",
+    }
+
+
+@pytest.mark.unit
+class TestBuildFromSummaryPricesByModel:
+    def test_opus_session_prices_as_opus_not_sonnet(self) -> None:
+        service = SessionCostQueryService(pool=None)  # type: ignore[arg-type]
+
+        result = service._build_from_summary(
+            _summary_row(_OPUS_MODEL), tool_counts={}, started_map={}
+        )
+
+        assert result.total_cost_usd == _OPUS_COST_1M_1M
+        assert result.total_cost_usd != _SONNET_COST_1M_1M
+        assert result.cost_by_model == {_OPUS_MODEL: _OPUS_COST_1M_1M}
+        assert result.agent_model == _OPUS_MODEL
+
+    def test_unknown_model_contributes_zero_not_a_guess(self) -> None:
+        service = SessionCostQueryService(pool=None)  # type: ignore[arg-type]
+
+        result = service._build_from_summary(_summary_row(None), tool_counts={}, started_map={})
+
+        assert result.total_cost_usd == Decimal("0")
+        assert result.cost_by_model == {}
+        assert result.agent_model is None
+
+
+@pytest.mark.unit
+class TestBuildFromTokenUsagePricesByModel:
+    def test_opus_session_prices_as_opus_not_sonnet(self) -> None:
+        service = SessionCostQueryService(pool=None)  # type: ignore[arg-type]
+
+        result = service._build_from_token_usage(
+            _token_usage_row(_OPUS_MODEL), tool_counts={}, started_map={}
+        )
+
+        assert result.total_cost_usd == _OPUS_COST_1M_1M
+        assert result.total_cost_usd != _SONNET_COST_1M_1M
+        assert result.cost_by_model == {_OPUS_MODEL: _OPUS_COST_1M_1M}
+
+    def test_unknown_model_contributes_zero_not_a_guess(self) -> None:
+        service = SessionCostQueryService(pool=None)  # type: ignore[arg-type]
+
+        result = service._build_from_token_usage(
+            _token_usage_row(None), tool_counts={}, started_map={}
+        )
+
+        assert result.total_cost_usd == Decimal("0")
+        assert result.cost_by_model == {}

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/_shared/ExecutionValueObjects.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/_shared/ExecutionValueObjects.py
@@ -54,7 +54,11 @@ class AgentConfiguration:
 
     provider: str = AgentProvider.CLAUDE  # + claude-interactive, codex, openai (mock in tests)
     # NOTE: Temporarily using Haiku to reduce costs during testing
-    model: str = "haiku"  # CLI alias - auto-resolves to latest version
+    # None means "no model chosen" - the honest state for a codex phase that
+    # omits `model:` (codex does not report its own model on the wire, so we
+    # must not synthesize a value; see _default_model_for_provider in
+    # ExecuteWorkflowHandler.py, issue #788). Never a sentinel string.
+    model: str | None = "haiku"  # CLI alias - auto-resolves to latest version
     max_tokens: int = 4096
     temperature: float = 0.7
     timeout_seconds: int = 300

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_execution/value_objects.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/aggregate_execution/value_objects.py
@@ -75,7 +75,11 @@ class AgentConfiguration:
 
     provider: str = AgentProvider.CLAUDE  # + claude-interactive, codex, openai (mock in tests)
     # NOTE: Temporarily using Haiku to reduce costs during testing
-    model: str = "haiku"  # CLI alias - auto-resolves to latest version
+    # None means "no model chosen" - the honest state for a codex phase that
+    # omits `model:` (codex does not report its own model on the wire, so we
+    # must not synthesize a value; see _default_model_for_provider in
+    # ExecuteWorkflowHandler.py, issue #788). Never a sentinel string.
+    model: str | None = "haiku"  # CLI alias - auto-resolves to latest version
     max_tokens: int = 4096
     temperature: float = 0.7
     timeout_seconds: int = 300

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/read_models/execution_cost.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/domain/read_models/execution_cost.py
@@ -95,6 +95,14 @@ class ExecutionCost:
     cost_by_tool: dict[str, Decimal] = field(default_factory=dict)
     """Cost breakdown by tool."""
 
+    unpriced_observation_count: int = 0
+    """Count of TOKEN_USAGE observations whose model was unknown/missing.
+
+    These contribute zero cost to ``total_cost_usd`` (never priced as a
+    default/guessed model - see issue #788). A non-zero count means the
+    total is incomplete, not confidently wrong.
+    """
+
     # Status
     is_complete: bool = False
     """Whether all sessions have completed."""
@@ -131,6 +139,7 @@ class ExecutionCost:
             cost_by_phase=_coerce_decimal_dict(data.get("cost_by_phase")),
             cost_by_model=_coerce_decimal_dict(data.get("cost_by_model")),
             cost_by_tool=_coerce_decimal_dict(data.get("cost_by_tool")),
+            unpriced_observation_count=data.get("unpriced_observation_count", 0),
             is_complete=data.get("is_complete", False),
             started_at=_coerce_datetime(data.get("started_at")),
             completed_at=_coerce_datetime(data.get("completed_at")),
@@ -157,6 +166,7 @@ class ExecutionCost:
             "cost_by_phase": {k: str(v) for k, v in self.cost_by_phase.items()},
             "cost_by_model": {k: str(v) for k, v in self.cost_by_model.items()},
             "cost_by_tool": {k: str(v) for k, v in self.cost_by_tool.items()},
+            "unpriced_observation_count": self.unpriced_observation_count,
             "is_complete": self.is_complete,
             "started_at": self.started_at.isoformat() if self.started_at else None,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/CodexStreamProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/CodexStreamProcessor.py
@@ -238,7 +238,7 @@ class CodexStreamProcessor:
         execution_id: str,
         phase_id: str,
         session_id: str,
-        agent_model: str,
+        agent_model: str | None,
     ) -> None:
         self._tokens = tokens
         self._collector = collector
@@ -323,7 +323,16 @@ class CodexStreamProcessor:
         )
 
     def _estimate_cost(self) -> float | None:
-        """Estimate total cost via the STRICT resolver (never Sonnet default)."""
+        """Estimate total cost via the STRICT resolver (never Sonnet default).
+
+        ``self._agent_model`` is ``None`` when the phase omitted `model:`
+        (codex does not report its own model on the wire, so there is no
+        authoritative id to resolve). Returning ``None`` here - rather than
+        guessing a model to price against - leaves cost unpriced instead of
+        confidently wrong (issue #788 follow-up).
+        """
+        if self._agent_model is None:
+            return None
         pricing = resolve_model_pricing(self._agent_model)
         if pricing is None:
             return None

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/CodexStreamProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/CodexStreamProcessor.py
@@ -54,6 +54,12 @@ from syn_domain.contexts.orchestration.slices.execute_workflow.EventStreamProces
     InterruptibleWorkspace,
     StreamResult,
 )
+from syn_shared.codex_stream import (
+    CODEX_TOOL_NAME_COMMAND,
+    CODEX_TOOL_NAME_FILE_CHANGE,
+    CodexItemType,
+    CodexStreamType,
+)
 from syn_shared.pricing import resolve_model_pricing
 
 if TYPE_CHECKING:
@@ -67,9 +73,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _MAX_PREVIEW_LEN = 500
-
-_TOOL_NAME_COMMAND = "Bash"
-_TOOL_NAME_FILE_CHANGE = "Edit"
 
 
 def _as_int(value: object) -> int:
@@ -367,11 +370,11 @@ class CodexStreamProcessor:
             return
 
         event_type = event.get("type", "")
-        if event_type == "item.started":
+        if event_type == CodexStreamType.ITEM_STARTED:
             await self._handle_item_started(event)
-        elif event_type == "item.completed":
+        elif event_type == CodexStreamType.ITEM_COMPLETED:
             await self._handle_item_completed(event)
-        elif event_type == "turn.completed":
+        elif event_type == CodexStreamType.TURN_COMPLETED:
             await self._handle_turn_completed(event)
         # "thread.started" / "turn.started": no observability call needed.
 
@@ -383,13 +386,13 @@ class CodexStreamProcessor:
         started+completed pair there instead (see ``_handle_item_completed``).
         """
         item = event.get("item")
-        if not isinstance(item, dict) or item.get("type") != "command_execution":
+        if not isinstance(item, dict) or item.get("type") != CodexItemType.COMMAND_EXECUTION:
             return
 
         tool_use_id = str(item.get("id", "unknown"))
         command = str(item.get("command", ""))
         await self._collector.record_tool_started(
-            tool_name=_TOOL_NAME_COMMAND,
+            tool_name=CODEX_TOOL_NAME_COMMAND,
             tool_use_id=tool_use_id,
             input_preview=command[:_MAX_PREVIEW_LEN],
         )
@@ -401,9 +404,9 @@ class CodexStreamProcessor:
             return
 
         item_type = item.get("type")
-        if item_type == "command_execution":
+        if item_type == CodexItemType.COMMAND_EXECUTION:
             await self._handle_command_execution_completed(item)
-        elif item_type == "file_change":
+        elif item_type == CodexItemType.FILE_CHANGE:
             await self._handle_file_change_completed(item)
         # "agent_message" items are conversational text, not a tool op.
 
@@ -425,7 +428,7 @@ class CodexStreamProcessor:
                 exit_code,
             )
         await self._collector.record_tool_completed(
-            tool_name=_TOOL_NAME_COMMAND,
+            tool_name=CODEX_TOOL_NAME_COMMAND,
             tool_use_id=tool_use_id,
             success=success,
             output_preview=output[:_MAX_PREVIEW_LEN] if output else None,
@@ -443,12 +446,12 @@ class CodexStreamProcessor:
         success = item.get("status") != "failed"
 
         await self._collector.record_tool_started(
-            tool_name=_TOOL_NAME_FILE_CHANGE,
+            tool_name=CODEX_TOOL_NAME_FILE_CHANGE,
             tool_use_id=tool_use_id,
             input_preview=preview,
         )
         await self._collector.record_tool_completed(
-            tool_name=_TOOL_NAME_FILE_CHANGE,
+            tool_name=CODEX_TOOL_NAME_FILE_CHANGE,
             tool_use_id=tool_use_id,
             success=success,
             output_preview=preview or None,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ConversationRecorder.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ConversationRecorder.py
@@ -29,7 +29,7 @@ class ConversationRecorder:
         execution_id: str,
         phase_id: str,
         workflow_id: str,
-        model: str,
+        model: str | None,
         input_tokens: int,
         output_tokens: int,
         started_at: datetime,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/EventStreamProcessor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/EventStreamProcessor.py
@@ -200,7 +200,7 @@ class EventStreamProcessor:
         phase_id: str,
         session_id: str,
         workspace_id: str | None,
-        agent_model: str,
+        agent_model: str | None,
         collector: ObservabilityCollector | None = None,
     ) -> None:
         self._tokens = tokens

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
@@ -160,7 +160,7 @@ def _resolve_repos_from_template(
     return []
 
 
-def _default_model_for_provider(provider: str, claude_default_model: str) -> str:
+def _default_model_for_provider(provider: str, claude_default_model: str | None) -> str | None:
     """Pick the model to attribute cost/pricing to when a phase omits one.
 
     ``AgentConfiguration.model`` defaults to a claude alias (``"haiku"``),
@@ -174,12 +174,25 @@ def _default_model_for_provider(provider: str, claude_default_model: str) -> str
     through to the claude default silently priced every unspecified-model
     codex phase with CLAUDE HAIKU rates (issue #788).
 
-    ``AgentProvider.CODEX`` doubles as a ``MODEL_ALIASES`` key
-    (``"codex" -> "gpt-5.6"``), so using it here routes an unspecified-model
-    codex phase to codex pricing instead of a wrong claude number.
+    An earlier fix synthesized ``AgentProvider.CODEX.value`` (``"codex"``)
+    here so the phase would resolve to codex pricing instead of a claude
+    number. That over-corrected: ``"codex"`` then passed as a genuine model
+    id everywhere downstream too -  ``codex exec --model codex`` (a
+    nonexistent model, since ``_is_codex_model`` in ``_wiring.py`` can't
+    tell "unspecified" from "user chose the literal string codex") and
+    ``resolve_model_pricing("codex")`` confidently returned GPT-5.6 pricing
+    for a model we never actually ran. Both are worse than the original bug:
+    a wrong model argument can break the run, and a confidently-wrong price
+    is invisible in a dashboard (an absent price is at least visibly
+    missing).
+
+    So: codex phases with no explicit ``model`` get ``None`` here, not a
+    synthesized string. ``None`` means "run codex model-unforced (its own
+    account default) and leave cost unpriced until the real model is known"
+    - honest absence beats a guessed value in either direction.
     """
     if provider == AgentProvider.CODEX:
-        return AgentProvider.CODEX.value
+        return None
     return claude_default_model
 
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ExecuteWorkflowHandler.py
@@ -22,6 +22,7 @@ from syn_domain.contexts.orchestration.slices.execute_workflow.errors import (
     DuplicateExecutionError,
     WorkflowNotFoundError,
 )
+from syn_shared.agents import AgentProvider
 
 if TYPE_CHECKING:
     from syn_domain.contexts.orchestration._shared.claude_plugin_ref import (
@@ -159,6 +160,29 @@ def _resolve_repos_from_template(
     return []
 
 
+def _default_model_for_provider(provider: str, claude_default_model: str) -> str:
+    """Pick the model to attribute cost/pricing to when a phase omits one.
+
+    ``AgentConfiguration.model`` defaults to a claude alias (``"haiku"``),
+    which is correct when the phase's provider is claude. But codex phases
+    routinely omit ``model`` on purpose (see ``workflows/examples/codex-demo.yaml``):
+    the codex CLI rejects claude-shaped model ids when authenticated via a
+    ChatGPT account, and codex does not report its own model in the
+    ``--json`` stream (verified against
+    ``packages/syn-domain/tests/fixtures/codex/codex_exec_recording.jsonl`` -
+    no ``model`` field on ``thread.started`` or ``turn.completed``). Falling
+    through to the claude default silently priced every unspecified-model
+    codex phase with CLAUDE HAIKU rates (issue #788).
+
+    ``AgentProvider.CODEX`` doubles as a ``MODEL_ALIASES`` key
+    (``"codex" -> "gpt-5.6"``), so using it here routes an unspecified-model
+    codex phase to codex pricing instead of a wrong claude number.
+    """
+    if provider == AgentProvider.CODEX:
+        return AgentProvider.CODEX.value
+    return claude_default_model
+
+
 def _build_agent_config_from_phase(phase: object) -> AgentConfiguration:
     """Build an AgentConfiguration from a workflow-template phase.
 
@@ -174,9 +198,10 @@ def _build_agent_config_from_phase(phase: object) -> AgentConfiguration:
     if not (phase_model or phase_provider or phase_agent_id or allow_delegation):
         return AgentConfiguration()
     defaults = AgentConfiguration()
+    resolved_provider = phase_provider or defaults.provider
     return AgentConfiguration(
-        provider=phase_provider or defaults.provider,
-        model=phase_model or defaults.model,
+        provider=resolved_provider,
+        model=phase_model or _default_model_for_provider(resolved_provider, defaults.model),
         agent_id=phase_agent_id or defaults.agent_id,
         allow_delegation=allow_delegation,
     )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ObservabilityCollector.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/ObservabilityCollector.py
@@ -70,7 +70,7 @@ class ObservabilityCollector:
         execution_id: str,
         phase_id: str,
         workspace_id: str | None,
-        agent_model: str,
+        agent_model: str | None,
     ) -> None:
         self._writer = writer
         self._session_id = session_id

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/SessionLifecycleManager.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/SessionLifecycleManager.py
@@ -42,7 +42,7 @@ class SessionLifecycleManager:
         execution_id: str,
         phase_id: str,
         agent_provider: str,
-        agent_model: str,
+        agent_model: str | None,
         repos: list[str] | None = None,
     ) -> None:
         self._repo = repository

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/AgentExecutionHandler.py
@@ -167,7 +167,7 @@ class AgentExecutionHandler:
         agent_env: dict[str, str],
         claude_cmd: list[str],
         session_id: str,
-        agent_model: str,
+        agent_model: str | None,
         timeout_seconds: int,
         collector: ObservabilityCollector | None = None,
         interactive_prompt: str | None = None,
@@ -232,7 +232,7 @@ class AgentExecutionHandler:
         todo: TodoItem,
         workspace: ManagedWorkspace,
         session_id: str,
-        agent_model: str,
+        agent_model: str | None,
         collector: ObservabilityCollector | None,
     ) -> EventStreamProcessor | CodexStreamProcessor:
         """Pick the codex or claude stream processor for a headless phase."""
@@ -270,7 +270,7 @@ class AgentExecutionHandler:
         agent_env: dict[str, str],
         claude_cmd: list[str],
         session_id: str,
-        agent_model: str,
+        agent_model: str | None,
         timeout_seconds: int,
         collector: ObservabilityCollector | None,
         tokens: TokenAccumulator,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_delegation.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_delegation.py
@@ -76,6 +76,54 @@ def test_agent_config_carries_allow_delegation() -> None:
     assert cfg.allow_delegation is True
 
 
+# === Issue #788: codex phases must not inherit the claude default model ===
+
+
+def test_codex_phase_without_explicit_model_does_not_default_to_haiku() -> None:
+    """A codex phase that omits `model:` (the common/recommended case, see
+    workflows/examples/codex-demo.yaml) must not silently resolve to the
+    claude "haiku" default - that mispriced every codex phase with claude
+    haiku rates (#788).
+    """
+    phase = PhaseDefinition(
+        phase_id="p1",
+        name="p",
+        order=1,
+        prompt_template="x",
+        provider=AgentProvider.CODEX,
+    )
+    cfg = _build_agent_config_from_phase(phase)
+    assert cfg.model != "haiku"
+    assert cfg.model == AgentProvider.CODEX.value
+
+
+def test_claude_phase_without_explicit_model_still_defaults_to_haiku() -> None:
+    """The claude default model is unchanged for claude-provider phases."""
+    phase = PhaseDefinition(
+        phase_id="p1",
+        name="p",
+        order=1,
+        prompt_template="x",
+        provider=AgentProvider.CLAUDE,
+    )
+    cfg = _build_agent_config_from_phase(phase)
+    assert cfg.model == "haiku"
+
+
+def test_codex_phase_explicit_model_override_is_preserved() -> None:
+    """An explicit `model:` on a codex phase still wins over the default."""
+    phase = PhaseDefinition(
+        phase_id="p1",
+        name="p",
+        order=1,
+        prompt_template="x",
+        provider=AgentProvider.CODEX,
+        model="gpt-5.6",
+    )
+    cfg = _build_agent_config_from_phase(phase)
+    assert cfg.model == "gpt-5.6"
+
+
 # === B3: auth staging ===
 
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_delegation.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/handlers/test_delegation.py
@@ -84,6 +84,12 @@ def test_codex_phase_without_explicit_model_does_not_default_to_haiku() -> None:
     workflows/examples/codex-demo.yaml) must not silently resolve to the
     claude "haiku" default - that mispriced every codex phase with claude
     haiku rates (#788).
+
+    It also must not resolve to a synthesized "codex" model string (the
+    original #788 fix's over-correction): that string then flowed into
+    `codex exec --model codex` (a nonexistent model) and got confidently
+    priced as GPT-5.6 via a pricing alias, despite the real model being
+    unknown. The honest state is `None` - unforced model, unpriced cost.
     """
     phase = PhaseDefinition(
         phase_id="p1",
@@ -94,7 +100,7 @@ def test_codex_phase_without_explicit_model_does_not_default_to_haiku() -> None:
     )
     cfg = _build_agent_config_from_phase(phase)
     assert cfg.model != "haiku"
-    assert cfg.model == AgentProvider.CODEX.value
+    assert cfg.model is None
 
 
 def test_claude_phase_without_explicit_model_still_defaults_to_haiku() -> None:

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/processor_types.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/processor_types.py
@@ -93,7 +93,7 @@ class AgentHandlerProtocol(Protocol):
         agent_env: dict[str, str],
         claude_cmd: list[str],
         session_id: str,
-        agent_model: str,
+        agent_model: str | None,
         timeout_seconds: int,
         collector: ObservabilityCollector | None = None,
         interactive_prompt: str | None = None,

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_codex_stream_processor.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execute_workflow/test_codex_stream_processor.py
@@ -61,7 +61,7 @@ async def _lines(path: Path) -> AsyncIterator[str]:
 
 
 def _make_processor(
-    collector: _RecordingCollector, agent_model: str = "gpt-5.6"
+    collector: _RecordingCollector, agent_model: str | None = "gpt-5.6"
 ) -> tuple[CodexStreamProcessor, TokenAccumulator]:
     tokens = TokenAccumulator()
     processor = CodexStreamProcessor(
@@ -191,6 +191,25 @@ async def test_unknown_model_marks_cost_unavailable() -> None:
     rec = _FIXTURES_DIR / "codex_exec_recording.jsonl"
     collector = _RecordingCollector()
     processor, _tokens = _make_processor(collector, agent_model="mystery-model")
+
+    result = await processor.process_stream(_lines(rec), _NoopWorkspace())
+
+    assert result.total_cost_usd is None
+    summary = next(c[1] for c in collector.calls if c[0] == "summary")
+    assert summary["total_cost_usd"] is None
+
+
+@pytest.mark.asyncio
+async def test_none_model_marks_cost_unavailable_not_haiku_not_gpt_5_6() -> None:
+    """A codex phase with no explicit model (agent_model=None) must NOT be
+    priced at all - specifically not claude haiku rates (the original #788
+    bug) and not GPT-5.6 rates (the #788 fix's over-correction, which
+    synthesized "codex" as the model and let it alias to gpt-5.6 pricing).
+    Cost must resolve to unknown/unpriced (None).
+    """
+    rec = _FIXTURES_DIR / "codex_exec_recording.jsonl"
+    collector = _RecordingCollector()
+    processor, _tokens = _make_processor(collector, agent_model=None)
 
     result = await processor.process_stream(_lines(rec), _NoopWorkspace())
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/projection.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 from syn_domain.contexts.agent_sessions import ObservationType
 from syn_domain.contexts.orchestration.domain.read_models.execution_cost import ExecutionCost
-from syn_shared.pricing import get_model_pricing
+from syn_shared.pricing import resolve_model_pricing
 
 
 def _get_or_create(existing: dict[str, Any] | None, execution_id: str) -> ExecutionCost:
@@ -54,10 +54,24 @@ def _calculate_token_cost(
     cache_creation: int,
     cache_read: int,
     model: str | None = None,
-) -> Decimal:
-    """Calculate token cost from counts using model-specific pricing."""
-    pricing = get_model_pricing(model or "")
-    return pricing.calculate_cost(input_tokens, output_tokens, cache_creation, cache_read)
+) -> tuple[Decimal, bool]:
+    """Calculate token cost from counts using model-specific pricing.
+
+    Uses the STRICT resolver (``resolve_model_pricing``), never the
+    legacy-fallback ``get_model_pricing``. An unknown or missing model
+    MUST NOT be priced as any real model (issue #788).
+
+    Returns:
+        A ``(cost, priced)`` tuple. ``priced`` is ``False`` when the model
+        was unknown/missing, in which case ``cost`` is always
+        ``Decimal("0")`` rather than a guessed price.
+    """
+    if not model:
+        return Decimal("0"), False
+    pricing = resolve_model_pricing(model)
+    if pricing is None:
+        return Decimal("0"), False
+    return pricing.calculate_cost(input_tokens, output_tokens, cache_creation, cache_read), True
 
 
 def _apply_token_usage(
@@ -77,12 +91,14 @@ def _apply_token_usage(
     execution_cost.cache_read_tokens += cache_read
 
     model = data.get("model")
-    token_cost = _calculate_token_cost(
+    token_cost, priced = _calculate_token_cost(
         input_tokens, output_tokens, cache_creation, cache_read, model=model
     )
     execution_cost.token_cost_usd += token_cost
     execution_cost.total_cost_usd += token_cost
-    if model:
+    if not priced:
+        execution_cost.unpriced_observation_count += 1
+    if model and priced:
         current = execution_cost.cost_by_model.get(model, Decimal("0"))
         execution_cost.cost_by_model[model] = current + token_cost
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/query_service.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/query_service.py
@@ -19,6 +19,7 @@ from syn_domain.contexts.agent_sessions import CostCalculator
 from syn_domain.contexts.orchestration.domain.read_models.execution_cost import ExecutionCost
 from syn_domain.contexts.orchestration.slices.execution_cost.timescale_query import (
     TimescaleExecutionCostQuery,
+    price_grouped_token_usage,
 )
 from syn_shared.events import (
     SESSION_SUMMARY,
@@ -49,10 +50,17 @@ ORDER BY MAX(time) DESC
 LIMIT $2
 """
 
-# Fallback: list executions from token_usage (in-progress, no summary yet)
+# Fallback: list executions from token_usage (in-progress, no summary yet).
+#
+# Grouped by (execution_id, model): an execution can span multiple
+# sessions/phases on different models, so pricing must happen per model
+# group rather than flattening all tokens into one SUM per execution and
+# pricing them as a single model (issue #788). Rows for the same
+# execution_id are merged in Python via ``price_grouped_token_usage``.
 _LIST_ALL_FROM_TOKEN_USAGE_QUERY = """
 SELECT
     execution_id,
+    data->>'model' as model,
     SUM((data->>'input_tokens')::int) as total_input,
     SUM((data->>'output_tokens')::int) as total_output,
     SUM(COALESCE((data->>'cache_creation_tokens')::int, 0)) as cache_creation,
@@ -64,7 +72,7 @@ SELECT
 FROM agent_events
 WHERE event_type = $1
   AND execution_id IS NOT NULL
-GROUP BY execution_id
+GROUP BY execution_id, data->>'model'
 """
 
 _TOOL_COUNT_BY_EXECUTION_QUERY = """
@@ -154,10 +162,15 @@ class ExecutionCostQueryService:
             results: list[ExecutionCost] = []
             for row in summary_rows:
                 results.append(self._build_from_summary(row, tool_counts, phase_map, model_map))
+
+            rows_by_execution: dict[str, list[asyncpg.Record]] = {}
             for row in token_rows:
                 eid = row["execution_id"]  # type: ignore[index]
-                if eid not in summarized_exec_ids:
-                    results.append(self._build_from_token_usage(row, tool_counts))
+                if eid in summarized_exec_ids:
+                    continue
+                rows_by_execution.setdefault(eid, []).append(row)
+            for eid, rows in rows_by_execution.items():
+                results.append(self._build_from_token_usage(eid, rows, tool_counts))
             return results
 
     async def _fetch_tool_counts(self, conn: object) -> dict[str, int]:
@@ -245,35 +258,33 @@ class ExecutionCostQueryService:
 
     def _build_from_token_usage(
         self,
-        row: object,
+        execution_id: str,
+        rows: list[asyncpg.Record],
         tool_counts: dict[str, int],
     ) -> ExecutionCost:
-        """Build an ExecutionCost from a token_usage aggregate row (in-progress)."""
-        eid = row["execution_id"]  # type: ignore[index]
-        total_input = row["total_input"] or 0  # type: ignore[index]
-        total_output = row["total_output"] or 0  # type: ignore[index]
-        cache_creation = row["cache_creation"] or 0  # type: ignore[index]
-        cache_read = row["cache_read"] or 0  # type: ignore[index]
-        cost = self._cost_calculator.calculate_token_cost(
-            input_tokens=total_input,
-            output_tokens=total_output,
-            cache_creation=cache_creation,
-            cache_read=cache_read,
-        )
-        started_at = row["started_at"]  # type: ignore[index]
-        completed_at = row.get("last_observation")  # type: ignore[union-attr]
+        """Build an ExecutionCost from model-grouped token_usage rows (in-progress).
+
+        ``rows`` are all groups for this execution from
+        ``_LIST_ALL_FROM_TOKEN_USAGE_QUERY`` (one row per model). They are
+        merged and priced per model group via ``price_grouped_token_usage`` -
+        an execution can span multiple sessions/models, so a flat SUM priced
+        as a single model would be wrong (issue #788).
+        """
+        grouped = price_grouped_token_usage(rows, self._cost_calculator)
         return ExecutionCost(
-            execution_id=eid,
-            session_count=row["session_count"] or 0,  # type: ignore[index]
-            session_ids=list(row["session_ids"] or []),  # type: ignore[index]
-            total_cost_usd=cost,
-            token_cost_usd=cost,
-            input_tokens=total_input,
-            output_tokens=total_output,
-            cache_creation_tokens=cache_creation,
-            cache_read_tokens=cache_read,
-            tool_calls=tool_counts.get(eid, 0),
-            duration_ms=self._resolve_duration(None, started_at, completed_at),
-            started_at=started_at,
-            completed_at=completed_at,
+            execution_id=execution_id,
+            session_count=len(grouped.session_ids),
+            session_ids=grouped.session_ids,
+            total_cost_usd=grouped.total_cost,
+            token_cost_usd=grouped.total_cost,
+            input_tokens=grouped.input_tokens,
+            output_tokens=grouped.output_tokens,
+            cache_creation_tokens=grouped.cache_creation,
+            cache_read_tokens=grouped.cache_read,
+            tool_calls=tool_counts.get(execution_id, 0),
+            duration_ms=self._resolve_duration(None, grouped.started_at, grouped.end_at),
+            cost_by_model=grouped.cost_by_model,
+            unpriced_observation_count=grouped.unpriced_observation_count,
+            started_at=grouped.started_at,
+            completed_at=grouped.end_at,
         )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/query_service.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/query_service.py
@@ -13,12 +13,15 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     import asyncpg
 
 from syn_domain.contexts.agent_sessions import CostCalculator
 from syn_domain.contexts.orchestration.domain.read_models.execution_cost import ExecutionCost
 from syn_domain.contexts.orchestration.slices.execution_cost.timescale_query import (
     TimescaleExecutionCostQuery,
+    price_grouped_session_summary,
     price_grouped_token_usage,
 )
 from syn_shared.events import (
@@ -28,26 +31,42 @@ from syn_shared.events import (
 )
 
 # List all executions with cost data from session_summary (authoritative).
+#
+# Grouped by (execution_id, model): an execution can span multiple
+# sessions/phases on different models, so pricing must happen per model
+# group rather than flattening all rows for an execution into one SUM and
+# pricing them as a single model (issue #788). The most-recent-N-executions
+# selection happens in ``recent_executions`` first, so LIMIT still counts
+# executions rather than (execution, model) groups.
 _LIST_ALL_FROM_SUMMARY_QUERY = """
+WITH recent_executions AS (
+    SELECT execution_id, MAX(time) as last_time
+    FROM agent_events
+    WHERE event_type = $1
+      AND execution_id IS NOT NULL
+    GROUP BY execution_id
+    ORDER BY last_time DESC
+    LIMIT $2
+)
 SELECT
-    execution_id,
-    SUM((data->>'total_input_tokens')::int) as total_input,
-    SUM((data->>'total_output_tokens')::int) as total_output,
-    SUM(COALESCE((data->>'cache_creation_tokens')::int, 0)) as cache_creation,
-    SUM(COALESCE((data->>'cache_read_tokens')::int, 0)) as cache_read,
-    SUM((data->>'total_cost_usd')::numeric) as sdk_cost,
-    SUM(COALESCE((data->>'duration_ms')::bigint, 0)) as duration_ms_val,
-    SUM(COALESCE((data->>'num_turns')::int, 0)) as total_turns,
-    COUNT(DISTINCT session_id) as session_count,
-    ARRAY_AGG(DISTINCT session_id) as session_ids,
-    MIN(time) as started_at,
-    MAX(time) as completed_at
-FROM agent_events
-WHERE event_type = $1
-  AND execution_id IS NOT NULL
-GROUP BY execution_id
-ORDER BY MAX(time) DESC
-LIMIT $2
+    a.execution_id,
+    a.data->>'model' as model,
+    SUM((a.data->>'total_input_tokens')::int) as total_input,
+    SUM((a.data->>'total_output_tokens')::int) as total_output,
+    SUM(COALESCE((a.data->>'cache_creation_tokens')::int, 0)) as cache_creation,
+    SUM(COALESCE((a.data->>'cache_read_tokens')::int, 0)) as cache_read,
+    SUM((a.data->>'total_cost_usd')::numeric) as sdk_cost,
+    SUM(COALESCE((a.data->>'duration_ms')::bigint, 0)) as duration_ms_val,
+    SUM(COALESCE((a.data->>'num_turns')::int, 0)) as total_turns,
+    COUNT(DISTINCT a.session_id) as session_count,
+    ARRAY_AGG(DISTINCT a.session_id) as session_ids,
+    MIN(a.time) as started_at,
+    MAX(a.time) as completed_at,
+    COUNT(*) as observation_count
+FROM agent_events a
+JOIN recent_executions r ON r.execution_id = a.execution_id
+WHERE a.event_type = $1
+GROUP BY a.execution_id, a.data->>'model'
 """
 
 # Fallback: list executions from token_usage (in-progress, no summary yet).
@@ -68,7 +87,8 @@ SELECT
     COUNT(DISTINCT session_id) as session_count,
     ARRAY_AGG(DISTINCT session_id) as session_ids,
     MIN(time) as started_at,
-    MAX(time) as last_observation
+    MAX(time) as last_observation,
+    COUNT(*) as observation_count
 FROM agent_events
 WHERE event_type = $1
   AND execution_id IS NOT NULL
@@ -94,19 +114,6 @@ WHERE event_type = $1
   AND execution_id IS NOT NULL
   AND phase_id IS NOT NULL
 GROUP BY execution_id, phase_id
-"""
-
-# Per-execution, per-model cost breakdown
-_COST_BY_MODEL_QUERY = """
-SELECT
-    execution_id,
-    data->>'model' as model,
-    SUM((data->>'total_cost_usd')::numeric) as model_cost
-FROM agent_events
-WHERE event_type = $1
-  AND execution_id IS NOT NULL
-  AND data->>'model' IS NOT NULL
-GROUP BY execution_id, data->>'model'
 """
 
 
@@ -149,29 +156,38 @@ class ExecutionCostQueryService:
         """
         async with self._pool.acquire() as conn:
             summary_rows = await conn.fetch(_LIST_ALL_FROM_SUMMARY_QUERY, SESSION_SUMMARY, limit)
-            summarized_exec_ids = {row["execution_id"] for row in summary_rows}  # type: ignore[index]
+            summary_rows_by_execution = self._group_rows_by_execution(summary_rows)
             token_rows = await conn.fetch(_LIST_ALL_FROM_TOKEN_USAGE_QUERY, TOKEN_USAGE)
             tool_counts = await self._fetch_tool_counts(conn)
             phase_map = await self._fetch_breakdown_map(
                 conn, _COST_BY_PHASE_QUERY, "phase_id", "phase_cost"
             )
-            model_map = await self._fetch_breakdown_map(
-                conn, _COST_BY_MODEL_QUERY, "model", "model_cost"
-            )
 
             results: list[ExecutionCost] = []
-            for row in summary_rows:
-                results.append(self._build_from_summary(row, tool_counts, phase_map, model_map))
+            for eid, rows in summary_rows_by_execution.items():
+                results.append(self._build_from_summary(eid, rows, tool_counts, phase_map))
 
-            rows_by_execution: dict[str, list[asyncpg.Record]] = {}
-            for row in token_rows:
-                eid = row["execution_id"]  # type: ignore[index]
-                if eid in summarized_exec_ids:
-                    continue
-                rows_by_execution.setdefault(eid, []).append(row)
-            for eid, rows in rows_by_execution.items():
+            token_rows_by_execution = self._group_rows_by_execution(
+                token_rows, exclude=summary_rows_by_execution.keys()
+            )
+            for eid, rows in token_rows_by_execution.items():
                 results.append(self._build_from_token_usage(eid, rows, tool_counts))
             return results
+
+    @staticmethod
+    def _group_rows_by_execution(
+        rows: list[asyncpg.Record],
+        exclude: Iterable[str] = (),
+    ) -> dict[str, list[asyncpg.Record]]:
+        """Group model-grouped rows by execution_id, skipping excluded execution IDs."""
+        excluded = set(exclude)
+        rows_by_execution: dict[str, list[asyncpg.Record]] = {}
+        for row in rows:
+            eid = row["execution_id"]  # type: ignore[index]
+            if eid in excluded:
+                continue
+            rows_by_execution.setdefault(eid, []).append(row)
+        return rows_by_execution
 
     async def _fetch_tool_counts(self, conn: object) -> dict[str, int]:
         """Fetch tool call counts per execution."""
@@ -197,18 +213,6 @@ class ExecutionCostQueryService:
                 breakdown[eid][row[key_field]] = Decimal(str(value))  # type: ignore[index]
         return breakdown
 
-    def _resolve_cost(self, row: object) -> Decimal:
-        """Resolve cost from sdk_cost field or calculate from token counts."""
-        sdk_cost = row["sdk_cost"]  # type: ignore[index]
-        if sdk_cost is not None:
-            return Decimal(str(sdk_cost))
-        return self._cost_calculator.calculate_token_cost(
-            input_tokens=row["total_input"] or 0,  # type: ignore[index]
-            output_tokens=row["total_output"] or 0,  # type: ignore[index]
-            cache_creation=row["cache_creation"] or 0,  # type: ignore[index]
-            cache_read=row["cache_read"] or 0,  # type: ignore[index]
-        )
-
     @staticmethod
     def _resolve_duration(
         duration_ms_val: object, started_at: object, completed_at: object
@@ -227,33 +231,41 @@ class ExecutionCostQueryService:
 
     def _build_from_summary(
         self,
-        row: object,
+        execution_id: str,
+        rows: list[asyncpg.Record],
         tool_counts: dict[str, int],
         phase_map: dict[str, dict[str, Decimal]],
-        model_map: dict[str, dict[str, Decimal]],
     ) -> ExecutionCost:
-        """Build an ExecutionCost from a session_summary aggregate row."""
-        eid = row["execution_id"]  # type: ignore[index]
-        cost = self._resolve_cost(row)
-        started_at = row["started_at"]  # type: ignore[index]
-        completed_at = row["completed_at"]  # type: ignore[index]
+        """Build an ExecutionCost from model-grouped session_summary rows.
+
+        ``rows`` are all (execution_id, model) groups for this execution
+        from ``_LIST_ALL_FROM_SUMMARY_QUERY``. Priced per group via
+        ``price_grouped_session_summary`` - a plain ``SUM(total_cost_usd)``
+        across mixed-model, partially-NULL-cost rows silently drops the NULL
+        rows from the total instead of pricing them from that group's own
+        tokens (issue #788).
+        """
+        grouped = price_grouped_session_summary(rows, self._cost_calculator)
         return ExecutionCost(
-            execution_id=eid,
-            session_count=row["session_count"] or 0,  # type: ignore[index]
-            session_ids=list(row["session_ids"] or []),  # type: ignore[index]
-            total_cost_usd=cost,
-            token_cost_usd=cost,
-            input_tokens=row["total_input"] or 0,  # type: ignore[index]
-            output_tokens=row["total_output"] or 0,  # type: ignore[index]
-            cache_creation_tokens=row["cache_creation"] or 0,  # type: ignore[index]
-            cache_read_tokens=row["cache_read"] or 0,  # type: ignore[index]
-            tool_calls=tool_counts.get(eid, 0),
-            turns=row["total_turns"] or 0,  # type: ignore[index]
-            duration_ms=self._resolve_duration(row["duration_ms_val"], started_at, completed_at),  # type: ignore[index]
-            cost_by_phase=phase_map.get(eid, {}),
-            cost_by_model=model_map.get(eid, {}),
-            started_at=started_at,
-            completed_at=completed_at,
+            execution_id=execution_id,
+            session_count=len(grouped.session_ids),
+            session_ids=grouped.session_ids,
+            total_cost_usd=grouped.total_cost,
+            token_cost_usd=grouped.total_cost,
+            input_tokens=grouped.input_tokens,
+            output_tokens=grouped.output_tokens,
+            cache_creation_tokens=grouped.cache_creation,
+            cache_read_tokens=grouped.cache_read,
+            tool_calls=tool_counts.get(execution_id, 0),
+            turns=grouped.total_turns,
+            duration_ms=self._resolve_duration(
+                grouped.duration_ms_raw, grouped.started_at, grouped.end_at
+            ),
+            cost_by_phase=phase_map.get(execution_id, {}),
+            cost_by_model=grouped.cost_by_model,
+            unpriced_observation_count=grouped.unpriced_observation_count,
+            started_at=grouped.started_at,
+            completed_at=grouped.end_at,
         )
 
     def _build_from_token_usage(

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_multi_model_pricing.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_multi_model_pricing.py
@@ -1,0 +1,134 @@
+"""Regression tests: execution cost prices each model group correctly.
+
+Issue #788 (structural follow-up): an execution can span multiple
+sessions/phases on different models (e.g. an Opus planning phase followed by
+a Haiku worker phase). The token_usage fallback path (used before a
+session_summary lands) used to flatten every session's tokens into one SUM
+and price them as a single model - or, after the first #788 fix, silently
+drop to $0 for the whole execution the moment any session's model was
+unresolvable. Both are wrong: each model group must be priced with its own
+rate, and only genuinely unpriceable groups should contribute $0.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+
+import pytest
+
+from syn_domain.contexts.orchestration.slices.execution_cost.query_service import (
+    ExecutionCostQueryService,
+)
+from syn_domain.contexts.orchestration.slices.execution_cost.timescale_query import (
+    price_grouped_token_usage,
+)
+
+_FakeRow = Mapping[str, object]
+
+_OPUS_MODEL = "claude-opus-4-20250514"
+_HAIKU_MODEL = "claude-3-5-haiku-20241022"
+
+# 1M input + 1M output tokens at Opus rates: $15.00 + $75.00 = $90.00
+_OPUS_COST_1M_1M = Decimal("90.00")
+# 1M input + 1M output tokens at Haiku rates: $1.00 + $5.00 = $6.00
+_HAIKU_COST_1M_1M = Decimal("6.00")
+
+
+def _group_row(
+    model: str | None,
+    session_id: str,
+    input_tokens: int = 1_000_000,
+    output_tokens: int = 1_000_000,
+) -> _FakeRow:
+    return {
+        "execution_id": "exec-multi",
+        "model": model,
+        "total_input": input_tokens,
+        "total_output": output_tokens,
+        "cache_creation": 0,
+        "cache_read": 0,
+        "session_count": 1,
+        "session_ids": [session_id],
+        "started_at": None,
+        "last_observation": None,
+    }
+
+
+@pytest.mark.unit
+class TestPriceGroupedTokenUsage:
+    def test_prices_each_model_group_with_its_own_rate(self) -> None:
+        from syn_domain.contexts.agent_sessions.slices.session_cost.cost_calculator import (
+            CostCalculator,
+        )
+
+        rows = [
+            _group_row(_OPUS_MODEL, "session-opus"),
+            _group_row(_HAIKU_MODEL, "session-haiku"),
+        ]
+
+        grouped = price_grouped_token_usage(rows, CostCalculator())
+
+        assert grouped.cost_by_model == {
+            _OPUS_MODEL: _OPUS_COST_1M_1M,
+            _HAIKU_MODEL: _HAIKU_COST_1M_1M,
+        }
+        assert grouped.total_cost == _OPUS_COST_1M_1M + _HAIKU_COST_1M_1M
+        assert grouped.unpriced_observation_count == 0
+        assert set(grouped.session_ids) == {"session-opus", "session-haiku"}
+        assert grouped.input_tokens == 2_000_000
+
+    def test_unknown_model_group_is_unpriced_not_dropped_or_guessed(self) -> None:
+        from syn_domain.contexts.agent_sessions.slices.session_cost.cost_calculator import (
+            CostCalculator,
+        )
+
+        rows = [
+            _group_row(_OPUS_MODEL, "session-opus"),
+            _group_row(None, "session-unknown"),
+        ]
+
+        grouped = price_grouped_token_usage(rows, CostCalculator())
+
+        # The known group is still priced correctly...
+        assert grouped.cost_by_model == {_OPUS_MODEL: _OPUS_COST_1M_1M}
+        assert grouped.total_cost == _OPUS_COST_1M_1M
+        # ...and the unknown group is counted as unpriced, not silently
+        # dropped from session_count/token totals and not guessed at.
+        assert grouped.unpriced_observation_count == 1
+        assert set(grouped.session_ids) == {"session-opus", "session-unknown"}
+        assert grouped.input_tokens == 2_000_000
+
+
+@pytest.mark.unit
+class TestExecutionCostQueryServiceBuildFromTokenUsageMultiModel:
+    def test_execution_with_two_models_prices_each_correctly(self) -> None:
+        service = ExecutionCostQueryService(pool=None)  # type: ignore[arg-type]
+
+        rows = [
+            _group_row(_OPUS_MODEL, "session-opus"),
+            _group_row(_HAIKU_MODEL, "session-haiku"),
+        ]
+
+        result = service._build_from_token_usage("exec-multi", rows, tool_counts={})
+
+        assert result.total_cost_usd == _OPUS_COST_1M_1M + _HAIKU_COST_1M_1M
+        assert result.cost_by_model == {
+            _OPUS_MODEL: _OPUS_COST_1M_1M,
+            _HAIKU_MODEL: _HAIKU_COST_1M_1M,
+        }
+        assert result.unpriced_observation_count == 0
+        assert result.session_count == 2
+
+    def test_one_unresolvable_model_group_does_not_zero_the_whole_execution(self) -> None:
+        service = ExecutionCostQueryService(pool=None)  # type: ignore[arg-type]
+
+        rows = [
+            _group_row(_OPUS_MODEL, "session-opus"),
+            _group_row(None, "session-unknown"),
+        ]
+
+        result = service._build_from_token_usage("exec-multi", rows, tool_counts={})
+
+        assert result.total_cost_usd == _OPUS_COST_1M_1M
+        assert result.unpriced_observation_count == 1

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_projection.py
@@ -1,6 +1,7 @@
 """Tests for ExecutionCostProjection with unified AgentObservation model."""
 
 from datetime import UTC, datetime
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -114,6 +115,80 @@ class TestAgentObservationHandling:
         assert "session-2" in execution_cost.session_ids
         assert execution_cost.input_tokens == 3000
         assert execution_cost.output_tokens == 1500
+
+    @pytest.mark.asyncio
+    async def test_unknown_model_contributes_no_cost(
+        self, projection: ExecutionCostProjection
+    ) -> None:
+        """A TOKEN_USAGE observation with no model MUST NOT be priced as any
+
+        real model (issue #788). Cost stays zero and the projection records
+        that the total is incomplete rather than confidently wrong.
+        """
+        await projection.on_agent_observation(
+            {
+                "session_id": "session-1",
+                "execution_id": "exec-1",
+                "observation_type": ObservationType.TOKEN_USAGE.value,
+                "data": {
+                    "input_tokens": 1_000_000,
+                    "output_tokens": 1_000_000,
+                },
+            }
+        )
+
+        execution_cost = await projection.get_execution_cost("exec-1")
+        assert execution_cost is not None
+        assert execution_cost.total_cost_usd == Decimal("0")
+        assert execution_cost.cost_by_model == {}
+        assert execution_cost.unpriced_observation_count == 1
+
+    @pytest.mark.asyncio
+    async def test_codex_phase_not_priced_as_haiku_or_sonnet(
+        self, projection: ExecutionCostProjection
+    ) -> None:
+        """A codex phase (no model reported) is not haiku-priced or sonnet-priced."""
+        await projection.on_agent_observation(
+            {
+                "session_id": "codex-session-1",
+                "execution_id": "codex-exec-1",
+                "observation_type": ObservationType.TOKEN_USAGE.value,
+                "data": {
+                    "input_tokens": 1_000_000,
+                    "output_tokens": 1_000_000,
+                },
+            }
+        )
+
+        execution_cost = await projection.get_execution_cost("codex-exec-1")
+        assert execution_cost is not None
+        # Haiku would be $1 + $5 = $6.00; Sonnet would be $3 + $15 = $18.00.
+        assert execution_cost.total_cost_usd not in (Decimal("6.00"), Decimal("18.00"))
+        assert execution_cost.total_cost_usd == Decimal("0")
+
+    @pytest.mark.asyncio
+    async def test_claude_phase_prices_exactly_as_before(
+        self, projection: ExecutionCostProjection
+    ) -> None:
+        """Regression guard: a claude phase with a real model prices unaffected."""
+        await projection.on_agent_observation(
+            {
+                "session_id": "session-1",
+                "execution_id": "exec-1",
+                "observation_type": ObservationType.TOKEN_USAGE.value,
+                "data": {
+                    "input_tokens": 1_000_000,
+                    "output_tokens": 1_000_000,
+                    "model": "claude-sonnet-4-20250514",
+                },
+            }
+        )
+
+        execution_cost = await projection.get_execution_cost("exec-1")
+        assert execution_cost is not None
+        assert execution_cost.total_cost_usd == Decimal("18.00")
+        assert execution_cost.cost_by_model == {"claude-sonnet-4-20250514": Decimal("18.00")}
+        assert execution_cost.unpriced_observation_count == 0
 
     @pytest.mark.asyncio
     async def test_observation_without_execution_skipped(
@@ -276,12 +351,23 @@ class TestExtractedHelpers:
         assert ec.started_at == first
 
     def test_calculate_token_cost(self) -> None:
-        """_calculate_token_cost computes correct cost."""
-        cost = _calculate_token_cost(1_000_000, 1_000_000, 0, 0)
+        """_calculate_token_cost computes correct cost for a known model."""
+        cost, priced = _calculate_token_cost(
+            1_000_000, 1_000_000, 0, 0, model="claude-sonnet-4-20250514"
+        )
         # 1M input @ $3 + 1M output @ $15 = $18
-        from decimal import Decimal
-
+        assert priced is True
         assert cost == Decimal("18.00")
+
+    def test_calculate_token_cost_unknown_model_is_unpriced(self) -> None:
+        """An unknown/missing model MUST NOT be priced as any real model (#788)."""
+        cost, priced = _calculate_token_cost(1_000_000, 1_000_000, 0, 0)
+        assert priced is False
+        assert cost == Decimal("0")
+
+        cost, priced = _calculate_token_cost(1_000_000, 1_000_000, 0, 0, model="unknown-model")
+        assert priced is False
+        assert cost == Decimal("0")
 
     def test_update_completed_at_sets_latest(self) -> None:
         """_update_completed_at updates to latest timestamp."""

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_projection.py
@@ -407,6 +407,7 @@ class TestExecutionCostQueryServiceBuildFromTokenUsage:
 
         row: dict[str, object] = {
             "execution_id": "exec-1",
+            "model": "claude-sonnet-4-20250514",
             "total_input": 1000,
             "total_output": 500,
             "cache_creation": 0,
@@ -416,7 +417,7 @@ class TestExecutionCostQueryServiceBuildFromTokenUsage:
             "started_at": started,
             "last_observation": completed,
         }
-        result = service._build_from_token_usage(row, tool_counts={})
+        result = service._build_from_token_usage("exec-1", [row], tool_counts={})
 
         assert result.duration_ms == pytest.approx(150_000.0)  # 2.5 min = 150,000 ms
 
@@ -430,6 +431,7 @@ class TestExecutionCostQueryServiceBuildFromTokenUsage:
 
         row: dict[str, object] = {
             "execution_id": "exec-2",
+            "model": "claude-sonnet-4-20250514",
             "total_input": 500,
             "total_output": 200,
             "cache_creation": 0,
@@ -439,7 +441,7 @@ class TestExecutionCostQueryServiceBuildFromTokenUsage:
             "started_at": None,
             "last_observation": None,
         }
-        result = service._build_from_token_usage(row, tool_counts={})
+        result = service._build_from_token_usage("exec-2", [row], tool_counts={})
 
         assert result.duration_ms == 0.0
 

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_projection.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_projection.py
@@ -469,6 +469,7 @@ class TestExecutionCostQueryServiceBuildFromSummary:
 
         row: dict[str, object] = {
             "execution_id": "exec-s1",
+            "model": "claude-sonnet-4-20250514",
             "total_input": 5000,
             "total_output": 2000,
             "cache_creation": 0,
@@ -481,7 +482,7 @@ class TestExecutionCostQueryServiceBuildFromSummary:
             "started_at": started,
             "completed_at": completed,
         }
-        result = service._build_from_summary(row, tool_counts={}, phase_map={}, model_map={})
+        result = service._build_from_summary("exec-s1", [row], tool_counts={}, phase_map={})
 
         assert result.duration_ms == pytest.approx(300_000.0)  # 5 min = 300,000 ms
 
@@ -499,6 +500,7 @@ class TestExecutionCostQueryServiceBuildFromSummary:
 
         row: dict[str, object] = {
             "execution_id": "exec-s2",
+            "model": "claude-sonnet-4-20250514",
             "total_input": 1000,
             "total_output": 500,
             "cache_creation": 0,
@@ -511,7 +513,7 @@ class TestExecutionCostQueryServiceBuildFromSummary:
             "started_at": started,
             "completed_at": completed,
         }
-        result = service._build_from_summary(row, tool_counts={}, phase_map={}, model_map={})
+        result = service._build_from_summary("exec-s2", [row], tool_counts={}, phase_map={})
 
         # Should use the explicit value, not recompute from timestamps
         assert result.duration_ms == pytest.approx(120_000.0)

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_summary_path_multi_model.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_summary_path_multi_model.py
@@ -1,0 +1,207 @@
+"""Regression tests: completed-execution session_summary path prices per model.
+
+Review finding on #788 (structural follow-up, third occurrence of the same
+bug class): the session_summary aggregation used by *completed* executions
+flattened ``SUM(total_cost_usd)`` across all sessions in an execution before
+this fix, with two concrete failure modes:
+
+- All-NULL case: every summary's ``total_cost_usd`` is NULL -> ``SUM``
+  returns NULL -> the old fallback priced with no model -> $0 for a known
+  Opus/Haiku execution.
+- Partial-NULL case (worse): only some summaries are NULL -> PostgreSQL
+  silently excludes those rows from ``SUM`` -> a plausible-looking but
+  wrong partial total.
+
+The fix groups session_summary rows by model (mirroring the token_usage
+fallback path) and prices each group: use ``sdk_cost`` when present
+(authoritative), else price that group's own tokens with that group's own
+model. These tests exercise ``price_grouped_session_summary`` directly and
+the full ``TimescaleExecutionCostQuery.calculate()`` path.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from syn_domain.contexts.agent_sessions.slices.session_cost.cost_calculator import CostCalculator
+from syn_domain.contexts.orchestration.slices.execution_cost.timescale_query import (
+    TimescaleExecutionCostQuery,
+    price_grouped_session_summary,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_OPUS_MODEL = "claude-opus-4-20250514"
+_HAIKU_MODEL = "claude-3-5-haiku-20241022"
+# 1M input + 1M output tokens at Opus rates: $15.00 + $75.00 = $90.00
+_OPUS_COST_1M_1M = Decimal("90.00")
+# 1M input + 1M output tokens at Haiku rates: $1.00 + $5.00 = $6.00
+_HAIKU_COST_1M_1M = Decimal("6.00")
+
+
+class _FakeRow:
+    """Fake asyncpg Record supporting both bracket and .get() access."""
+
+    def __init__(self, data: Mapping[str, object]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> object:
+        return self._data[key]
+
+    def get(self, key: str, default: object = None) -> object:
+        return self._data.get(key, default)
+
+
+def _summary_group_row(
+    model: str | None,
+    session_id: str,
+    sdk_cost: Decimal | None,
+    input_tokens: int = 1_000_000,
+    output_tokens: int = 1_000_000,
+    observation_count: int = 1,
+) -> _FakeRow:
+    return _FakeRow(
+        {
+            "execution_id": "exec-summary",
+            "model": model,
+            "total_input": input_tokens,
+            "total_output": output_tokens,
+            "cache_creation": 0,
+            "cache_read": 0,
+            "sdk_cost": sdk_cost,
+            "duration_ms_val": 0,
+            "total_turns": 1,
+            "session_count": 1,
+            "session_ids": [session_id],
+            "started_at": None,
+            "completed_at": None,
+            "observation_count": observation_count,
+        }
+    )
+
+
+@pytest.mark.unit
+class TestPriceGroupedSessionSummary:
+    def test_all_null_sdk_cost_known_model_is_priced_not_zero(self) -> None:
+        """All summaries NULL -> priced from that group's tokens, not $0."""
+        rows = [_summary_group_row(_OPUS_MODEL, "session-opus", sdk_cost=None)]
+
+        grouped = price_grouped_session_summary(rows, CostCalculator())
+
+        assert grouped.total_cost == _OPUS_COST_1M_1M
+        assert grouped.cost_by_model == {_OPUS_MODEL: _OPUS_COST_1M_1M}
+        assert grouped.unpriced_observation_count == 0
+
+    def test_partial_null_sdk_cost_does_not_silently_drop_the_null_group(self) -> None:
+        """One group NULL, one populated -> total is populated + priced-NULL, not just populated."""
+        rows = [
+            _summary_group_row(_OPUS_MODEL, "session-opus", sdk_cost=Decimal("12.50")),
+            _summary_group_row(_HAIKU_MODEL, "session-haiku", sdk_cost=None),
+        ]
+
+        grouped = price_grouped_session_summary(rows, CostCalculator())
+
+        # Populated sdk_cost is used verbatim; the NULL group is priced from
+        # its own tokens/model rather than vanishing from the SUM.
+        assert grouped.total_cost == Decimal("12.50") + _HAIKU_COST_1M_1M
+        assert grouped.cost_by_model == {
+            _OPUS_MODEL: Decimal("12.50"),
+            _HAIKU_MODEL: _HAIKU_COST_1M_1M,
+        }
+        assert grouped.unpriced_observation_count == 0
+
+    def test_multi_model_mixed_null_and_populated_prices_each_correctly(self) -> None:
+        """Opus (populated) + Haiku (NULL) -> each priced with its own rate."""
+        rows = [
+            _summary_group_row(_OPUS_MODEL, "session-opus", sdk_cost=None),
+            _summary_group_row(_HAIKU_MODEL, "session-haiku", sdk_cost=Decimal("3.33")),
+        ]
+
+        grouped = price_grouped_session_summary(rows, CostCalculator())
+
+        assert grouped.cost_by_model == {
+            _OPUS_MODEL: _OPUS_COST_1M_1M,
+            _HAIKU_MODEL: Decimal("3.33"),
+        }
+        assert grouped.total_cost == _OPUS_COST_1M_1M + Decimal("3.33")
+        assert set(grouped.session_ids) == {"session-opus", "session-haiku"}
+
+    def test_unpriced_observation_count_reflects_real_observations_not_group_count(self) -> None:
+        """N unknown-model observations in one group -> unpriced_observation_count == N."""
+        rows = [
+            _summary_group_row(None, "session-unknown", sdk_cost=None, observation_count=10_000)
+        ]
+
+        grouped = price_grouped_session_summary(rows, CostCalculator())
+
+        assert grouped.total_cost == Decimal("0")
+        assert grouped.unpriced_observation_count == 10_000
+
+    def test_unknown_model_group_missing_observation_count_defaults_to_one(self) -> None:
+        """Hand-built rows without observation_count still count as 1, not dropped."""
+        rows = [_summary_group_row(None, "session-unknown", sdk_cost=None, observation_count=1)]
+
+        grouped = price_grouped_session_summary(rows, CostCalculator())
+
+        assert grouped.unpriced_observation_count == 1
+
+
+def _fake_pool(summary_rows: list[_FakeRow]) -> MagicMock:
+    async def fetch_side_effect(query: str, _execution_id: str, _event_type: str) -> list[_FakeRow]:
+        # _COST_BY_PHASE_QUERY groups by phase_id; no phase data in these tests.
+        if "phase_id" in query:
+            return []
+        return summary_rows
+
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(side_effect=fetch_side_effect)
+    conn.fetchval = AsyncMock(return_value=0)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock(return_value=None)
+        )
+    )
+    return pool
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestTimescaleExecutionCostQueryCompletedSummaryPath:
+    """Exercises the full ``calculate()`` path for completed (session_summary) executions."""
+
+    async def test_all_null_summaries_known_model_prices_correctly(self) -> None:
+        rows = [_summary_group_row(_OPUS_MODEL, "session-opus", sdk_cost=None)]
+        pool = _fake_pool(rows)
+        query = TimescaleExecutionCostQuery(pool)
+
+        result = await query.calculate("exec-summary")
+
+        assert result is not None
+        assert result.total_cost_usd == _OPUS_COST_1M_1M
+        assert result.unpriced_observation_count == 0
+
+    async def test_mixed_null_and_populated_multi_model_execution(self) -> None:
+        rows = [
+            _summary_group_row(_OPUS_MODEL, "session-opus", sdk_cost=None),
+            _summary_group_row(_HAIKU_MODEL, "session-haiku", sdk_cost=Decimal("3.33")),
+        ]
+        pool = _fake_pool(rows)
+        query = TimescaleExecutionCostQuery(pool)
+
+        result = await query.calculate("exec-summary")
+
+        assert result is not None
+        assert result.total_cost_usd == _OPUS_COST_1M_1M + Decimal("3.33")
+        assert result.cost_by_model == {
+            _OPUS_MODEL: _OPUS_COST_1M_1M,
+            _HAIKU_MODEL: Decimal("3.33"),
+        }
+        assert result.unpriced_observation_count == 0
+        assert result.input_tokens == 2_000_000

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_timescale_query_multi_model.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_timescale_query_multi_model.py
@@ -16,6 +16,7 @@ import pytest
 from syn_domain.contexts.orchestration.slices.execution_cost.timescale_query import (
     TimescaleExecutionCostQuery,
 )
+from syn_shared.events import SESSION_SUMMARY, TOKEN_USAGE
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -72,9 +73,15 @@ def _grouped_token_rows() -> list[_FakeRow]:
 
 def _make_mock_pool() -> MagicMock:
     """No session_summary rows exist yet; only grouped token_usage rows."""
+
+    async def fetch_side_effect(_query: str, _execution_id: str, event_type: str) -> list[_FakeRow]:
+        if event_type == SESSION_SUMMARY:
+            return []  # no session_summary rows yet
+        assert event_type == TOKEN_USAGE
+        return _grouped_token_rows()
+
     conn = AsyncMock()
-    conn.fetchrow = AsyncMock(return_value=None)  # no session_summary
-    conn.fetch = AsyncMock(return_value=_grouped_token_rows())
+    conn.fetch = AsyncMock(side_effect=fetch_side_effect)
     conn.fetchval = AsyncMock(return_value=0)
 
     pool = MagicMock()

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_timescale_query_multi_model.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/test_timescale_query_multi_model.py
@@ -1,0 +1,104 @@
+"""Regression test: TimescaleExecutionCostQuery.calculate() prices per model.
+
+Exercises the full ``calculate()`` path (not just the pricing helper) against
+a mocked connection, for an in-progress execution (no session_summary yet)
+whose sessions span two different models.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from syn_domain.contexts.orchestration.slices.execution_cost.timescale_query import (
+    TimescaleExecutionCostQuery,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_OPUS_MODEL = "claude-opus-4-20250514"
+_HAIKU_MODEL = "claude-3-5-haiku-20241022"
+_OPUS_COST_1M_1M = Decimal("90.00")
+_HAIKU_COST_1M_1M = Decimal("6.00")
+
+
+class _FakeRow:
+    """Fake asyncpg Record supporting both bracket and .get() access."""
+
+    def __init__(self, data: Mapping[str, object]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> object:
+        return self._data[key]
+
+    def get(self, key: str, default: object = None) -> object:
+        return self._data.get(key, default)
+
+
+def _grouped_token_rows() -> list[_FakeRow]:
+    return [
+        _FakeRow(
+            {
+                "model": _OPUS_MODEL,
+                "total_input": 1_000_000,
+                "total_output": 1_000_000,
+                "cache_creation": 0,
+                "cache_read": 0,
+                "session_count": 1,
+                "session_ids": ["session-opus"],
+                "started_at": None,
+                "last_observation": None,
+            }
+        ),
+        _FakeRow(
+            {
+                "model": _HAIKU_MODEL,
+                "total_input": 1_000_000,
+                "total_output": 1_000_000,
+                "cache_creation": 0,
+                "cache_read": 0,
+                "session_count": 1,
+                "session_ids": ["session-haiku"],
+                "started_at": None,
+                "last_observation": None,
+            }
+        ),
+    ]
+
+
+def _make_mock_pool() -> MagicMock:
+    """No session_summary rows exist yet; only grouped token_usage rows."""
+    conn = AsyncMock()
+    conn.fetchrow = AsyncMock(return_value=None)  # no session_summary
+    conn.fetch = AsyncMock(return_value=_grouped_token_rows())
+    conn.fetchval = AsyncMock(return_value=0)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock(return_value=None)
+        )
+    )
+    return pool
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_in_progress_execution_prices_each_model_group() -> None:
+    pool = _make_mock_pool()
+    query = TimescaleExecutionCostQuery(pool)
+
+    result = await query.calculate("exec-multi")
+
+    assert result is not None
+    assert result.total_cost_usd == _OPUS_COST_1M_1M + _HAIKU_COST_1M_1M
+    assert result.cost_by_model == {
+        _OPUS_MODEL: _OPUS_COST_1M_1M,
+        _HAIKU_MODEL: _HAIKU_COST_1M_1M,
+    }
+    assert result.unpriced_observation_count == 0
+    assert result.input_tokens == 2_000_000

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/timescale_query.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/timescale_query.py
@@ -48,8 +48,15 @@ WHERE execution_id = $1 AND event_type = $2
 
 # Fallback: aggregate from individual token_usage events when no
 # session_summary is available (e.g. mid-execution queries).
+#
+# Grouped by model: an execution can span multiple sessions/phases, each
+# potentially on a different model (e.g. an Opus planning phase followed
+# by a Haiku worker phase). Pricing must happen per model group rather
+# than flattening all tokens into one SUM and pricing them as a single
+# model - the same class of bug as issue #788.
 _TOKEN_USAGE_FALLBACK_QUERY = """
 SELECT
+    data->>'model' as model,
     SUM((data->>'input_tokens')::int) as total_input,
     SUM((data->>'output_tokens')::int) as total_output,
     SUM(COALESCE((data->>'cache_creation_tokens')::int, 0)) as cache_creation,
@@ -60,6 +67,7 @@ SELECT
     MAX(time) as last_observation
 FROM agent_events
 WHERE execution_id = $1 AND event_type = $2
+GROUP BY data->>'model'
 """
 
 _TOOL_COUNT_QUERY = """
@@ -117,6 +125,131 @@ class _TokenData:
     from_summary: bool
 
 
+@dataclass
+class _PricedTokenUsage:
+    """Result of pricing one or more model-grouped token_usage rows."""
+
+    data: _TokenData
+    total_cost: Decimal
+    cost_by_model: dict[str, Decimal]
+    unpriced_observation_count: int
+
+
+@dataclass
+class GroupedTokenUsage:
+    """Aggregated + priced token usage merged from model-grouped rows.
+
+    Shared between ``TimescaleExecutionCostQuery`` (single execution) and
+    ``ExecutionCostQueryService`` (list_all) - both need to merge rows that
+    are grouped by (execution_id, model) into one priced total per execution.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    cache_creation: int
+    cache_read: int
+    session_ids: list[str]
+    started_at: datetime | None
+    end_at: datetime | None
+    total_cost: Decimal
+    cost_by_model: dict[str, Decimal]
+    unpriced_observation_count: int
+
+
+@dataclass
+class _GroupTokens:
+    """Token counts extracted from one model-grouped row."""
+
+    input_tokens: int
+    output_tokens: int
+    cache_creation: int
+    cache_read: int
+
+
+def _extract_group_tokens(row: asyncpg.Record) -> _GroupTokens:
+    """Pull token counts out of one model-grouped row."""
+    return _GroupTokens(
+        input_tokens=row["total_input"] or 0,
+        output_tokens=row["total_output"] or 0,
+        cache_creation=row.get("cache_creation") or 0,
+        cache_read=row.get("cache_read") or 0,
+    )
+
+
+def _extend_time_range(
+    started_at: datetime | None, end_at: datetime | None, row: asyncpg.Record
+) -> tuple[datetime | None, datetime | None]:
+    """Widen (started_at, end_at) with a row's own timestamps, if any."""
+    group_started_at = row.get("started_at")
+    if group_started_at and (started_at is None or group_started_at < started_at):
+        started_at = group_started_at
+    group_end_at = row.get("last_observation")
+    if group_end_at and (end_at is None or group_end_at > end_at):
+        end_at = group_end_at
+    return started_at, end_at
+
+
+def _resolve_row_model(row: asyncpg.Record) -> str | None:
+    """Extract the model for a row, or None if missing/not a string."""
+    raw_model = row.get("model")
+    return raw_model if isinstance(raw_model, str) else None
+
+
+def price_grouped_token_usage(
+    rows: list[asyncpg.Record], cost_calculator: CostCalculator
+) -> GroupedTokenUsage:
+    """Merge model-grouped token_usage rows into one priced aggregate.
+
+    Each row is one model's token totals (e.g. for one execution). Every
+    group is priced with its own model - never flattened into a single SUM
+    and priced as one model (issue #788). A group whose model is
+    unknown/missing contributes zero cost and counts toward
+    ``unpriced_observation_count`` instead of guessing.
+    """
+    totals = _GroupTokens(0, 0, 0, 0)
+    session_ids: set[str] = set()
+    started_at: datetime | None = None
+    end_at: datetime | None = None
+    total_cost = Decimal("0")
+    cost_by_model: dict[str, Decimal] = {}
+    unpriced_observation_count = 0
+
+    for row in rows:
+        group = _extract_group_tokens(row)
+        totals = _GroupTokens(
+            input_tokens=totals.input_tokens + group.input_tokens,
+            output_tokens=totals.output_tokens + group.output_tokens,
+            cache_creation=totals.cache_creation + group.cache_creation,
+            cache_read=totals.cache_read + group.cache_read,
+        )
+        session_ids.update(row.get("session_ids") or [])
+        started_at, end_at = _extend_time_range(started_at, end_at, row)
+
+        model = _resolve_row_model(row)
+        pricing = cost_calculator.resolve_pricing(model)
+        if pricing is None or model is None:
+            unpriced_observation_count += 1
+            continue
+        group_cost = pricing.calculate_cost(
+            group.input_tokens, group.output_tokens, group.cache_creation, group.cache_read
+        )
+        total_cost += group_cost
+        cost_by_model[model] = cost_by_model.get(model, Decimal("0")) + group_cost
+
+    return GroupedTokenUsage(
+        input_tokens=totals.input_tokens,
+        output_tokens=totals.output_tokens,
+        cache_creation=totals.cache_creation,
+        cache_read=totals.cache_read,
+        session_ids=sorted(session_ids),
+        started_at=started_at,
+        end_at=end_at,
+        total_cost=total_cost,
+        cost_by_model=cost_by_model,
+        unpriced_observation_count=unpriced_observation_count,
+    )
+
+
 class TimescaleExecutionCostQuery:
     """Calculates execution cost directly from TimescaleDB observations.
 
@@ -136,9 +269,9 @@ class TimescaleExecutionCostQuery:
 
     async def _query_token_usage(
         self, conn: asyncpg.pool.PoolConnectionProxy, execution_id: str
-    ) -> asyncpg.Record | None:
-        """Query token_usage events as fallback for in-progress executions."""
-        return await conn.fetchrow(_TOKEN_USAGE_FALLBACK_QUERY, execution_id, TOKEN_USAGE)
+    ) -> list[asyncpg.Record]:
+        """Query token_usage events, grouped by model, as fallback for in-progress executions."""
+        return await conn.fetch(_TOKEN_USAGE_FALLBACK_QUERY, execution_id, TOKEN_USAGE)
 
     def _extract_common_fields(self, row: asyncpg.Record) -> dict[str, Any]:
         """Extract common token fields shared by both query types."""
@@ -174,6 +307,35 @@ class TimescaleExecutionCostQuery:
             output_tokens=data.output_tokens,
             cache_creation=data.cache_creation,
             cache_read=data.cache_read,
+        )
+
+    def _price_token_usage_groups(self, rows: list[asyncpg.Record]) -> _PricedTokenUsage:
+        """Merge model-grouped token_usage rows into one priced aggregate.
+
+        Delegates to ``price_grouped_token_usage`` (shared with
+        ``ExecutionCostQueryService``) and repackages the result as
+        ``_TokenData`` for this class's internal pipeline.
+        """
+        grouped = price_grouped_token_usage(rows, self._cost_calculator)
+        data = _TokenData(
+            input_tokens=grouped.input_tokens,
+            output_tokens=grouped.output_tokens,
+            cache_creation=grouped.cache_creation,
+            cache_read=grouped.cache_read,
+            session_count=len(grouped.session_ids),
+            session_ids=grouped.session_ids,
+            started_at=grouped.started_at,
+            end_at=grouped.end_at,
+            sdk_cost=None,
+            duration_ms_raw=0,
+            total_turns=0,
+            from_summary=False,
+        )
+        return _PricedTokenUsage(
+            data=data,
+            total_cost=grouped.total_cost,
+            cost_by_model=grouped.cost_by_model,
+            unpriced_observation_count=grouped.unpriced_observation_count,
         )
 
     def _calculate_duration(self, data: _TokenData) -> float:
@@ -219,13 +381,20 @@ class TimescaleExecutionCostQuery:
             if row["model"] and row["model_cost"] is not None
         }
 
-    async def _resolve_token_row(
+    async def _resolve_token_rows(
         self, conn: asyncpg.pool.PoolConnectionProxy, execution_id: str
-    ) -> tuple[asyncpg.Record | None, bool]:
-        """Get the best available token data row and whether it's from session_summary."""
+    ) -> tuple[list[asyncpg.Record], bool]:
+        """Get the best available token data rows and whether they're from session_summary.
+
+        Session_summary rows are already aggregated across all sessions in the
+        execution using the SDK-reported ``total_cost_usd`` (model-correct by
+        construction), so a single row suffices. The token_usage fallback is
+        grouped one row per model (see ``_TOKEN_USAGE_FALLBACK_QUERY``) so each
+        group can be priced with its own model.
+        """
         summary_row = await self._query_session_summaries(conn, execution_id)
         if summary_row is not None and summary_row["total_input"] is not None:
-            return summary_row, True
+            return [summary_row], True
         return await self._query_token_usage(conn, execution_id), False
 
     def _build_execution_cost(
@@ -238,6 +407,7 @@ class TimescaleExecutionCostQuery:
         turn_count: int,
         cost_by_phase: dict[str, Decimal],
         cost_by_model: dict[str, Decimal],
+        unpriced_observation_count: int,
     ) -> ExecutionCost:
         """Construct the ExecutionCost read model from aggregated data."""
         return ExecutionCost(
@@ -255,6 +425,7 @@ class TimescaleExecutionCostQuery:
             duration_ms=duration_ms,
             cost_by_phase=cost_by_phase,
             cost_by_model=cost_by_model,
+            unpriced_observation_count=unpriced_observation_count,
             started_at=data.started_at,
             completed_at=data.end_at,
         )
@@ -263,32 +434,41 @@ class TimescaleExecutionCostQuery:
         """Calculate execution cost from TimescaleDB.
 
         Prefers session_summary events (authoritative). Falls back to
-        token_usage aggregation for in-progress executions.
+        token_usage aggregation, grouped by model, for in-progress executions.
         """
         async with self._pool.acquire() as conn:
-            token_row, has_summary = await self._resolve_token_row(conn, execution_id)
-            if token_row is None or token_row["total_input"] is None:
+            token_rows, has_summary = await self._resolve_token_rows(conn, execution_id)
+            if not token_rows:
                 return None
 
-            data = self._extract_token_data(token_row, from_summary=has_summary)
             tool_count = (
                 await conn.fetchval(_TOOL_COUNT_QUERY, execution_id, TOOL_EXECUTION_COMPLETED) or 0
             )
-            turn_count = await self._query_turn_count(conn, execution_id, data)
-            cost_by_phase = (
-                await self._query_cost_by_phase(conn, execution_id) if has_summary else {}
-            )
-            cost_by_model = (
-                await self._query_cost_by_model(conn, execution_id) if has_summary else {}
-            )
+
+            if has_summary:
+                data = self._extract_token_data(token_rows[0], from_summary=True)
+                total_cost = self._calculate_cost(data)
+                turn_count = await self._query_turn_count(conn, execution_id, data)
+                cost_by_phase = await self._query_cost_by_phase(conn, execution_id)
+                cost_by_model = await self._query_cost_by_model(conn, execution_id)
+                unpriced_observation_count = 0
+            else:
+                priced = self._price_token_usage_groups(token_rows)
+                data = priced.data
+                total_cost = priced.total_cost
+                turn_count = await self._query_turn_count(conn, execution_id, data)
+                cost_by_phase = {}
+                cost_by_model = priced.cost_by_model
+                unpriced_observation_count = priced.unpriced_observation_count
 
             return self._build_execution_cost(
                 execution_id=execution_id,
                 data=data,
-                total_cost=self._calculate_cost(data),
+                total_cost=total_cost,
                 duration_ms=self._calculate_duration(data),
                 tool_count=tool_count,
                 turn_count=turn_count,
                 cost_by_phase=cost_by_phase,
                 cost_by_model=cost_by_model,
+                unpriced_observation_count=unpriced_observation_count,
             )

--- a/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/timescale_query.py
+++ b/packages/syn-domain/src/syn_domain/contexts/orchestration/slices/execution_cost/timescale_query.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -29,8 +29,16 @@ from syn_shared.events import (
 
 # Prefer session_summary rows (authoritative totals from Claude CLI).
 # Aggregates across all sessions in the execution.
+#
+# Grouped by model, same as the token_usage fallback below: an execution
+# spanning multiple sessions/phases can span multiple models, and a flat
+# SUM(total_cost_usd) across mixed models silently drops any row whose
+# cost is NULL (PostgreSQL excludes NULLs from SUM) instead of raising or
+# falling back to that row's own token-based price - the same class of
+# bug as issue #788, surviving on the completed-execution summary path.
 _SESSION_SUMMARY_QUERY = """
 SELECT
+    data->>'model' as model,
     SUM((data->>'total_input_tokens')::int) as total_input,
     SUM((data->>'total_output_tokens')::int) as total_output,
     SUM(COALESCE((data->>'cache_creation_tokens')::int, 0)) as cache_creation,
@@ -41,9 +49,11 @@ SELECT
     COUNT(DISTINCT session_id) as session_count,
     ARRAY_AGG(DISTINCT session_id) as session_ids,
     MIN(time) as started_at,
-    MAX(time) as completed_at
+    MAX(time) as completed_at,
+    COUNT(*) as observation_count
 FROM agent_events
 WHERE execution_id = $1 AND event_type = $2
+GROUP BY data->>'model'
 """
 
 # Fallback: aggregate from individual token_usage events when no
@@ -64,7 +74,8 @@ SELECT
     COUNT(DISTINCT session_id) as session_count,
     ARRAY_AGG(DISTINCT session_id) as session_ids,
     MIN(time) as started_at,
-    MAX(time) as last_observation
+    MAX(time) as last_observation,
+    COUNT(*) as observation_count
 FROM agent_events
 WHERE execution_id = $1 AND event_type = $2
 GROUP BY data->>'model'
@@ -92,18 +103,6 @@ WHERE execution_id = $1
   AND event_type = $2
   AND phase_id IS NOT NULL
 GROUP BY phase_id
-"""
-
-# Per-model cost breakdown from session_summary events
-_COST_BY_MODEL_QUERY = """
-SELECT
-    data->>'model' as model,
-    SUM((data->>'total_cost_usd')::numeric) as model_cost
-FROM agent_events
-WHERE execution_id = $1
-  AND event_type = $2
-  AND data->>'model' IS NOT NULL
-GROUP BY data->>'model'
 """
 
 
@@ -157,6 +156,30 @@ class GroupedTokenUsage:
 
 
 @dataclass
+class GroupedSessionSummary:
+    """Aggregated + priced session_summary data merged from model-grouped rows.
+
+    Shared between ``TimescaleExecutionCostQuery`` (single execution) and
+    ``ExecutionCostQueryService`` (list_all) - both need to merge rows that
+    are grouped by (execution_id, model) into one priced total per execution,
+    mirroring ``GroupedTokenUsage`` for the token_usage fallback path.
+    """
+
+    input_tokens: int
+    output_tokens: int
+    cache_creation: int
+    cache_read: int
+    session_ids: list[str]
+    started_at: datetime | None
+    end_at: datetime | None
+    total_cost: Decimal
+    cost_by_model: dict[str, Decimal]
+    unpriced_observation_count: int
+    duration_ms_raw: int
+    total_turns: int
+
+
+@dataclass
 class _GroupTokens:
     """Token counts extracted from one model-grouped row."""
 
@@ -177,13 +200,20 @@ def _extract_group_tokens(row: asyncpg.Record) -> _GroupTokens:
 
 
 def _extend_time_range(
-    started_at: datetime | None, end_at: datetime | None, row: asyncpg.Record
+    started_at: datetime | None,
+    end_at: datetime | None,
+    row: asyncpg.Record,
+    end_key: str = "last_observation",
 ) -> tuple[datetime | None, datetime | None]:
-    """Widen (started_at, end_at) with a row's own timestamps, if any."""
+    """Widen (started_at, end_at) with a row's own timestamps, if any.
+
+    ``end_key`` names the row's end-of-range column: token_usage rows carry
+    it as ``last_observation``, session_summary rows as ``completed_at``.
+    """
     group_started_at = row.get("started_at")
     if group_started_at and (started_at is None or group_started_at < started_at):
         started_at = group_started_at
-    group_end_at = row.get("last_observation")
+    group_end_at = row.get(end_key)
     if group_end_at and (end_at is None or group_end_at > end_at):
         end_at = group_end_at
     return started_at, end_at
@@ -193,6 +223,18 @@ def _resolve_row_model(row: asyncpg.Record) -> str | None:
     """Extract the model for a row, or None if missing/not a string."""
     raw_model = row.get("model")
     return raw_model if isinstance(raw_model, str) else None
+
+
+def _row_observation_count(row: asyncpg.Record) -> int:
+    """Number of underlying agent_events rows a grouped row represents.
+
+    Grouped queries project ``COUNT(*) AS observation_count`` so an unpriced
+    group's contribution to ``unpriced_observation_count`` reflects real
+    observations, not one count per model group (issue #788 follow-up).
+    Falls back to 1 when a row doesn't carry the column (e.g. hand-built
+    test fixtures), so a single unpriced group still counts as unpriced.
+    """
+    return int(row.get("observation_count") or 1)
 
 
 def price_grouped_token_usage(
@@ -228,7 +270,7 @@ def price_grouped_token_usage(
         model = _resolve_row_model(row)
         pricing = cost_calculator.resolve_pricing(model)
         if pricing is None or model is None:
-            unpriced_observation_count += 1
+            unpriced_observation_count += _row_observation_count(row)
             continue
         group_cost = pricing.calculate_cost(
             group.input_tokens, group.output_tokens, group.cache_creation, group.cache_read
@@ -250,6 +292,107 @@ def price_grouped_token_usage(
     )
 
 
+@dataclass
+class _RowPricing:
+    """Result of pricing one session_summary row.
+
+    ``cost`` is ``None`` when the row is genuinely unpriceable (unknown
+    model and no ``sdk_cost``) - in that case ``unpriced_count`` carries how
+    many observations that row represents.
+    """
+
+    cost: Decimal | None
+    model: str | None
+    unpriced_count: int
+
+
+def _price_session_summary_row(
+    row: asyncpg.Record, group: _GroupTokens, cost_calculator: CostCalculator
+) -> _RowPricing:
+    """Price one session_summary row: authoritative ``sdk_cost`` first, else per-model calc.
+
+    ``sdk_cost`` (the CLI-reported ``total_cost_usd``) is used verbatim when
+    present. A NULL ``sdk_cost`` is priced from this row's own tokens using
+    this row's own model - never silently dropped from the total the way a
+    flat ``SUM(total_cost_usd)`` would (PostgreSQL excludes NULL rows from
+    SUM) and never priced as if the model were unknown when it is in fact
+    known (issue #788).
+    """
+    model = _resolve_row_model(row)
+    raw_sdk_cost = row.get("sdk_cost")
+    if raw_sdk_cost is not None:
+        return _RowPricing(cost=Decimal(str(raw_sdk_cost)), model=model, unpriced_count=0)
+
+    pricing = cost_calculator.resolve_pricing(model)
+    if pricing is None or model is None:
+        return _RowPricing(cost=None, model=None, unpriced_count=_row_observation_count(row))
+
+    group_cost = pricing.calculate_cost(
+        group.input_tokens, group.output_tokens, group.cache_creation, group.cache_read
+    )
+    return _RowPricing(cost=group_cost, model=model, unpriced_count=0)
+
+
+def price_grouped_session_summary(
+    rows: list[asyncpg.Record], cost_calculator: CostCalculator
+) -> GroupedSessionSummary:
+    """Merge model-grouped session_summary rows into one priced aggregate.
+
+    Each row is one model's session_summary totals (e.g. for one execution).
+    A group whose model really is unknown/missing and has no ``sdk_cost``
+    contributes zero cost and counts toward ``unpriced_observation_count``
+    instead of guessing (issue #788). See ``_price_session_summary_row`` for
+    the per-row pricing rule.
+    """
+    totals = _GroupTokens(0, 0, 0, 0)
+    session_ids: set[str] = set()
+    started_at: datetime | None = None
+    end_at: datetime | None = None
+    total_cost = Decimal("0")
+    cost_by_model: dict[str, Decimal] = {}
+    unpriced_observation_count = 0
+    duration_ms_raw = 0
+    total_turns = 0
+
+    for row in rows:
+        group = _extract_group_tokens(row)
+        totals = _GroupTokens(
+            input_tokens=totals.input_tokens + group.input_tokens,
+            output_tokens=totals.output_tokens + group.output_tokens,
+            cache_creation=totals.cache_creation + group.cache_creation,
+            cache_read=totals.cache_read + group.cache_read,
+        )
+        session_ids.update(row.get("session_ids") or [])
+        started_at, end_at = _extend_time_range(started_at, end_at, row, end_key="completed_at")
+        duration_ms_raw += int(row.get("duration_ms_val") or 0)
+        total_turns += int(row.get("total_turns") or 0)
+
+        priced = _price_session_summary_row(row, group, cost_calculator)
+        if priced.cost is None:
+            unpriced_observation_count += priced.unpriced_count
+            continue
+        total_cost += priced.cost
+        if priced.model is not None:
+            cost_by_model[priced.model] = (
+                cost_by_model.get(priced.model, Decimal("0")) + priced.cost
+            )
+
+    return GroupedSessionSummary(
+        input_tokens=totals.input_tokens,
+        output_tokens=totals.output_tokens,
+        cache_creation=totals.cache_creation,
+        cache_read=totals.cache_read,
+        session_ids=sorted(session_ids),
+        started_at=started_at,
+        end_at=end_at,
+        total_cost=total_cost,
+        cost_by_model=cost_by_model,
+        unpriced_observation_count=unpriced_observation_count,
+        duration_ms_raw=duration_ms_raw,
+        total_turns=total_turns,
+    )
+
+
 class TimescaleExecutionCostQuery:
     """Calculates execution cost directly from TimescaleDB observations.
 
@@ -263,9 +406,9 @@ class TimescaleExecutionCostQuery:
 
     async def _query_session_summaries(
         self, conn: asyncpg.pool.PoolConnectionProxy, execution_id: str
-    ) -> asyncpg.Record | None:
-        """Query session_summary events for authoritative totals."""
-        return await conn.fetchrow(_SESSION_SUMMARY_QUERY, execution_id, SESSION_SUMMARY)
+    ) -> list[asyncpg.Record]:
+        """Query session_summary events, grouped by model, for authoritative totals."""
+        return await conn.fetch(_SESSION_SUMMARY_QUERY, execution_id, SESSION_SUMMARY)
 
     async def _query_token_usage(
         self, conn: asyncpg.pool.PoolConnectionProxy, execution_id: str
@@ -273,40 +416,33 @@ class TimescaleExecutionCostQuery:
         """Query token_usage events, grouped by model, as fallback for in-progress executions."""
         return await conn.fetch(_TOKEN_USAGE_FALLBACK_QUERY, execution_id, TOKEN_USAGE)
 
-    def _extract_common_fields(self, row: asyncpg.Record) -> dict[str, Any]:
-        """Extract common token fields shared by both query types."""
-        return {
-            "input_tokens": row["total_input"] or 0,
-            "output_tokens": row["total_output"] or 0,
-            "cache_creation": row.get("cache_creation") or 0,
-            "cache_read": row.get("cache_read") or 0,
-            "session_count": row.get("session_count") or 0,
-            "session_ids": list(row.get("session_ids") or []),
-            "started_at": row.get("started_at"),
-        }
+    def _price_session_summary_groups(self, rows: list[asyncpg.Record]) -> _PricedTokenUsage:
+        """Merge model-grouped session_summary rows into one priced aggregate.
 
-    def _extract_token_data(self, row: asyncpg.Record, from_summary: bool) -> _TokenData:
-        """Extract token counts and metadata from a query row."""
-        common = self._extract_common_fields(row)
-        sdk_cost = Decimal(str(row["sdk_cost"])) if row.get("sdk_cost") is not None else None
-        return _TokenData(
-            **common,
-            end_at=row.get("completed_at" if from_summary else "last_observation"),
-            sdk_cost=sdk_cost if from_summary else None,
-            duration_ms_raw=int(row.get("duration_ms_val") or 0) if from_summary else 0,
-            total_turns=int(row.get("total_turns") or 0) if from_summary else 0,
-            from_summary=from_summary,
+        Delegates to ``price_grouped_session_summary`` (shared with
+        ``ExecutionCostQueryService``) and repackages the result as
+        ``_TokenData`` for this class's internal pipeline.
+        """
+        grouped = price_grouped_session_summary(rows, self._cost_calculator)
+        data = _TokenData(
+            input_tokens=grouped.input_tokens,
+            output_tokens=grouped.output_tokens,
+            cache_creation=grouped.cache_creation,
+            cache_read=grouped.cache_read,
+            session_count=len(grouped.session_ids),
+            session_ids=grouped.session_ids,
+            started_at=grouped.started_at,
+            end_at=grouped.end_at,
+            sdk_cost=None,
+            duration_ms_raw=grouped.duration_ms_raw,
+            total_turns=grouped.total_turns,
+            from_summary=True,
         )
-
-    def _calculate_cost(self, data: _TokenData) -> Decimal:
-        """Calculate total cost from token data, preferring SDK cost."""
-        if data.sdk_cost is not None:
-            return data.sdk_cost
-        return self._cost_calculator.calculate_token_cost(
-            input_tokens=data.input_tokens,
-            output_tokens=data.output_tokens,
-            cache_creation=data.cache_creation,
-            cache_read=data.cache_read,
+        return _PricedTokenUsage(
+            data=data,
+            total_cost=grouped.total_cost,
+            cost_by_model=grouped.cost_by_model,
+            unpriced_observation_count=grouped.unpriced_observation_count,
         )
 
     def _price_token_usage_groups(self, rows: list[asyncpg.Record]) -> _PricedTokenUsage:
@@ -370,31 +506,20 @@ class TimescaleExecutionCostQuery:
             if row["phase_id"] and row["phase_cost"] is not None
         }
 
-    async def _query_cost_by_model(
-        self, conn: asyncpg.pool.PoolConnectionProxy, execution_id: str
-    ) -> dict[str, Decimal]:
-        """Query per-model cost breakdown from session_summary events."""
-        model_rows = await conn.fetch(_COST_BY_MODEL_QUERY, execution_id, SESSION_SUMMARY)
-        return {
-            row["model"]: Decimal(str(row["model_cost"]))
-            for row in model_rows
-            if row["model"] and row["model_cost"] is not None
-        }
-
     async def _resolve_token_rows(
         self, conn: asyncpg.pool.PoolConnectionProxy, execution_id: str
     ) -> tuple[list[asyncpg.Record], bool]:
         """Get the best available token data rows and whether they're from session_summary.
 
-        Session_summary rows are already aggregated across all sessions in the
-        execution using the SDK-reported ``total_cost_usd`` (model-correct by
-        construction), so a single row suffices. The token_usage fallback is
-        grouped one row per model (see ``_TOKEN_USAGE_FALLBACK_QUERY``) so each
-        group can be priced with its own model.
+        Session_summary rows are grouped one row per model (see
+        ``_SESSION_SUMMARY_QUERY``) so each group can be priced with its own
+        model and a NULL ``sdk_cost`` in one group never silently drops out
+        of the total. The token_usage fallback is grouped the same way (see
+        ``_TOKEN_USAGE_FALLBACK_QUERY``).
         """
-        summary_row = await self._query_session_summaries(conn, execution_id)
-        if summary_row is not None and summary_row["total_input"] is not None:
-            return [summary_row], True
+        summary_rows = await self._query_session_summaries(conn, execution_id)
+        if summary_rows:
+            return summary_rows, True
         return await self._query_token_usage(conn, execution_id), False
 
     def _build_execution_cost(
@@ -446,20 +571,17 @@ class TimescaleExecutionCostQuery:
             )
 
             if has_summary:
-                data = self._extract_token_data(token_rows[0], from_summary=True)
-                total_cost = self._calculate_cost(data)
-                turn_count = await self._query_turn_count(conn, execution_id, data)
+                priced = self._price_session_summary_groups(token_rows)
                 cost_by_phase = await self._query_cost_by_phase(conn, execution_id)
-                cost_by_model = await self._query_cost_by_model(conn, execution_id)
-                unpriced_observation_count = 0
             else:
                 priced = self._price_token_usage_groups(token_rows)
-                data = priced.data
-                total_cost = priced.total_cost
-                turn_count = await self._query_turn_count(conn, execution_id, data)
                 cost_by_phase = {}
-                cost_by_model = priced.cost_by_model
-                unpriced_observation_count = priced.unpriced_observation_count
+
+            data = priced.data
+            total_cost = priced.total_cost
+            turn_count = await self._query_turn_count(conn, execution_id, data)
+            cost_by_model = priced.cost_by_model
+            unpriced_observation_count = priced.unpriced_observation_count
 
             return self._build_execution_cost(
                 execution_id=execution_id,

--- a/packages/syn-domain/src/syn_domain/contexts/organization/slices/contribution_heatmap/GetContributionHeatmapHandler.py
+++ b/packages/syn-domain/src/syn_domain/contexts/organization/slices/contribution_heatmap/GetContributionHeatmapHandler.py
@@ -40,6 +40,7 @@ _ZERO_BREAKDOWN: dict[str, float] = {
     "output_tokens": 0.0,
     "cache_creation_tokens": 0.0,
     "cache_read_tokens": 0.0,
+    "unpriced_tokens": 0.0,
 }
 
 

--- a/packages/syn-domain/src/syn_domain/contexts/organization/slices/contribution_heatmap/TimescaleHeatmapQuery.py
+++ b/packages/syn-domain/src/syn_domain/contexts/organization/slices/contribution_heatmap/TimescaleHeatmapQuery.py
@@ -14,25 +14,29 @@ from syn_domain.contexts.agent_sessions import CostCalculator
 from syn_domain.contexts.organization.domain.read_models.contribution_heatmap import (
     HeatmapDayBucket,
 )
+from syn_shared.events import GIT_COMMIT, TOKEN_USAGE
 
 # SQL fragment shared between filtered and unfiltered queries.
 # Metrics are derived from the actual event types in agent_events:
 #   sessions   — distinct session_id values active that day
 #   executions — distinct execution_id values active that day
-#   commits    — count of git_commit events
+#   commits    — count of GIT_COMMIT events
 #   tokens     — broken down by input, output, cache_creation, cache_read
-_METRIC_COLUMNS = """
+#
+# Event type literals come from the shared syn_shared.events constants
+# rather than being repeated as magic strings.
+_METRIC_COLUMNS = f"""
     COUNT(DISTINCT session_id) AS sessions,
     COUNT(DISTINCT execution_id) AS executions,
-    COUNT(*) FILTER (WHERE event_type = 'git_commit') AS commits,
+    COUNT(*) FILTER (WHERE event_type = '{GIT_COMMIT}') AS commits,
     COALESCE(SUM(COALESCE((data->>'input_tokens')::bigint, 0))
-        FILTER (WHERE event_type = 'token_usage'), 0) AS input_tokens,
+        FILTER (WHERE event_type = '{TOKEN_USAGE}'), 0) AS input_tokens,
     COALESCE(SUM(COALESCE((data->>'output_tokens')::bigint, 0))
-        FILTER (WHERE event_type = 'token_usage'), 0) AS output_tokens,
+        FILTER (WHERE event_type = '{TOKEN_USAGE}'), 0) AS output_tokens,
     COALESCE(SUM(COALESCE((data->>'cache_creation_tokens')::bigint, 0))
-        FILTER (WHERE event_type = 'token_usage'), 0) AS cache_creation_tokens,
+        FILTER (WHERE event_type = '{TOKEN_USAGE}'), 0) AS cache_creation_tokens,
     COALESCE(SUM(COALESCE((data->>'cache_read_tokens')::bigint, 0))
-        FILTER (WHERE event_type = 'token_usage'), 0) AS cache_read_tokens
+        FILTER (WHERE event_type = '{TOKEN_USAGE}'), 0) AS cache_read_tokens
 """
 
 # Per-day, per-model token totals. A day's activity can span many sessions
@@ -169,7 +173,7 @@ class TimescaleHeatmapQuery:
                 SELECT
                     {_MODEL_TOKEN_COLUMNS}
                 FROM agent_events
-                WHERE event_type = 'token_usage'
+                WHERE event_type = '{TOKEN_USAGE}'
                   AND time >= $1::date
                   AND time < ($2::date + interval '1 day')
                   AND execution_id = ANY($3)
@@ -184,7 +188,7 @@ class TimescaleHeatmapQuery:
             SELECT
                 {_MODEL_TOKEN_COLUMNS}
             FROM agent_events
-            WHERE event_type = 'token_usage'
+            WHERE event_type = '{TOKEN_USAGE}'
               AND time >= $1::date
               AND time < ($2::date + interval '1 day')
             GROUP BY day, model

--- a/packages/syn-domain/src/syn_domain/contexts/organization/slices/contribution_heatmap/TimescaleHeatmapQuery.py
+++ b/packages/syn-domain/src/syn_domain/contexts/organization/slices/contribution_heatmap/TimescaleHeatmapQuery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import date, timedelta
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -34,6 +35,34 @@ _METRIC_COLUMNS = """
         FILTER (WHERE event_type = 'token_usage'), 0) AS cache_read_tokens
 """
 
+# Per-day, per-model token totals. A day's activity can span many sessions
+# on many different models, so cost must be priced per model group rather
+# than summing all tokens for the day and pricing them as a single model
+# (the same class of bug fixed in issue #788 for session/execution cost).
+_MODEL_TOKEN_COLUMNS = """
+    time_bucket('1 day', time)::date AS day,
+    data->>'model' AS model,
+    COALESCE(SUM((data->>'input_tokens')::bigint), 0) AS input_tokens,
+    COALESCE(SUM((data->>'output_tokens')::bigint), 0) AS output_tokens,
+    COALESCE(SUM((data->>'cache_creation_tokens')::bigint), 0) AS cache_creation_tokens,
+    COALESCE(SUM((data->>'cache_read_tokens')::bigint), 0) AS cache_read_tokens
+"""
+
+
+@dataclass
+class _DayCost:
+    """A day's cost, priced per model group.
+
+    ``unpriced_tokens`` counts tokens from model groups that could not be
+    priced (unknown/missing model) - these never contribute to
+    ``priced_cost``, they are surfaced separately instead of guessed at
+    (issue #788).
+    """
+
+    priced_cost: Decimal = field(default_factory=lambda: Decimal("0"))
+    unpriced_tokens: int = 0
+
+
 _EMPTY_BREAKDOWN: dict[str, float] = {
     "sessions": 0.0,
     "executions": 0.0,
@@ -44,6 +73,7 @@ _EMPTY_BREAKDOWN: dict[str, float] = {
     "output_tokens": 0.0,
     "cache_creation_tokens": 0.0,
     "cache_read_tokens": 0.0,
+    "unpriced_tokens": 0.0,
 }
 
 
@@ -53,6 +83,136 @@ class TimescaleHeatmapQuery:
     def __init__(self, pool: asyncpg.Pool) -> None:
         self._pool = pool
         self._cost_calculator = CostCalculator()
+
+    def _price_by_day_and_model(self, model_rows: list[asyncpg.Record]) -> dict[str, _DayCost]:
+        """Price token_usage rows grouped by (day, model) into per-day costs.
+
+        Each row is one model's token totals for one day. A group whose
+        model is unknown/missing contributes zero cost and its tokens are
+        counted in ``unpriced_tokens`` instead of being priced as a
+        guessed/default model.
+        """
+        cost_by_day: dict[str, _DayCost] = {}
+        for row in model_rows:
+            day_str = row["day"].isoformat()
+            day_cost = cost_by_day.setdefault(day_str, _DayCost())
+
+            input_tokens = int(row["input_tokens"])
+            output_tokens = int(row["output_tokens"])
+            cache_creation = int(row["cache_creation_tokens"])
+            cache_read = int(row["cache_read_tokens"])
+
+            raw_model = row.get("model")
+            model = raw_model if isinstance(raw_model, str) else None
+            pricing = self._cost_calculator.resolve_pricing(model)
+            if pricing is None:
+                day_cost.unpriced_tokens += (
+                    input_tokens + output_tokens + cache_creation + cache_read
+                )
+                continue
+            day_cost.priced_cost += pricing.calculate_cost(
+                input_tokens, output_tokens, cache_creation, cache_read
+            )
+        return cost_by_day
+
+    async def _fetch_rows(
+        self,
+        conn: asyncpg.pool.PoolConnectionProxy,
+        start: date,
+        end: date,
+        execution_ids: set[str] | None,
+    ) -> list[asyncpg.Record]:
+        """Fetch per-day metric rows (sessions/executions/commits/tokens)."""
+        if execution_ids is not None:
+            return await conn.fetch(
+                f"""
+                SELECT
+                    time_bucket('1 day', time)::date AS day,
+                    {_METRIC_COLUMNS}
+                FROM agent_events
+                WHERE time >= $1::date
+                  AND time < ($2::date + interval '1 day')
+                  AND execution_id = ANY($3)
+                GROUP BY day
+                ORDER BY day
+                """,
+                start,
+                end,
+                list(execution_ids),
+            )
+        return await conn.fetch(
+            f"""
+            SELECT
+                time_bucket('1 day', time)::date AS day,
+                {_METRIC_COLUMNS}
+            FROM agent_events
+            WHERE time >= $1::date
+              AND time < ($2::date + interval '1 day')
+            GROUP BY day
+            ORDER BY day
+            """,
+            start,
+            end,
+        )
+
+    async def _fetch_model_rows(
+        self,
+        conn: asyncpg.pool.PoolConnectionProxy,
+        start: date,
+        end: date,
+        execution_ids: set[str] | None,
+    ) -> list[asyncpg.Record]:
+        """Fetch per-day, per-model token rows for pricing (see ``_MODEL_TOKEN_COLUMNS``)."""
+        if execution_ids is not None:
+            return await conn.fetch(
+                f"""
+                SELECT
+                    {_MODEL_TOKEN_COLUMNS}
+                FROM agent_events
+                WHERE event_type = 'token_usage'
+                  AND time >= $1::date
+                  AND time < ($2::date + interval '1 day')
+                  AND execution_id = ANY($3)
+                GROUP BY day, model
+                """,
+                start,
+                end,
+                list(execution_ids),
+            )
+        return await conn.fetch(
+            f"""
+            SELECT
+                {_MODEL_TOKEN_COLUMNS}
+            FROM agent_events
+            WHERE event_type = 'token_usage'
+              AND time >= $1::date
+              AND time < ($2::date + interval '1 day')
+            GROUP BY day, model
+            """,
+            start,
+            end,
+        )
+
+    @staticmethod
+    def _build_day_breakdown(row: asyncpg.Record, day_cost: _DayCost) -> dict[str, float]:
+        """Build one day's breakdown dict from a metric row and its priced cost."""
+        input_tokens = int(row["input_tokens"])
+        output_tokens = int(row["output_tokens"])
+        cache_creation = int(row["cache_creation_tokens"])
+        cache_read = int(row["cache_read_tokens"])
+        total_tokens = input_tokens + output_tokens + cache_creation + cache_read
+        return {
+            "sessions": float(row["sessions"]),
+            "executions": float(row["executions"]),
+            "commits": float(row["commits"]),
+            "cost_usd": float(day_cost.priced_cost.quantize(Decimal("0.0001"))),
+            "tokens": float(total_tokens),
+            "input_tokens": float(input_tokens),
+            "output_tokens": float(output_tokens),
+            "cache_creation_tokens": float(cache_creation),
+            "cache_read_tokens": float(cache_read),
+            "unpriced_tokens": float(day_cost.unpriced_tokens),
+        }
 
     async def query(
         self,
@@ -72,67 +232,17 @@ class TimescaleHeatmapQuery:
             List of HeatmapDayBucket, one per day (zero-filled).
         """
         async with self._pool.acquire() as conn:
-            if execution_ids is not None:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT
-                        time_bucket('1 day', time)::date AS day,
-                        {_METRIC_COLUMNS}
-                    FROM agent_events
-                    WHERE time >= $1::date
-                      AND time < ($2::date + interval '1 day')
-                      AND execution_id = ANY($3)
-                    GROUP BY day
-                    ORDER BY day
-                    """,
-                    start,
-                    end,
-                    list(execution_ids),
-                )
-            else:
-                rows = await conn.fetch(
-                    f"""
-                    SELECT
-                        time_bucket('1 day', time)::date AS day,
-                        {_METRIC_COLUMNS}
-                    FROM agent_events
-                    WHERE time >= $1::date
-                      AND time < ($2::date + interval '1 day')
-                    GROUP BY day
-                    ORDER BY day
-                    """,
-                    start,
-                    end,
-                )
+            rows = await self._fetch_rows(conn, start, end, execution_ids)
+            model_rows = await self._fetch_model_rows(conn, start, end, execution_ids)
+
+        cost_by_day = self._price_by_day_and_model(model_rows)
 
         # Build lookup from query results
         day_data: dict[str, dict[str, float]] = {}
         for row in rows:
             day_str = row["day"].isoformat()
-            input_tokens = int(row["input_tokens"])
-            output_tokens = int(row["output_tokens"])
-            cache_creation = int(row["cache_creation_tokens"])
-            cache_read = int(row["cache_read_tokens"])
-            total_tokens = input_tokens + output_tokens + cache_creation + cache_read
-
-            cost = self._cost_calculator.calculate_token_cost(
-                input_tokens=input_tokens,
-                output_tokens=output_tokens,
-                cache_creation=cache_creation,
-                cache_read=cache_read,
-            )
-
-            day_data[day_str] = {
-                "sessions": float(row["sessions"]),
-                "executions": float(row["executions"]),
-                "commits": float(row["commits"]),
-                "cost_usd": float(cost.quantize(Decimal("0.0001"))),
-                "tokens": float(total_tokens),
-                "input_tokens": float(input_tokens),
-                "output_tokens": float(output_tokens),
-                "cache_creation_tokens": float(cache_creation),
-                "cache_read_tokens": float(cache_read),
-            }
+            day_cost = cost_by_day.get(day_str, _DayCost())
+            day_data[day_str] = self._build_day_breakdown(row, day_cost)
 
         # Zero-fill all days in the range
         buckets: list[HeatmapDayBucket] = []

--- a/packages/syn-domain/src/syn_domain/testing/fake_agent_handler.py
+++ b/packages/syn-domain/src/syn_domain/testing/fake_agent_handler.py
@@ -77,7 +77,7 @@ class FakeAgentExecutionHandler:
         agent_env: dict[str, str],
         claude_cmd: list[str],
         session_id: str,
-        agent_model: str,
+        agent_model: str | None,
         timeout_seconds: int,
         collector: ObservabilityCollector | None = None,
         interactive_prompt: str | None = None,

--- a/packages/syn-domain/tests/contexts/organization/slices/contribution_heatmap/test_timescale_query_multi_model.py
+++ b/packages/syn-domain/tests/contexts/organization/slices/contribution_heatmap/test_timescale_query_multi_model.py
@@ -1,0 +1,129 @@
+"""Pin the heatmap's per-model pricing decision.
+
+A day's heatmap bucket aggregates activity across every session and every
+model active that day. There is no single "correct" model to price the
+whole day's tokens at, so ``TimescaleHeatmapQuery`` groups token_usage rows
+by (day, model) and prices each group with its own rate - a day with an
+unresolvable model's tokens surfaces those as ``unpriced_tokens`` instead of
+silently multiplying mixed-model tokens by one model's rate (issue #788).
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from syn_domain.contexts.organization.slices.contribution_heatmap.TimescaleHeatmapQuery import (
+    TimescaleHeatmapQuery,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_OPUS_MODEL = "claude-opus-4-20250514"
+_HAIKU_MODEL = "claude-3-5-haiku-20241022"
+_OPUS_COST_1M_1M = Decimal("90.00")
+_HAIKU_COST_1M_1M = Decimal("6.00")
+
+
+class _FakeRow:
+    def __init__(self, data: Mapping[str, object]) -> None:
+        self._data = data
+
+    def __getitem__(self, key: str) -> object:
+        return self._data[key]
+
+    def get(self, key: str, default: object = None) -> object:
+        return self._data.get(key, default)
+
+
+def _day_row(day: date) -> _FakeRow:
+    """Row shaped like _METRIC_COLUMNS - no model breakdown here."""
+    return _FakeRow(
+        {
+            "day": day,
+            "sessions": 2,
+            "executions": 1,
+            "commits": 0,
+            "input_tokens": 2_000_000,
+            "output_tokens": 2_000_000,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+    )
+
+
+def _model_row(day: date, model: str | None) -> _FakeRow:
+    """Row shaped like _MODEL_TOKEN_COLUMNS - one model's totals for the day."""
+    return _FakeRow(
+        {
+            "day": day,
+            "model": model,
+            "input_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+        }
+    )
+
+
+def _make_mock_pool(day_rows: list[_FakeRow], model_rows: list[_FakeRow]) -> MagicMock:
+    """Differentiate the two `conn.fetch` calls by inspecting the query text."""
+
+    async def _fetch(query: str, *_args: object) -> list[_FakeRow]:
+        if "GROUP BY day, model" in query:
+            return model_rows
+        return day_rows
+
+    conn = AsyncMock()
+    conn.fetch = AsyncMock(side_effect=_fetch)
+
+    pool = MagicMock()
+    pool.acquire = MagicMock(
+        return_value=AsyncMock(
+            __aenter__=AsyncMock(return_value=conn), __aexit__=AsyncMock(return_value=None)
+        )
+    )
+    return pool
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_day_with_two_models_prices_each_at_its_own_rate() -> None:
+    day = date(2026, 4, 1)
+    pool = _make_mock_pool(
+        day_rows=[_day_row(day)],
+        model_rows=[_model_row(day, _OPUS_MODEL), _model_row(day, _HAIKU_MODEL)],
+    )
+    query = TimescaleHeatmapQuery(pool)
+
+    buckets = await query.query(start=day, end=day, execution_ids=None)
+
+    assert len(buckets) == 1
+    breakdown = buckets[0].breakdown
+    assert breakdown["cost_usd"] == pytest.approx(float(_OPUS_COST_1M_1M + _HAIKU_COST_1M_1M))
+    assert breakdown["unpriced_tokens"] == 0.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_day_with_unresolvable_model_surfaces_unpriced_tokens_not_a_guess() -> None:
+    day = date(2026, 4, 2)
+    pool = _make_mock_pool(
+        day_rows=[_day_row(day)],
+        model_rows=[_model_row(day, _OPUS_MODEL), _model_row(day, None)],
+    )
+    query = TimescaleHeatmapQuery(pool)
+
+    buckets = await query.query(start=day, end=day, execution_ids=None)
+
+    breakdown = buckets[0].breakdown
+    # Only the priceable (Opus) group contributes to cost_usd - the unknown
+    # group's tokens are surfaced separately, never priced as Opus or any
+    # other default model.
+    assert breakdown["cost_usd"] == pytest.approx(float(_OPUS_COST_1M_1M))
+    assert breakdown["unpriced_tokens"] == 2_000_000.0

--- a/packages/syn-shared/src/syn_shared/pricing/__init__.py
+++ b/packages/syn-shared/src/syn_shared/pricing/__init__.py
@@ -131,8 +131,16 @@ DEFAULT_MODEL_ID = "claude-sonnet-4-20250514"
 # The workflow YAML and AgentConfiguration use short names like
 # ``sonnet``/``opus``/``haiku``; resolve them so pricing lookups don't
 # silently fall back to the default.
+#
+# NOTE: no "codex" -> "gpt-5.6" alias. "codex" is a provider name
+# (AgentProvider.CODEX), not a model id, and an earlier fix briefly used it
+# as both at once - synthesizing "codex" as the model for a codex phase
+# with no explicit `model:`. That collapsed "provider" and "model unknown"
+# into the same string, which then silently priced unspecified-model codex
+# phases as GPT-5.6 (issue #788 follow-up). A truly unknown model must
+# resolve to no pricing, not a guessed one - see
+# ExecuteWorkflowHandler._default_model_for_provider.
 MODEL_ALIASES: dict[str, str] = {
-    "codex": "gpt-5.6",
     "gpt-codex": "gpt-5.6",
     "opus": "claude-opus-4-20250514",
     "sonnet": "claude-sonnet-4-20250514",


### PR DESCRIPTION
## #788 - codex cost data was wrong system-wide

**Symptom:** a codex phase showed `haiku` at 100% in Cost by Model (verified live on session `68ee27b1`, $0.0456).

**Root cause:** a codex phase with no explicit model in its workflow YAML fell through to a claude default, so `resolve_model_pricing` returned **claude haiku rates** for codex work.

**Blast radius:** cost flows into the `execution_cost`, `session_cost` and `repo_cost` projections, so this corrupted every cost rollup touching a codex phase, not just the one badge.

**Fix:** `ExecuteWorkflowHandler` no longer applies a claude-shaped default to a codex phase. Pricing already supported codex (`resolve_model_pricing("gpt-5.6")`); the gap was the model never reaching it.

Tests assert: a codex phase without an explicit model resolves to codex pricing not haiku; a claude phase's default is unchanged; an explicit model override on a codex phase is preserved.

**Caveat, tracked separately:** `syn_shared/pricing/__init__.py` carries `TODO(#780)` placeholder GPT-5.6 rates ($15/$60 per million, explicitly unconfirmed). Attribution is now correct, but codex costs stay approximate until #780 verifies the real rates. Fixing attribution is necessary but not sufficient for trustworthy codex cost analysis.

## #793 - shared codex constants

`CodexStreamProcessor` hardcoded its own copies of the codex stream/item literals and tool-name labels that `syn_shared/codex_stream.py` already owns. Now imports them and the duplicates are gone.

This is not cosmetic: the duplicate-transcript-row bug fixed in #791 was exactly the live parser and the transcript reader disagreeing about codex semantics. One source of truth prevents the next variant.

Closes #788, closes #793